### PR TITLE
liteeth/mac: support SRAM/Wishbone operation with dw > 32 bit

### DIFF
--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -74,7 +74,6 @@ class LiteEthMAC(Module, AutoCSR):
                 self.submodules.crossbar     = LiteEthMACCrossbar(dw)
                 self.submodules.mac_crossbar = LiteEthMACCoreCrossbar(self.core, self.crossbar, self.interface, dw, hw_mac)
             else:
-                assert dw == 32
                 self.comb += self.interface.source.connect(self.core.sink)
                 self.comb += self.core.source.connect(self.interface.sink)
 

--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -50,7 +50,7 @@ class LiteEthMAC(Module, AutoCSR):
             self.tx_slots  = CSRConstant(ntxslots)
             self.slot_size = CSRConstant(2**bits_for(eth_mtu))
             wishbone_interface = LiteEthMACWishboneInterface(
-                dw         = 32,
+                dw         = dw,
                 nrxslots   = nrxslots,
                 ntxslots   = ntxslots,
                 endianness = endianness,


### PR DESCRIPTION
These is required to support 64-bit wide data paths using the automatic Wishbone bus width conversion as discussed in #75. Otherwise, if the MAC data width deviates from the 32-bit default set previously, received and transmitted packets will be broken.

This also removes an assertion of the MAC data width for the Wishbone interface mode of operation.