### PR TITLE
core/udp: Add dw>8 support to LiteEthUDPRX

### DIFF
--- a/liteeth/core/udp.py
+++ b/liteeth/core/udp.py
@@ -180,7 +180,7 @@ class LiteEthUDPRX(Module):
         count = Signal(16)
         self.submodules.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
-            NextValue(count, 0),
+            NextValue(count, dw//8),
             If(depacketizer.source.valid,
                 NextState("DROP"),
                 If(sink.protocol == udp_protocol,
@@ -190,7 +190,22 @@ class LiteEthUDPRX(Module):
         )
         fsm.act("RECEIVE",
             depacketizer.source.connect(source, keep={"valid", "ready"}),
-            source.last.eq(depacketizer.source.last | (count == (source.length - dw//8))),
+            source.last.eq(depacketizer.source.last | (count >= source.length)),
+            If(depacketizer.source.last_be,
+               source.last_be.eq(depacketizer.source.last_be),
+            ).Elif(
+              source.last,
+              Case(source.length & (dw//8 - 1), {
+                  1         : source.last_be.eq(0b00000001),
+                  2         : source.last_be.eq(0b00000010),
+                  3         : source.last_be.eq(0b00000100),
+                  4         : source.last_be.eq(0b00001000),
+                  5         : source.last_be.eq(0b00010000),
+                  6         : source.last_be.eq(0b00100000),
+                  7         : source.last_be.eq(0b01000000),
+                  "default" : source.last_be.eq(2**(dw//8 - 1)),
+              })
+            ),
             If(source.valid & source.ready,
                 NextValue(count, count + dw//8),
                 If(depacketizer.source.last,


### PR DESCRIPTION
Pass through last_be or create a new one based on the length if needed

Initialize count at dw//8 and don't subtract source_length since it
could lead to underflow for very short packets. In case source.length is
not dw aligned, count will not be equal, so adjust comparison for that.

Crib last_be Case lookup from mac/sram.py

Only tested with some custom receiver code & dw==32 & in simulation, with correct udp length.