### PR TITLE
ecp5rgmii: enable reading inband PHY_status

### DIFF
--- a/liteeth/phy/rgmii.py
+++ b/liteeth/phy/rgmii.py
@@ -1,0 +1,27 @@
+# This file is Copyright (c) 2020 Shawn Hoffman <godisgovernment@gmail.com>
+# License: BSD
+
+from liteeth.common import *
+
+phy_status_layout = [
+    ("ctl_r", 1),
+    ("ctl_f", 1),
+    ("data", 8),
+]
+
+class LiteEthPHYRGMIIStatus(Module):
+    def __init__(self):
+        self.phy = phy = Record(phy_status_layout)
+
+        # phy_status signals optionally sent during inter-frame
+        self.link_up = Signal()
+        self.rxc_speed = Signal(2)
+        self.full_duplex = Signal()
+
+        inter_frame = Signal()
+        self.comb += inter_frame.eq(~(phy.ctl_r | phy.ctl_f))
+
+        self.sync += If(inter_frame,
+            self.link_up.eq(phy.data[0]),
+            self.rxc_speed.eq(phy.data[1:3]),
+            self.full_duplex.eq(phy.data[3]))


### PR DESCRIPTION
I've tried to do it in a way that could be used by other rgmii modules...

If supported by phy, this is much more convenient than mdio