### PR TITLE
phy/ecp5rgmii: Fix io delay blocks

### DIFF
--- a/liteeth/phy/ecp5rgmii.py
+++ b/liteeth/phy/ecp5rgmii.py
@@ -31,12 +31,9 @@ class LiteEthPHYRGMIITX(Module):
                 i1  = sink.valid,
                 i2  = sink.valid,
                 o   = tx_ctl_oddrx1f),
-            Instance("DELAYF",
+            Instance("DELAYG",
                 p_DEL_MODE  = "SCLK_ALIGNED",
-                p_DEL_VALUE = "DELAY0",
-                i_LOADN     = 1,
-                i_MOVE      = 0,
-                i_DIRECTION = 0,
+                p_DEL_VALUE = 0,
                 i_A         = tx_ctl_oddrx1f,
                 o_Z         = pads.tx_ctl)
         ]
@@ -47,12 +44,9 @@ class LiteEthPHYRGMIITX(Module):
                     i1  = sink.data[i],
                     i2  = sink.data[4+i],
                     o   = tx_data_oddrx1f[i]),
-                Instance("DELAYF",
+                Instance("DELAYG",
                     p_DEL_MODE  = "SCLK_ALIGNED",
-                    p_DEL_VALUE = "DELAY0",
-                    i_LOADN     = 1,
-                    i_MOVE      = 0,
-                    i_DIRECTION = 0,
+                    p_DEL_VALUE = 0,
                     i_A         = tx_data_oddrx1f[i],
                     o_Z         = pads.tx_data[i]
                 )
@@ -94,12 +88,9 @@ class LiteEthPHYRGMIIRX(Module, AutoCSR):
         rx_data_reg    = Signal(8)
 
         self.specials += [
-            Instance("DELAYF",
+            Instance("DELAYG",
                 p_DEL_MODE  = "SCLK_ALIGNED",
-                p_DEL_VALUE = "DELAY{}".format(rx_delay_taps),
-                i_LOADN     = 1,
-                i_MOVE      = 0,
-                i_DIRECTION = 0,
+                p_DEL_VALUE = rx_delay_taps,
                 i_A         = pads.rx_ctl,
                 o_Z         = rx_ctl_delayf),
             DDRInput(
@@ -112,12 +103,9 @@ class LiteEthPHYRGMIIRX(Module, AutoCSR):
         self.sync += rx_ctl_reg.eq(rx_ctl)
         for i in range(4):
             self.specials += [
-                Instance("DELAYF",
+                Instance("DELAYG",
                     p_DEL_MODE  = "SCLK_ALIGNED",
-                    p_DEL_VALUE = "DELAY{}".format(rx_delay_taps),
-                    i_LOADN     = 1,
-                    i_MOVE      = 0,
-                    i_DIRECTION = 0,
+                    p_DEL_VALUE = rx_delay_taps,
                     i_A         = pads.rx_data[i],
                     o_Z         = rx_data_delayf[i]),
                 DDRInput(
@@ -175,12 +163,9 @@ class LiteEthPHYRGMIICRG(Module, AutoCSR):
                 i1  = 1,
                 i2  = 0,
                 o   = eth_tx_clk_o),
-            Instance("DELAYF",
+            Instance("DELAYG",
                 p_DEL_MODE  = "SCLK_ALIGNED",
-                p_DEL_VALUE = "DELAY{}".format(tx_delay_taps),
-                i_LOADN     = 1,
-                i_MOVE      = 0,
-                i_DIRECTION = 0,
+                p_DEL_VALUE = tx_delay_taps,
                 i_A         = eth_tx_clk_o,
                 o_Z         = clock_pads.tx)
         ]


### PR DESCRIPTION
For correct io delays in nextpnr the DEL_VALUE parameter needs to
be an integer, instead of the "DELAY{}" string.

The use of a "DELAY{}" string appears in the Lattice primitive
manual, but appears to be incorrect. At least based of the current
nextpnr.

Because we are not making use of dynamic io delays here we can
also use the simpler DELAYG block instead of DELAYF.

Fixes #50