### PR TITLE
Using multiple RMII phys with (possible multiple) external clock(s)

### DIFF
--- a/liteeth/phy/rmii.py
+++ b/liteeth/phy/rmii.py
@@ -94,7 +94,7 @@ class LiteEthPHYRMIIRX(Module):
 
 class LiteEthPHYRMIICRG(Module, AutoCSR):
     def __init__(self, clock_pads, pads, with_hw_init_reset,
-                 no_clk_out=False):
+                 no_clk_out=False, clock_cd="eth"):
         self._reset = CSRStorage()
 
         # # #
@@ -103,12 +103,13 @@ class LiteEthPHYRMIICRG(Module, AutoCSR):
         self.clock_domains.cd_eth_rx = ClockDomain()
         self.clock_domains.cd_eth_tx = ClockDomain()
         self.comb += [
-            self.cd_eth_rx.clk.eq(ClockSignal("eth")),
-            self.cd_eth_tx.clk.eq(ClockSignal("eth"))
+            self.cd_eth_rx.clk.eq(ClockSignal(clock_cd)),
+            self.cd_eth_tx.clk.eq(ClockSignal(clock_cd))
         ]
 
         if not no_clk_out:
-            self.specials += DDROutput(0, 1, clock_pads.ref_clk, ClockSignal("eth_tx"))
+            self.specials += DDROutput(0, 1, clock_pads.ref_clk,
+                                       ClockSignal(clock_cd + "_tx"))
 
         # Reset
         self.reset = reset = Signal()
@@ -130,10 +131,10 @@ class LiteEthPHYRMII(Module, AutoCSR):
     tx_clk_freq = 50e6
     rx_clk_freq = 50e6
     def __init__(self, clock_pads, pads, with_hw_init_reset=True,
-                 no_clk_out=False):
+                 no_clk_out=False, clock_cd="eth"):
         self.submodules.crg = LiteEthPHYRMIICRG(clock_pads, pads,
                                                 with_hw_init_reset,
-                                                no_clk_out)
+                                                no_clk_out, clock_cd)
         self.submodules.tx = ClockDomainsRenamer("eth_tx")(LiteEthPHYRMIITX(pads))
         self.submodules.rx = ClockDomainsRenamer("eth_rx")(LiteEthPHYRMIIRX(pads))
         self.sink, self.source = self.tx.sink, self.rx.source


### PR DESCRIPTION
- Control (disable) output of eth clock when using external clock
- Specify ClockDomain name when using multiple RMIIs each with its own external clock(domain)