### PR TITLE
packet.py: fix typo in Packetizer

### DIFF
--- a/liteeth/packet.py
+++ b/liteeth/packet.py
@@ -97,7 +97,7 @@ class Packetizer(Module):
         )
         if not aligned:
             header_offset_multiplier = 1 if header_words == 1 else 2
-            self.sync += If(source.ready, sink_d.eq(sink))
+            self.sync += If(source.valid & source.ready, sink_d.eq(sink))
             fsm.act("UNALIGNED-DATA-COPY",
                 source.valid.eq(sink.valid | sink_d.last),
                 source_last_a.eq(sink.last | sink_d.last),


### PR DESCRIPTION
  * in some cases, the delayed sink data was updated even though sink was not valid, leading to corrupted source data
  * this together with #97 and [a change to StrideConverter](https://github.com/yetifrisstlama/litex/commit/74cb80be640a506eb13e4e10527a43c8d21b7e37) fixed etherbone with DW=64
  * updated testbench [test_etherbone.py](https://github.com/yetifrisstlama/liteeth/blob/yfl/test/test_etherbone.py)
  * also tested with [modified litex_sim](https://github.com/yetifrisstlama/litex/commit/f965cee2f12d95bd8bbb8e4890d40f99733633f4) and on [hardware](https://github.com/yetifrisstlama/litex_test_project/blob/master/hello_10g/udp_sender.py)