### PR TITLE
gen: fix for RMII PHY

### DIFF
--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -185,6 +185,7 @@ class PHYCore(SoCMini):
                 pads       = platform.request("mii_eth"))
         elif phy in [liteeth_phys.LiteEthPHYRMII]:
             ethphy = phy(
+                refclk_cd  = None,
                 clock_pads = platform.request("rmii_eth_clocks"),
                 pads       = platform.request("rmii_eth"))
         elif phy in [liteeth_phys.LiteEthPHYGMII]:


### PR DESCRIPTION
Without setting the ref clock domain to None, generation failed:

```
Traceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/litex/gen/fhdl/verilog.py", line 535, in convert
    f.clock_domains[cd_name]
  File "/usr/lib/python3.10/site-packages/migen/fhdl/structure.py", line 741, in __getitem__
    raise KeyError(key)
KeyError: 'eth'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/bin/liteeth_gen", line 33, in <module>
    sys.exit(load_entry_point('liteeth==0.0.0', 'console_scripts', 'liteeth_gen')())
  File "/usr/lib/python3.10/site-packages/liteeth/gen.py", line 389, in main
    builder.build(build_name="liteeth_core")
  File "/usr/lib/python3.10/site-packages/litex/soc/integration/builder.py", line 350, in build
    vns = self.soc.build(build_dir=self.gateware_dir, **kwargs)
  File "/usr/lib/python3.10/site-packages/litex/soc/integration/soc.py", line 1208, in build
    return self.platform.build(self, *args, **kwargs)
  File "/usr/lib/python3.10/site-packages/litex/build/xilinx/platform.py", line 73, in build
    return self.toolchain.build(self, *args, **kwargs)
  File "/usr/lib/python3.10/site-packages/litex/build/xilinx/vivado.py", line 349, in build
    v_output = platform.get_verilog(fragment, name=build_name, **kwargs)
  File "/usr/lib/python3.10/site-packages/litex/build/xilinx/platform.py", line 64, in get_verilog
    return GenericPlatform.get_verilog(self, *args,
  File "/usr/lib/python3.10/site-packages/litex/build/generic_platform.py", line 423, in get_verilog
    return verilog.convert(fragment, platform=self, **kwargs)
  File "/usr/lib/python3.10/site-packages/litex/gen/fhdl/verilog.py", line 541, in convert
    raise Exception(msg)
Exception: Unresolved clock domain eth, availables:
- sys
- por
- eth_rx
- eth_tx
```