### PR TITLE
Using multiple RMII Ethernet PHYs in one SoC design

### DIFF
--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -20,9 +20,15 @@ class LiteEthMACCore(Module, AutoCSR):
         rx_pipeline = [phy]
         tx_pipeline = [phy]
 
+        rx_cd_name = "eth_rx"
+        tx_cd_name = "eth_tx"
+        if hasattr(phy, 'name'):
+            rx_cd_name = phy.name + "_" + rx_cd_name
+            tx_cd_name = phy.name + "_" + tx_cd_name
+
         # Interpacket gap
         tx_gap_inserter = gap.LiteEthMACGap(phy.dw)
-        self.submodules += ClockDomainsRenamer("eth_tx")(tx_gap_inserter)
+        self.submodules += ClockDomainsRenamer(tx_cd_name)(tx_gap_inserter)
         tx_pipeline += [tx_gap_inserter]
 
         # Preamble / CRC
@@ -38,21 +44,21 @@ class LiteEthMACCore(Module, AutoCSR):
             # Preamble insert/check
             preamble_inserter = preamble.LiteEthMACPreambleInserter(phy.dw)
             preamble_checker = preamble.LiteEthMACPreambleChecker(phy.dw)
-            self.submodules += ClockDomainsRenamer("eth_tx")(preamble_inserter)
-            self.submodules += ClockDomainsRenamer("eth_rx")(preamble_checker)
+            self.submodules += ClockDomainsRenamer(tx_cd_name)(preamble_inserter)
+            self.submodules += ClockDomainsRenamer(rx_cd_name)(preamble_checker)
 
             # CRC insert/check
             crc32_inserter = crc.LiteEthMACCRC32Inserter(eth_phy_description(phy.dw))
             crc32_checker = crc.LiteEthMACCRC32Checker(eth_phy_description(phy.dw))
-            self.submodules += ClockDomainsRenamer("eth_tx")(crc32_inserter)
-            self.submodules += ClockDomainsRenamer("eth_rx")(crc32_checker)
+            self.submodules += ClockDomainsRenamer(tx_cd_name)(crc32_inserter)
+            self.submodules += ClockDomainsRenamer(rx_cd_name)(crc32_checker)
 
             tx_pipeline += [preamble_inserter, crc32_inserter]
             rx_pipeline += [preamble_checker, crc32_checker]
 
             # Error counters
-            self.submodules.ps_preamble_error = PulseSynchronizer("eth_rx", "sys")
-            self.submodules.ps_crc_error = PulseSynchronizer("eth_rx", "sys")
+            self.submodules.ps_preamble_error = PulseSynchronizer(rx_cd_name, "sys")
+            self.submodules.ps_crc_error = PulseSynchronizer(rx_cd_name, "sys")
 
             self.comb += [
                 self.ps_preamble_error.i.eq(preamble_checker.error),
@@ -69,8 +75,8 @@ class LiteEthMACCore(Module, AutoCSR):
         if with_padding:
             padding_inserter = padding.LiteEthMACPaddingInserter(phy.dw, 60)
             padding_checker = padding.LiteEthMACPaddingChecker(phy.dw, 60)
-            self.submodules += ClockDomainsRenamer("eth_tx")(padding_inserter)
-            self.submodules += ClockDomainsRenamer("eth_rx")(padding_checker)
+            self.submodules += ClockDomainsRenamer(tx_cd_name)(padding_inserter)
+            self.submodules += ClockDomainsRenamer(rx_cd_name)(padding_checker)
 
             tx_pipeline += [padding_inserter]
             rx_pipeline += [padding_checker]
@@ -79,8 +85,8 @@ class LiteEthMACCore(Module, AutoCSR):
         if dw != 8:
             tx_last_be = last_be.LiteEthMACTXLastBE(phy.dw)
             rx_last_be = last_be.LiteEthMACRXLastBE(phy.dw)
-            self.submodules += ClockDomainsRenamer("eth_tx")(tx_last_be)
-            self.submodules += ClockDomainsRenamer("eth_rx")(rx_last_be)
+            self.submodules += ClockDomainsRenamer(tx_cd_name)(tx_last_be)
+            self.submodules += ClockDomainsRenamer(rx_cd_name)(rx_last_be)
 
             tx_pipeline += [tx_last_be]
             rx_pipeline += [rx_last_be]
@@ -94,8 +100,8 @@ class LiteEthMACCore(Module, AutoCSR):
             rx_converter = stream.StrideConverter(eth_phy_description(phy.dw),
                                                   eth_phy_description(dw),
                                                   reverse=reverse)
-            self.submodules += ClockDomainsRenamer("eth_tx")(tx_converter)
-            self.submodules += ClockDomainsRenamer("eth_rx")(rx_converter)
+            self.submodules += ClockDomainsRenamer(tx_cd_name)(tx_converter)
+            self.submodules += ClockDomainsRenamer(rx_cd_name)(rx_converter)
 
             tx_pipeline += [tx_converter]
             rx_pipeline += [rx_converter]
@@ -103,8 +109,8 @@ class LiteEthMACCore(Module, AutoCSR):
         # Cross Domain Crossing
         tx_cdc = stream.AsyncFIFO(eth_phy_description(dw), 64)
         rx_cdc = stream.AsyncFIFO(eth_phy_description(dw), 64)
-        self.submodules += ClockDomainsRenamer({"write": "sys", "read": "eth_tx"})(tx_cdc)
-        self.submodules += ClockDomainsRenamer({"write": "eth_rx", "read": "sys"})(rx_cdc)
+        self.submodules += ClockDomainsRenamer({"write": "sys", "read": tx_cd_name})(tx_cdc)
+        self.submodules += ClockDomainsRenamer({"write": rx_cd_name, "read": "sys"})(rx_cdc)
 
         tx_pipeline += [tx_cdc]
         rx_pipeline += [rx_cdc]

--- a/liteeth/phy/rmii.py
+++ b/liteeth/phy/rmii.py
@@ -111,7 +111,8 @@ class LiteEthPHYRMIICRG(Module, AutoCSR):
         else:
             self.comb += reset.eq(self._reset.storage)
 
-        self.comb += pads.rst_n.eq(~reset)
+        if hasattr(pads, "rst_n"):
+            self.comb += pads.rst_n.eq(~reset)
         self.specials += [
             AsyncResetSynchronizer(self.cd_eth_tx, reset),
             AsyncResetSynchronizer(self.cd_eth_rx, reset),

--- a/liteeth/phy/rmii.py
+++ b/liteeth/phy/rmii.py
@@ -90,7 +90,8 @@ class LiteEthPHYRMIIRX(Module):
 
 
 class LiteEthPHYRMIICRG(Module, AutoCSR):
-    def __init__(self, clock_pads, pads, with_hw_init_reset):
+    def __init__(self, clock_pads, pads, with_hw_init_reset,
+                 cd_name="eth"):
         self._reset = CSRStorage()
 
         # # #
@@ -98,8 +99,8 @@ class LiteEthPHYRMIICRG(Module, AutoCSR):
         self.clock_domains.cd_eth_rx = ClockDomain()
         self.clock_domains.cd_eth_tx = ClockDomain()
         self.comb += [
-            self.cd_eth_rx.clk.eq(ClockSignal("eth")),
-            self.cd_eth_tx.clk.eq(ClockSignal("eth"))
+            self.cd_eth_rx.clk.eq(ClockSignal(cd_name)),
+            self.cd_eth_tx.clk.eq(ClockSignal(cd_name))
         ]
 
         self.specials += DDROutput(0, 1, clock_pads.ref_clk, ClockSignal("eth_tx"))
@@ -123,8 +124,11 @@ class LiteEthPHYRMII(Module, AutoCSR):
     dw          = 8
     tx_clk_freq = 50e6
     rx_clk_freq = 50e6
-    def __init__(self, clock_pads, pads, with_hw_init_reset=True):
-        self.submodules.crg = LiteEthPHYRMIICRG(clock_pads, pads, with_hw_init_reset)
+    def __init__(self, clock_pads, pads, with_hw_init_reset=True,
+                name="ethphy", cd_name="eth"):
+        self.name = name
+        self.submodules.crg = LiteEthPHYRMIICRG(clock_pads, pads,
+                                                with_hw_init_reset, cd_name)
         self.submodules.tx = ClockDomainsRenamer("eth_tx")(LiteEthPHYRMIITX(pads))
         self.submodules.rx = ClockDomainsRenamer("eth_rx")(LiteEthPHYRMIIRX(pads))
         self.sink, self.source = self.tx.sink, self.rx.source


### PR DESCRIPTION
Hello,

the following two patches allow to use more than one RMII Ethernet PHY and the use of RMII PHY modules which do not use a "rst_n" signal. I didn't find a way of doing this without these two patches ...

Additional infos about the design:
[https://github.com/rprinz08/arty-s7-multinic](https://github.com/rprinz08/arty-s7-multinic)
and
[https://www.min.at/prinz/?x=entry:entry200428-150015](https://www.min.at/prinz/?x=entry:entry200428-150015)

br
Richard