### PR TITLE
core/arp: assert last_be only on the last data word

### DIFF
--- a/liteeth/core/arp.py
+++ b/liteeth/core/arp.py
@@ -51,7 +51,11 @@ class LiteEthARPTX(Module):
         )
         self.comb += [
             packetizer.sink.last.eq(counter == (packet_words - 1)),
-            packetizer.sink.last_be.eq(1 if len(packetizer.sink.last_be) == 1 else 2**(packet_length%(dw//8)-1)),
+            If(packetizer.sink.last,
+                packetizer.sink.last_be.eq(
+                    1 if len(packetizer.sink.last_be) == 1 else 2**(packet_length % (dw // 8) - 1)
+                ),
+            ),
             packetizer.sink.hwtype.eq(arp_hwtype_ethernet),
             packetizer.sink.proto.eq(arp_proto_ip),
             packetizer.sink.hwsize.eq(6),


### PR DESCRIPTION
This is in line with other components of the LiteEth repository using the `last_be` data qualifier. It is unexpected for last_be to be
asserted on any data word other than the last (i.e. only when `last` is also asserted). In particular it can confuse the Packetizer and cause it to pass through `last_be` on words other than the last as well. This then irritates some parts of the MAC pipeline.

With these changes, ARP works on a 64-bit wide data path (with the {Dep,P}acketizer changes integrated into LiteX).