### PR TITLE
mac: Allow configuring usage of FullMemoryWE (fixes #70)

### DIFF
--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -219,12 +219,13 @@ class MACCore(PHYCore):
 
         # MAC --------------------------------------------------------------------------------------
         self.submodules.ethmac = LiteEthMAC(
-            phy        = self.ethphy,
-            dw         = 32,
-            interface  = "wishbone",
-            endianness = core_config["endianness"],
-            nrxslots   = nrxslots,
-            ntxslots   = ntxslots)
+            phy            = self.ethphy,
+            dw             = 32,
+            interface      = "wishbone",
+            endianness     = core_config["endianness"],
+            nrxslots       = nrxslots,
+            ntxslots       = ntxslots,
+            full_memory_we = core_config.get("full_memory_we", False))
         self.add_wb_slave(self.mem_map["ethmac"], self.ethmac.bus)
         self.add_memory_region("ethmac", self.mem_map["ethmac"], mac_memsize, type="io")
         self.add_csr("ethmac")


### PR DESCRIPTION
On ecp5 `FullMemoryWE` leads to an increase of DP16KD block mem, while
it works better on Intel/Altera devices according to
6c3af746e28f55089c9f79966205499af394ae34.

Simple solution: Make it configurable

EDIT: Original issue leading to `FullMemoryWE` being used is #63