### PR TITLE
Adding TCP port 1234 to Etherbone dissector.

### DIFF
--- a/liteeth/software/dissectors/etherbone.lua
+++ b/liteeth/software/dissectors/etherbone.lua
@@ -221,3 +221,5 @@ end
 -- register eb protocol on UDP port 20000
 local tab = DissectorTable.get("udp.port")
 tab:add(20000, proto_eb)
+local tab = DissectorTable.get("tcp.port")
+tab:add(1234, proto_eb)


### PR DESCRIPTION
LiteEth designs seem to commonly use TCP port 1234.