### PR TITLE
phy/xgmii: remove vcd dump in test, fix comment

### DIFF
--- a/liteeth/phy/xgmii.py
+++ b/liteeth/phy/xgmii.py
@@ -248,7 +248,7 @@ class LiteEthPHYXGMIITX(Module):
                # Branch A: we've transmitted at least the full 12 bytes
                # IFG. This means that we can unconditionally start transmission
                # on the first octet. In addition to that, we may have inserted
-               # some extra XGMII, thus we can reduce the deficit.
+               # some extra IFG, thus we can reduce the deficit.
                *unshifted_idle_transmit,
                If(current_dic - last_packet_rem < 0,
                    NextValue(current_dic, 0),

--- a/test/test_xgmii_phy.py
+++ b/test/test_xgmii_phy.py
@@ -546,7 +546,6 @@ class TestXGMIIPHY(unittest.TestCase):
                         and not xgmii_tx_collector.collecting,
                 ),
             ],
-            vcd_name="xgmii_fuuuuuck.vcd",
         )
 
         self.assertTrue(


### PR DESCRIPTION
Removes a slightly inappropriately named VCD dump created by the XGMII tests which may or may not have been a result of some frustration during the test implementation. :)

Also fixes a comment about IFG insertion in the PHY.

@enjoy-digital I swear I've looked over the code multiple times and didn't notice this, it wasn't intentional to be left in there. I did have a good laugh at myself to see this made it into upstream though. :laughing: 