### PR TITLE
Revert "phy/ecp5rgmii: remove p_DEL_MODE (not required since we speci…

### DIFF
--- a/liteeth/phy/ecp5rgmii.py
+++ b/liteeth/phy/ecp5rgmii.py
@@ -32,6 +32,7 @@ class LiteEthPHYRGMIITX(Module):
                 i2  = sink.valid,
                 o   = tx_ctl_oddrx1f),
             Instance("DELAYG",
+                p_DEL_MODE  = "SCLK_ALIGNED",
                 p_DEL_VALUE = 0,
                 i_A         = tx_ctl_oddrx1f,
                 o_Z         = pads.tx_ctl)
@@ -44,6 +45,7 @@ class LiteEthPHYRGMIITX(Module):
                     i2  = sink.data[4+i],
                     o   = tx_data_oddrx1f[i]),
                 Instance("DELAYG",
+                    p_DEL_MODE  = "SCLK_ALIGNED",
                     p_DEL_VALUE = 0,
                     i_A         = tx_data_oddrx1f[i],
                     o_Z         = pads.tx_data[i]
@@ -87,6 +89,7 @@ class LiteEthPHYRGMIIRX(Module, AutoCSR):
 
         self.specials += [
             Instance("DELAYG",
+                p_DEL_MODE  = "SCLK_ALIGNED",
                 p_DEL_VALUE = rx_delay_taps,
                 i_A         = pads.rx_ctl,
                 o_Z         = rx_ctl_delayf),
@@ -101,6 +104,7 @@ class LiteEthPHYRGMIIRX(Module, AutoCSR):
         for i in range(4):
             self.specials += [
                 Instance("DELAYG",
+                    p_DEL_MODE  = "SCLK_ALIGNED",
                     p_DEL_VALUE = rx_delay_taps,
                     i_A         = pads.rx_data[i],
                     o_Z         = rx_data_delayf[i]),
@@ -158,6 +162,7 @@ class LiteEthPHYRGMIICRG(Module, AutoCSR):
                 i2  = 0,
                 o   = eth_tx_clk_o),
             Instance("DELAYG",
+                p_DEL_MODE  = "SCLK_ALIGNED",
                 p_DEL_VALUE = tx_delay_taps,
                 i_A         = eth_tx_clk_o,
                 o_Z         = clock_pads.tx)


### PR DESCRIPTION
This was silently (😞) causing my design to stop functioning correctly* (using Diamond 3.11). The lattice tools _will_ halt with error if you try to use the Reveal Inserter with `USER_DEFINED` and the `DEL_VALUE`s liteeth is setting.

Just reverting this commit seems to be the easiest way to fix behavior and prevent tools from erroring, although tbh I haven't looked further into the problem.

![image](https://user-images.githubusercontent.com/113063/112883035-9bdc8200-9082-11eb-955c-3150a7b70519.png)

*Ethernet traffic was either not sent on the wire from the phy, or whatever was sent was not understood by my host PC