### PR TITLE
mac padding: fix counter reset value

### DIFF
--- a/liteeth/mac/padding.py
+++ b/liteeth/mac/padding.py
@@ -18,7 +18,7 @@ class LiteEthMACPaddingInserter(Module):
 
         padding_limit = math.ceil(padding/(dw/8))-1
 
-        counter      = Signal(16, reset=1)
+        counter      = Signal(16)
         counter_done = Signal()
         self.comb += counter_done.eq(counter >= padding_limit)
 


### PR DESCRIPTION
I observed following behavior:
 1. first sent packet after the module reset required padding
 1. incorrect reset value would cause 1 fewer padding bytes to be appended than were required
 1. too-short packet was dropped as invalid by remote receiver