### PR TITLE
icmp: only send a ping reply to type 8 (ping request) packets

### DIFF
--- a/liteeth/common.py
+++ b/liteeth/common.py
@@ -84,6 +84,8 @@ ipv4_header = Header(ipv4_header_fields, ipv4_header_length, swap_field_bytes=Tr
 # ICMP Constants/Header ----------------------------------------------------------------------------
 
 icmp_protocol      = 0x01
+icmp_type_ping_reply = 0
+icmp_type_ping_request = 8
 icmp_header_length = 8
 icmp_header_fields = {
     "msgtype":  HeaderField(0, 0,  8),

--- a/liteeth/core/icmp.py
+++ b/liteeth/core/icmp.py
@@ -86,7 +86,9 @@ class LiteEthICMPRX(Module):
             If(depacketizer.source.valid,
                 NextState("DROP"),
                 If(sink.protocol == icmp_protocol,
-                    NextState("RECEIVE")
+                    If(depacketizer.source.msgtype == icmp_type_ping_request,
+                        NextState("RECEIVE")
+                    )
                 )
             )
         )
@@ -137,7 +139,7 @@ class LiteEthICMPEcho(Module):
         self.comb += [
             sink.connect(self.buffer.sink),
             self.buffer.source.connect(source, omit={"checksum"}),
-            self.source.msgtype.eq(0x0),
+            self.source.msgtype.eq(icmp_type_ping_reply),
             self.source.checksum.eq(self.buffer.source.checksum + 0x800 + (self.buffer.source.checksum >= 0xf800))
         ]
 


### PR DESCRIPTION
  * otherwise liteeth would send a ping reply to `destination unreachable` packets too, which is not wanted.
  * tested in simulation and on hardware (Kintex7)