### PR TITLE
liteeth/phy: add configurable hw reset duration

### DIFF
--- a/liteeth/phy/common.py
+++ b/liteeth/phy/common.py
@@ -11,17 +11,17 @@ from migen.fhdl.specials import Tristate
 
 
 class LiteEthPHYHWReset(Module):
-    def __init__(self):
+    def __init__(self, cycles=256):
         self.reset = Signal()
 
         # # #
 
-        counter      = Signal(max=512)
+        counter      = Signal(max=cycles + 1)
         counter_done = Signal()
         counter_ce   = Signal()
         self.sync += If(counter_ce, counter.eq(counter + 1))
         self.comb += [
-            counter_done.eq(counter == 256),
+            counter_done.eq(counter == cycles),
             counter_ce.eq(~counter_done),
             self.reset.eq(~counter_done)
         ]

--- a/liteeth/phy/s7rgmii.py
+++ b/liteeth/phy/s7rgmii.py
@@ -144,7 +144,7 @@ class LiteEthPHYRGMIIRX(Module):
 
 
 class LiteEthPHYRGMIICRG(Module, AutoCSR):
-    def __init__(self, clock_pads, pads, with_hw_init_reset, tx_delay=2e-9):
+    def __init__(self, clock_pads, pads, with_hw_init_reset, tx_delay=2e-9, hw_reset_cycles=256):
         self._reset = CSRStorage()
 
         # # #
@@ -195,7 +195,7 @@ class LiteEthPHYRGMIICRG(Module, AutoCSR):
         # Reset
         self.reset = reset = Signal()
         if with_hw_init_reset:
-            self.submodules.hw_reset = LiteEthPHYHWReset()
+            self.submodules.hw_reset = LiteEthPHYHWReset(cycles=hw_reset_cycles)
             self.comb += reset.eq(self._reset.storage | self.hw_reset.reset)
         else:
             self.comb += reset.eq(self._reset.storage)
@@ -211,8 +211,9 @@ class LiteEthPHYRGMII(Module, AutoCSR):
     dw          = 8
     tx_clk_freq = 125e6
     rx_clk_freq = 125e6
-    def __init__(self, clock_pads, pads, with_hw_init_reset=True, tx_delay=2e-9, rx_delay=2e-9, iodelay_clk_freq=200e6):
-        self.submodules.crg = LiteEthPHYRGMIICRG(clock_pads, pads, with_hw_init_reset, tx_delay)
+    def __init__(self, clock_pads, pads, with_hw_init_reset=True, tx_delay=2e-9, rx_delay=2e-9,
+            iodelay_clk_freq=200e6, hw_reset_cycles=256):
+        self.submodules.crg = LiteEthPHYRGMIICRG(clock_pads, pads, with_hw_init_reset, tx_delay, hw_reset_cycles)
         self.submodules.tx  = ClockDomainsRenamer("eth_tx")(LiteEthPHYRGMIITX(pads))
         self.submodules.rx  = ClockDomainsRenamer("eth_rx")(LiteEthPHYRGMIIRX(pads, rx_delay, iodelay_clk_freq))
         self.sink, self.source = self.tx.sink, self.rx.source


### PR DESCRIPTION
Sometimes 256 cycles is to short to reset the Ethernet PHY. This PR makes the reset duration configurable, leaving the previous value as the default.