### PR TITLE
frontend/stream/LiteEthUDPStreamer: make send_level configurable

### DIFF
--- a/examples/udp_s7phyrgmii.yml
+++ b/examples/udp_s7phyrgmii.yml
@@ -23,6 +23,7 @@ udp_ports:   {
     "data_width"    : 32,
     "tx_fifo_depth" : 64,
     "rx_fifo_depth" : 64,
+    "send_level"    : 32,
   },
   "udp1": {
     #"udp_port"      : , # Dynamic Params.

--- a/liteeth/frontend/stream.py
+++ b/liteeth/frontend/stream.py
@@ -28,6 +28,7 @@ class LiteEthStream2UDPTX(Module):
                 source.length.eq(data_width//8)
             ]
         else:
+            assert send_level >= 1 and send_level <= fifo_depth//2
             level   = Signal(max=fifo_depth+1)
             counter = Signal(max=fifo_depth+1)
 
@@ -98,8 +99,8 @@ class LiteEthUDP2StreamRX(Module):
 # UDP Streamer -------------------------------------------------------------------------------------
 
 class LiteEthUDPStreamer(Module):
-    def __init__(self, udp, ip_address, udp_port, data_width=8, rx_fifo_depth=64, tx_fifo_depth=64, with_broadcast=True, cd="sys"):
-        self.submodules.tx = tx = LiteEthStream2UDPTX(ip_address, udp_port, data_width, tx_fifo_depth)
+    def __init__(self, udp, ip_address, udp_port, data_width=8, rx_fifo_depth=64, tx_fifo_depth=64, with_broadcast=True, cd="sys", send_level=1):
+        self.submodules.tx = tx = LiteEthStream2UDPTX(ip_address, udp_port, data_width, tx_fifo_depth, send_level)
         self.submodules.rx = rx = LiteEthUDP2StreamRX(ip_address, udp_port, data_width, rx_fifo_depth, with_broadcast)
         udp_port = udp.crossbar.get_port(udp_port, dw=data_width, cd=cd)
         self.comb += [

--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -293,6 +293,9 @@ class UDPCore(PHYCore):
             tx_fifo_depth = port.get("tx_fifo_depth", 64)
             rx_fifo_depth = port.get("rx_fifo_depth", 64)
 
+            # UDP payloads are data_width * send_level long.
+            send_level = port.get("send_level", 1)
+
             # Create/Add IOs.
             # ---------------
             platform.add_extension(get_udp_port_ios(name,
@@ -314,7 +317,8 @@ class UDPCore(PHYCore):
                 udp_port      = udp_port,
                 data_width    = data_width,
                 tx_fifo_depth = tx_fifo_depth,
-                rx_fifo_depth = rx_fifo_depth
+                rx_fifo_depth = rx_fifo_depth,
+                send_level    = send_level
             )
             self.submodules += udp_streamer
 


### PR DESCRIPTION
When `send_level == 1`, UDP payload size is `data_width` which limits throughput.

Please check carefully because I am new to using litex/liteeth.