### PR TITLE
mac/core: Improve timing closure of core

### DIFF
--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -12,6 +12,8 @@ from liteeth.phy.model import LiteEthPHYModel
 
 from migen.genlib.cdc import PulseSynchronizer
 
+from litex.soc.interconnect.stream import BufferizeEndpoints, DIR_SOURCE, DIR_SINK
+
 # MAC Core -----------------------------------------------------------------------------------------
 
 class LiteEthMACCore(Module, AutoCSR):
@@ -44,8 +46,8 @@ class LiteEthMACCore(Module, AutoCSR):
             self.submodules += ClockDomainsRenamer("eth_rx")(preamble_checker)
 
             # CRC insert/check
-            crc32_inserter = crc.LiteEthMACCRC32Inserter(eth_phy_description(phy.dw))
-            crc32_checker  = crc.LiteEthMACCRC32Checker(eth_phy_description(phy.dw))
+            crc32_inserter = BufferizeEndpoints({"sink": DIR_SINK})(crc.LiteEthMACCRC32Inserter(eth_phy_description(phy.dw)))
+            crc32_checker  = BufferizeEndpoints({"sink": DIR_SINK})(crc.LiteEthMACCRC32Checker(eth_phy_description(phy.dw)))
             self.submodules += ClockDomainsRenamer("eth_tx")(crc32_inserter)
             self.submodules += ClockDomainsRenamer("eth_rx")(crc32_checker)
 


### PR DESCRIPTION
On ECP5 targets the core struggles to meet timing closure. This
change adds buffers to the CRC module on tx/rx paths.
This results in 20-30MHz gain to max clock rate.

This fixes #47


This is the timing result I've just got from running:
```console
$ ./versa_ecp5.py --build --with-ethernet --integrated-rom-size 36864 
...
Info: Max frequency for clock                     '$glbnet$sys_clk': 89.22 MHz (PASS at 75.01 MHz)
Info: Max frequency for clock '$glbnet$eth_clocks_rx$TRELLIS_IO_IN': 148.57 MHz (PASS at 125.00 MHz)
Info: Max frequency for clock                    '$glbnet$init_clk': 314.37 MHz (PASS at 25.00 MHz)
Info: Max frequency for clock        '$glbnet$clk100$TRELLIS_IO_IN': 451.06 MHz (PASS at 100.00 MHz)
...
```