### PR TITLE
WIP: Multiple eth clk domains

### DIFF
--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -37,8 +37,12 @@ class LiteEthMACCore(Module, AutoCSR):
             cd_rx       = "sys"
             datapath_dw = core_dw
         else:
-            cd_tx       = phy.cd_eth_tx
-            cd_rx       = phy.cd_eth_rx
+            if type(phy.cd_eth_tx) is str:
+                cd_tx       = phy.cd_eth_tx
+                cd_rx       = phy.cd_eth_rx
+            else:
+                cd_tx       = phy.cd_eth_tx.name
+                cd_rx       = phy.cd_eth_rx.name
             datapath_dw = phy_dw
         if isinstance(phy, LiteEthPHYModel):
             with_preamble_crc = False # Disable Preamble/CRC with PHY Model for direct connection to the Ethernet tap.

--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -37,12 +37,13 @@ class LiteEthMACCore(Module, AutoCSR):
             cd_rx       = "sys"
             datapath_dw = core_dw
         else:
-            if type(phy.cd_eth_tx) is str:
-                cd_tx       = phy.cd_eth_tx
-                cd_rx       = phy.cd_eth_rx
-            elif type(phy.cd_eth_tx) is ClockDomain:
-                cd_tx       = phy.cd_eth_tx.name
-                cd_rx       = phy.cd_eth_rx.name
+            if hasattr(phy, cd_eth_tx):
+                if type(phy.cd_eth_tx) is str:
+                    cd_tx       = phy.cd_eth_tx
+                    cd_rx       = phy.cd_eth_rx
+                elif type(phy.cd_eth_tx) is ClockDomain:
+                    cd_tx       = phy.cd_eth_tx.name
+                    cd_rx       = phy.cd_eth_rx.name
             else:
                 cd_tx       = "eth_tx"
                 cd_rx       = "eth_rx"

--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -40,9 +40,12 @@ class LiteEthMACCore(Module, AutoCSR):
             if type(phy.cd_eth_tx) is str:
                 cd_tx       = phy.cd_eth_tx
                 cd_rx       = phy.cd_eth_rx
-            else:
+            elif type(phy.cd_eth_tx) is ClockDomain:
                 cd_tx       = phy.cd_eth_tx.name
                 cd_rx       = phy.cd_eth_rx.name
+            else:
+                cd_tx       = "eth_tx"
+                cd_rx       = "eth_rx"
             datapath_dw = phy_dw
         if isinstance(phy, LiteEthPHYModel):
             with_preamble_crc = False # Disable Preamble/CRC with PHY Model for direct connection to the Ethernet tap.

--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -37,8 +37,8 @@ class LiteEthMACCore(Module, AutoCSR):
             cd_rx       = "sys"
             datapath_dw = core_dw
         else:
-            cd_tx       = "eth_tx"
-            cd_rx       = "eth_rx"
+            cd_tx       = phy.cd_eth_tx
+            cd_rx       = phy.cd_eth_rx
             datapath_dw = phy_dw
         if isinstance(phy, LiteEthPHYModel):
             with_preamble_crc = False # Disable Preamble/CRC with PHY Model for direct connection to the Ethernet tap.
@@ -56,7 +56,7 @@ class LiteEthMACCore(Module, AutoCSR):
             def add_cdc(self):
                 tx_cdc = stream.ClockDomainCrossing(eth_phy_description(core_dw),
                     cd_from = "sys",
-                    cd_to   = "eth_tx",
+                    cd_to   = cd_tx,
                     depth   = 32)
                 self.submodules += tx_cdc
                 self.pipeline.append(tx_cdc)
@@ -65,13 +65,13 @@ class LiteEthMACCore(Module, AutoCSR):
                 tx_converter = stream.StrideConverter(
                     description_from = eth_phy_description(core_dw),
                     description_to   = eth_phy_description(phy_dw))
-                tx_converter = ClockDomainsRenamer("eth_tx")(tx_converter)
+                tx_converter = ClockDomainsRenamer(cd_tx)(tx_converter)
                 self.submodules += tx_converter
                 self.pipeline.append(tx_converter)
 
             def add_last_be(self):
                 tx_last_be = last_be.LiteEthMACTXLastBE(phy_dw)
-                tx_last_be = ClockDomainsRenamer("eth_tx")(tx_last_be)
+                tx_last_be = ClockDomainsRenamer(cd_tx)(tx_last_be)
                 self.submodules += tx_last_be
                 self.pipeline.append(tx_last_be)
 
@@ -168,7 +168,7 @@ class LiteEthMACCore(Module, AutoCSR):
 
             def add_last_be(self):
                 rx_last_be = last_be.LiteEthMACRXLastBE(phy_dw)
-                rx_last_be = ClockDomainsRenamer("eth_rx")(rx_last_be)
+                rx_last_be = ClockDomainsRenamer(cd_rx)(rx_last_be)
                 self.submodules += rx_last_be
                 self.pipeline.append(rx_last_be)
 
@@ -176,13 +176,13 @@ class LiteEthMACCore(Module, AutoCSR):
                 rx_converter = stream.StrideConverter(
                     description_from = eth_phy_description(phy_dw),
                     description_to   = eth_phy_description(core_dw))
-                rx_converter = ClockDomainsRenamer("eth_rx")(rx_converter)
+                rx_converter = ClockDomainsRenamer(cd_rx)(rx_converter)
                 self.submodules += rx_converter
                 self.pipeline.append(rx_converter)
 
             def add_cdc(self):
                 rx_cdc = stream.ClockDomainCrossing(eth_phy_description(core_dw),
-                    cd_from = "eth_rx",
+                    cd_from = cd_rx,
                     cd_to   = "sys",
                     depth   = 32)
                 self.submodules += rx_cdc

--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -37,7 +37,7 @@ class LiteEthMACCore(Module, AutoCSR):
             cd_rx       = "sys"
             datapath_dw = core_dw
         else:
-            if hasattr(phy, cd_eth_tx):
+            if hasattr(phy, "cd_eth_tx") and hasattr(phy, "cd_eth_rx"):
                 if type(phy.cd_eth_tx) is str:
                     cd_tx       = phy.cd_eth_tx
                     cd_rx       = phy.cd_eth_rx

--- a/liteeth/phy/xgmii.py
+++ b/liteeth/phy/xgmii.py
@@ -310,9 +310,10 @@ class LiteEthPHYXGMII(Module, AutoCSR):
                  pads,
                  model=False,
                  dw=64,
-                 with_hw_init_reset=True):
+                 with_hw_init_reset=True,
+                 cd_eth_prefix="xgmii_"):
         self.dw = dw
-        self.cd_eth_tx, self.cd_eth_rx = "eth_tx", "eth_rx"
+        self.cd_eth_tx, self.cd_eth_rx = cd_eth_prefix + "eth_tx", cd_eth_prefix + "eth_rx"
         self.submodules.crg = LiteEthPHYXGMIICRG(clock_pads, model)
         self.submodules.tx = ClockDomainsRenamer(self.cd_eth_tx)(
             LiteEthPHYXGMIITX(pads, self.dw))

--- a/liteeth/phy/xgmii.py
+++ b/liteeth/phy/xgmii.py
@@ -311,7 +311,7 @@ class LiteEthPHYXGMII(Module, AutoCSR):
                  model=False,
                  dw=64,
                  with_hw_init_reset=True,
-                 cd_eth_prefix="xgmii_"):
+                 cd_eth_prefix=""):
         self.dw = dw
         self.cd_eth_tx, self.cd_eth_rx = cd_eth_prefix + "eth_tx", cd_eth_prefix + "eth_rx"
         self.submodules.crg = LiteEthPHYXGMIICRG(clock_pads, model)


### PR DESCRIPTION
Along the lines for having multiple ethernet cores, would mean multiple eth_rx/tx clockdomains.

@enjoy-digital would something like this make sense to you? This way, each phy contains the names of the clock domains and mac core has access to them through the phy?

Note I only did this for the XGMII case at the moment, but I can fix the other files with seemingly no regressions if you think it makes sense.