### PR TITLE
Add toggleable 32 bit support to mac pipeline

### DIFF
--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -20,9 +20,10 @@ class LiteEthMAC(Module, AutoCSR):
         ntxslots          = 2,
         hw_mac            = None,
         timestamp         = None,
-        full_memory_we    = False):
+        full_memory_we    = False,
+        sys_data_path     = True):
         assert interface in ["crossbar", "wishbone", "hybrid"]
-        self.submodules.core = LiteEthMACCore(phy, dw, endianness, with_preamble_crc)
+        self.submodules.core = LiteEthMACCore(phy, dw, endianness, with_preamble_crc, sys_data_path)
         self.csrs = []
         if interface == "crossbar":
             self.submodules.crossbar     = LiteEthMACCrossbar(dw)

--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -61,6 +61,11 @@ class LiteEthMACCore(Module, AutoCSR):
             self.sync += If(self.ps_preamble_error.o,
                             self.preamble_errors.status.eq(self.preamble_errors.status + 1)),
 
+        if sys_data_path:
+            self.data_path_converter(tx_pipeline, rx_pipeline, core_dw, phy.dw, endianness)
+            cd_tx = cd_rx = "sys"
+            dw = core_dw
+
         if not isinstance(phy, LiteEthPHYModel) and with_preamble_crc:
             # CRC insert/check
             crc32_inserter = BufferizeEndpoints({"sink": DIR_SINK})(crc.LiteEthMACCRC32Inserter(eth_phy_description(dw)))
@@ -77,11 +82,6 @@ class LiteEthMACCore(Module, AutoCSR):
             self.comb += self.ps_crc_error.i.eq(crc32_checker.error),
             self.sync += If(self.ps_crc_error.o,
                             self.crc_errors.status.eq(self.crc_errors.status + 1)),
-
-        if sys_data_path:
-            self.data_path_converter(tx_pipeline, rx_pipeline, core_dw, phy.dw, endianness)
-            cd_tx = cd_rx = "sys"
-            dw = core_dw
 
         # Padding
         if with_padding:

--- a/liteeth/mac/endian_converter.py
+++ b/liteeth/mac/endian_converter.py
@@ -1,0 +1,18 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2021 David Sawatzke <d-git@sawatzke.dev>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from liteeth.common import *
+
+class LiteEthMACEndianConverter(Module):
+    def __init__(self, dw):
+        self.sink = sink = stream.Endpoint(eth_phy_description(dw))
+        self.source = source = stream.Endpoint(eth_phy_description(dw))
+        self.comb += [
+            sink.connect(source),
+            source.data.eq(reverse_bytes(sink.data)),
+            source.last_be.eq(reverse_bits(sink.last_be)),
+            source.error.eq(reverse_bits(sink.error)),
+        ]

--- a/liteeth/mac/preamble.py
+++ b/liteeth/mac/preamble.py
@@ -25,13 +25,16 @@ class LiteEthMACPreambleInserter(Module):
         Preamble, SFD, and packet octets.
     """
     def __init__(self, dw):
+        assert dw in [8, 16, 32, 64]
         self.sink   = stream.Endpoint(eth_phy_description(dw))
         self.source = stream.Endpoint(eth_phy_description(dw))
 
         # # #
 
         preamble = Signal(64, reset=eth_preamble)
-        count    = Signal(max=(64//dw)-1, reset_less=True)
+        # For 64 bits, `count` doesn't need to change. But migen won't create a
+        # signal with a width of 0 bits, so add an unused bit for 64 bit path
+        count    = Signal(max=(64//dw) if dw != 64 else 2, reset_less=True)
         self.submodules.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
             self.sink.ready.eq(1),


### PR DESCRIPTION
This PR adds 32 bit support to all components of the mac pipeline. For everything apart from the crc 64 bit should also work but is *currently* untested. 64 bit support for the crc shouldn't be hard to add without a completely separate codepath, but since I wanted to keep this PR smaller and can't test it right now, I didn't implement it.

This PR duplicates some things from #21, but does some things nicer IMHO, like the preamble. #21 also doesn't properly implement crc for the 32 bit and padding doesn't work. It's also broken on big endian systems. I've also tried to add a few comments when they're helpful.

#21 also seems to have a trick to reduce the amount of crc engines needed, but this looked very confusing to me, so I took the simple route.

Each commit should be in a working state on little endian systems, it's probably also easier to review it commit-by-commit.

I'm not sure if there's a better way to do the endian conversion, I haven't been able to find one. We may want to do the endian conversion in any case for 32/64 bit phy support and make the stride converter only support little endian.

With this PR in place, the colorlight target easily hits the 125MHz cd target (this is with #72):
```
Info: Max frequency for clock '$glbnet$eth_clocks0_rx$TRELLIS_IO_IN': 138.29 MHz (PASS at 125.00 MHz)
```

With a smaller depth for the stride converter, it gets even higher. I'm not sure why the stride converter has such a large buffer, especially tx. With stride converter depth set at 4, the ethernet core also hits the frequency constraints on my own design all the time with > 150 MHz)

#49 can probably also be reverted.