### PR TITLE
frontend/etherbone: Add 1-Slot PacketFIFO on LiteEthEtherboneProbe to prevent deadlock situation.

### DIFF
--- a/liteeth/frontend/etherbone.py
+++ b/liteeth/frontend/etherbone.py
@@ -139,14 +139,21 @@ class LiteEthEtherboneProbe(Module):
 
         # # #
 
+        self.submodules.fifo = fifo = PacketFIFO(eth_etherbone_packet_user_description(32),
+            payload_depth = 1,
+            param_depth   = 1,
+            buffered      = False
+        )
+        self.comb += sink.connect(fifo.sink)
+
         self.submodules.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
-            If(sink.valid,
+            If(fifo.source.valid,
                 NextState("PROBE_RESPONSE")
             )
         )
         fsm.act("PROBE_RESPONSE",
-            sink.connect(source),
+            fifo.source.connect(source),
             source.pf.eq(0),
             source.pr.eq(1),
             If(source.valid & source.ready,


### PR DESCRIPTION
Based on  @david-sawatzke's analysis:
"Otherwise, depending on the caching in the path, a deadlock might occur due to the rx path being
blocked by the tx path, being blocked by the arp request, for which the answers get dropped in the
rx path."