### PR TITLE
allow for different nrxslots and ntxslots

### DIFF
--- a/liteeth/mac/wishbone.py
+++ b/liteeth/mac/wishbone.py
@@ -37,7 +37,9 @@ class LiteEthMACWishboneInterface(Module, AutoCSR):
 
         wb_slaves     = []
         decoderoffset = log2_int(sram_depth, need_pow2=False)
-        decoderbits   = log2_int(len(wb_sram_ifs))
+        rx_decoderbits   = log2_int(len(wb_rx_sram_ifs))
+        tx_decoderbits   = log2_int(len(wb_tx_sram_ifs))
+        decoderbits      = max(rx_decoderbits, tx_decoderbits)+1
         for n, wb_sram_if in enumerate(wb_sram_ifs):
             def slave_filter(a, v=n):
                 return a[decoderoffset:decoderoffset+decoderbits] == v


### PR DESCRIPTION
Background:
When there is a lot of broadcasts in the network, receive buffers
may overflow easly. Especially having onlu 2 of them.
To prevent that you can enlarge nrxslots, but because
nrxslots + ntxslots must be the power of two, you must also
inrease ntxslots. But there is no need to have more than 2 tx
buffers (they work as ping-pong buffer), the CPU will not use
more than two buffers.

So being able to set for example nrxslots=8 and ntxslots=2
is quite reasonable.