### PR TITLE
MAC: implement TX return channel & hardware timestamping

### DIFF
--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -18,7 +18,8 @@ class LiteEthMAC(Module, AutoCSR):
         with_preamble_crc = True,
         nrxslots          = 2,
         ntxslots          = 2,
-        hw_mac            = None):
+        hw_mac            = None,
+        timestamp_source  = None):
         assert interface in ["crossbar", "wishbone", "hybrid"]
         self.submodules.core = LiteEthMACCore(phy, dw, endianness, with_preamble_crc)
         self.csrs = []
@@ -37,7 +38,13 @@ class LiteEthMAC(Module, AutoCSR):
             self.rx_slots  = CSRConstant(nrxslots)
             self.tx_slots  = CSRConstant(ntxslots)
             self.slot_size = CSRConstant(2**bits_for(eth_mtu))
-            self.submodules.interface = FullMemoryWE()(LiteEthMACWishboneInterface(32, nrxslots, ntxslots, endianness))
+            self.submodules.interface = FullMemoryWE()(LiteEthMACWishboneInterface(
+                dw = 32,
+                nrxslots = nrxslots,
+                ntxslots = ntxslots,
+                endianness = endianness,
+                timestamp_source = timestamp_source,
+            ))
             self.ev, self.bus = self.interface.sram.ev, self.interface.bus
             self.csrs = self.interface.get_csrs() + self.core.get_csrs()
             if interface == "hybrid":

--- a/liteeth/mac/wishbone.py
+++ b/liteeth/mac/wishbone.py
@@ -13,7 +13,7 @@ from litex.soc.interconnect import wishbone
 # MAC Wishbone Interface ---------------------------------------------------------------------------
 
 class LiteEthMACWishboneInterface(Module, AutoCSR):
-    def __init__(self, dw, nrxslots=2, ntxslots=2, endianness="big"):
+    def __init__(self, dw, nrxslots=2, ntxslots=2, endianness="big", timestamp_source=None):
         self.sink   = stream.Endpoint(eth_phy_description(dw))
         self.source = stream.Endpoint(eth_phy_description(dw))
         self.bus    = wishbone.Interface()
@@ -22,7 +22,7 @@ class LiteEthMACWishboneInterface(Module, AutoCSR):
 
         # storage in SRAM
         sram_depth = eth_mtu//(dw//8)
-        self.submodules.sram = sram.LiteEthMACSRAM(dw, sram_depth, nrxslots, ntxslots, endianness)
+        self.submodules.sram = sram.LiteEthMACSRAM(dw, sram_depth, nrxslots, ntxslots, endianness, timestamp_source)
         self.comb += [
             self.sink.connect(self.sram.sink),
             self.sram.source.connect(self.source)


### PR DESCRIPTION
This adds optional packet hardware timestamping to the SRAM-backed MAC interface. Hardware timestamping is a feature which can help with implementing standards such as IEEE 1588 Precision Time Protocol and can be interesting for a variety of time-critical domains. Compared to software-based timestamping of received and transmitted packets, having a hardware-timestamp available that corresponds to a specific point time in packet transmission & reception can greatly increase the accuracy of such protocols.

## Implementation strategy

While RX timestamping was very straightforward to implement (simply latch the current timestamp on reception start and store it in the SyncFIFO for incoming packet metadata), TX timestamping requires some more work: the MAC's user must be informed about the precise transmission timestamp after the packet has been sent. Up to now the MAC does not seem to have any return channel except for a pulse-triggered event indicating a packet has been transmitted.

Therefore, this PR also introduces a return-channel FIFO which contains metadata about transmitted packets. It changes the event source from pulse- to FIFO-ready-triggered. This seems to have the advantage of avoiding potentially missing a _TX done_ events if the CPU cannot handle & clear the first _TX done_ event prior to a second arrives, as the FIFO can queue `num_slots` _TX done_ events (sufficient for the maximum number of queueable packets).

The timestamp fields in the FIFO & CSRs for both RX & TX are generated only when a timestamp source signal is provided.

## Implications

Switching from a pulse-triggered event to a FIFO-based level-triggered event does of course change the behavior substantially. However, it seems that coincidentally some implementations (the bootloader and Tock's driver for LiteEth) continue to work just fine given that the event clearing semantics remain the same. I can imagine this causing issues where drivers we relying on the fact that events could not be queued (two packets will only require clearing _TX done_ once).

## Further Tasks / Questions

I'm no expert in Python and Migen so I appreciate input about coding style & other comments. It seems to work fine on an Arty and Sim, both with and without hardware timestamping, but probably requires careful review that I don't break anything.

I'm not sure whether this change is substantial enough for adding myself to any AUTHORS record.

Thanks!