### PR TITLE
RMII PHY: Add support for ref_clk being provided externally

### DIFF
--- a/liteeth/phy/rmii.py
+++ b/liteeth/phy/rmii.py
@@ -101,9 +101,16 @@ class LiteEthPHYRMIICRG(Module, AutoCSR):
         # RX/TX clocks
         self.clock_domains.cd_eth_rx = ClockDomain()
         self.clock_domains.cd_eth_tx = ClockDomain()
-        self.comb += self.cd_eth_rx.clk.eq(ClockSignal(refclk_cd))
-        self.comb += self.cd_eth_tx.clk.eq(ClockSignal(refclk_cd))
-        if clock_pads is not None:
+
+        if clock_pads is not None and hasattr(clock_pads, 'ref_clk_in'):
+            eth_clk = clock_pads.ref_clk_in
+        else:
+            eth_clk = ClockSignal(refclk_cd)
+
+        self.comb += self.cd_eth_rx.clk.eq(eth_clk)
+        self.comb += self.cd_eth_tx.clk.eq(eth_clk)
+
+        if clock_pads is not None and not hasattr(clock_pads, 'ref_clk_in'):
             self.specials += DDROutput(0, 1, clock_pads.ref_clk, ClockSignal("eth_tx"))
 
         # Reset


### PR DESCRIPTION
RMII spec allows an alternate mode in which ref_clk is an input on both
the MAC and the PHY. This is used by a no-name "LAN8720 ETH board"
break-out board. This commit allows this mode by specifying a ref_clk_in
Subsignal in clock_pads (instead of ref_clk).