### PR TITLE
Allow changing all SoC options through YAML config

### DIFF
--- a/examples/wishbone_mii.yml
+++ b/examples/wishbone_mii.yml
@@ -9,5 +9,6 @@ clk_freq:   100e6
 core:       wishbone
 endianness: big
 
-mem_map:
-    ethmac: 0x50000000
+soc:
+    mem_map:
+        ethmac: 0x50000000


### PR DESCRIPTION
This can be useful for the likes of `csr_data_width`, for which special-casing would result in quite a messy script.

`mem_map` and `csr_map` are now children of the `soc` config tree, old configs fail with a warning instead of being silently ignored.