### PR TITLE
Adding 10BASE-T with direct IO connection

### DIFF
--- a/bench/arty_multi.py
+++ b/bench/arty_multi.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2020 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2022 Charles-Henri Mousset <ch.mousset@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+
+from migen import *
+
+from litex_boards.platforms import digilent_arty
+from litex.build.xilinx.vivado import vivado_build_args, vivado_build_argdict
+from litex_boards.targets.digilent_arty import _CRG, BaseSoC
+from litex.build.generic_platform import *
+
+from litex.soc.cores.clock import *
+from litex.soc.interconnect.csr import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+
+from liteeth.phy.mii import LiteEthPHYMII
+from liteeth.phy.ethernet import LiteEthPHYETHERNET
+
+from litescope import LiteScopeAnalyzer
+
+
+# PMOD Raw 10BASET Ethernet ------------------------------------------------------------------------
+#
+# This testbench uses 2 differential pairs of the Arty-A7, and 4 outputs to bias the termination
+# resistors.
+# Two(2) 100 Ohms resistor (termination), four(4) 1kOhms (bias) resistors and four(4) capacitors are
+# required to connect to the Ethernet port.
+# Both the TX and RX pairs are wired identically.
+# Using the 4 IOs as pullup/down are not strictly required (you can bias to GND/3V3 instead), but it
+# makes wiring very convenient using only a piece of proto-PCB and SMD components.
+#
+# Ideally the capacitors should be replaced with suitable transformers, but for short
+# wiring the capacitors usually work well.
+#
+# +───────PMOD Pinout───────+
+# | 7  td_p_pd | td_p     1 |
+# | 8  td_n_pu | td_n     2 |
+# | 9  rd_p_pd | rd_p     3 |
+# | 10 rd_n_pu | rd_n     4 |
+# | 11     GND | GND      5 |
+# | 12     3V3 | 3V3      6 |
+# +────────────+────────────+
+# 
+#           ___
+# td_p_pd──|___|───td_p────||────ORANGE/WHITE (RJ45 3)
+#           1k0     |      1u
+#                   ─
+#                  | | 100
+#                   ─
+#           ___     |
+# td_n_pu──|___|───td_n────||────ORANGE (RJ45 6)
+#           1k0            1u
+#
+#
+#           ___
+# rd_p_pd──|___|───rd_p────||────GREEN/WHITE (RJ45 1)
+#           1k0     |      1u
+#                   ─
+#                  | | 100
+#                   ─
+#           ___     |
+# rd_n_pu──|___|───rd_n────||────GREEN (RJ45 2)
+#           1k0            1u
+#
+#
+# Alternate wiring using a transformer (both channels are identical):
+#           ___
+# rd_p_pd──|___|───rd_p─────,      ,────GREEN/WHITE (RJ45 1)
+#           1k0     |      *_) || (_*
+#                   ─       _) || (_
+#                  | | 100  _) || (_
+#                   ─       _) || (_
+#           ___     |       _) || (_
+# rd_n_pu──|___|───rd_n─────'      '────GREEN (RJ45 2)
+#           1k0 
+#
+
+raw_eth = [
+    ("raw_eth", 0,
+        Subsignal("td_p", Pins("pmodb:0"), IOStandard("LVCMOS33")),
+        Subsignal("td_n", Pins("pmodb:1"), IOStandard("LVCMOS33")),
+        Subsignal("rd_p", Pins("pmodb:2"), IOStandard("LVDS_25"), Misc("PULLDOWN")),
+        Subsignal("rd_n", Pins("pmodb:3"), IOStandard("LVDS_25"), Misc("PULLUP")),
+        Subsignal("td_p_pd", Pins("pmodb:4"), IOStandard("LVCMOS33")),
+        Subsignal("td_n_pu", Pins("pmodb:5"), IOStandard("LVCMOS33")),
+        Subsignal("rd_p_pd", Pins("pmodb:6"), IOStandard("LVCMOS33")),
+        Subsignal("rd_n_pu", Pins("pmodb:7"), IOStandard("LVCMOS33")),
+    ),
+]
+
+
+# Bench SoC ----------------------------------------------------------------------------------------
+class BenchSoC(BaseSoC):
+    def __init__(self, sys_clk_freq=int(50e6), with_raw_ethernet=True, **kwarg):
+        analyzer_signals = []
+
+        # BaseSoC ----------------------------------------------------------------------------------
+        super().__init__(**kwarg
+        )
+        self.platform.add_extension(raw_eth)
+
+        # Etherbone on 'raw' ethernet --------------------------------------------------------------
+        if with_raw_ethernet:
+            eth_raw_pads = self.platform.request("raw_eth")
+            self.crg.clock_domains.cd_eth_raw = ClockDomain()
+            self.crg.clock_domains.cd_eth_raw_tx = ClockDomain()
+            self.crg.clock_domains.cd_eth_raw_rx = ClockDomain()
+            self.comb += [
+                self.crg.cd_eth_raw_rx.clk.eq(self.crg.cd_eth_raw.clk),
+                self.crg.cd_eth_raw_tx.clk.eq(self.crg.cd_eth_raw.clk),
+            ]
+            self.crg.pll.create_clkout(self.crg.cd_eth_raw, 40e6)
+            self.submodules.ethphy = ethphy = LiteEthPHYETHERNET(
+                pads = eth_raw_pads, refclk_cd="eth_raw",
+                with_hw_init_reset = False)
+            self.add_etherbone(name="etherbone", phy=self.ethphy, buffer_depth=255,
+                ip_address="192.168.2.51", phy_cd="eth_raw")
+            analyzer_signals += [
+                ethphy.rx.fsm,
+                ethphy.tx.fsm,
+                ethphy.rx.rx_i,
+                ethphy.tx.tx,
+            ]
+            self.comb += [
+                eth_raw_pads.td_p_pd.eq(0),
+                eth_raw_pads.td_n_pu.eq(1),
+                eth_raw_pads.rd_p_pd.eq(0),
+                eth_raw_pads.rd_n_pu.eq(1),
+            ]
+
+        # Analyzer ---------------------------------------------------------------------------------
+        ethcore   = self.ethcore_etherbone
+        etherbone = self.etherbone
+        self.submodules.analyzer = LiteScopeAnalyzer(analyzer_signals + [
+            self.ethphy.sink,
+            self.ethphy.source,
+            # MAC.
+            ethcore.mac.core.sink.valid,
+            ethcore.mac.core.sink.ready,
+            ethcore.mac.core.source.valid,
+            ethcore.mac.core.source.payload,
+            ethcore.mac.core.source.ready,
+
+            # ARP.
+            ethcore.arp.rx.sink.valid,
+            ethcore.arp.rx.sink.ready,
+            ethcore.arp.tx.source.valid,
+            ethcore.arp.tx.source.ready,
+
+            # IP.
+            ethcore.ip.rx.sink.valid,
+            ethcore.ip.rx.sink.ready,
+            ethcore.ip.tx.source.valid,
+            ethcore.ip.tx.source.ready,
+
+            # UDP.
+            ethcore.udp.rx.sink.valid,
+            ethcore.udp.rx.sink.ready,
+            ethcore.udp.tx.source.valid,
+            ethcore.udp.tx.source.ready,
+
+            # Etherbone.
+            etherbone.packet.rx.sink.valid,
+            etherbone.packet.rx.sink.ready,
+            etherbone.packet.rx.fsm,
+            etherbone.packet.tx.source.valid,
+            etherbone.packet.tx.source.ready,
+            etherbone.packet.tx.fsm,
+            etherbone.record.receiver.fsm,
+            etherbone.record.sender.fsm
+        ],
+        depth=1024 * 8, trigger_depth=256)
+
+
+# Main ---------------------------------------------------------------------------------------------
+
+def main():
+    from litex.soc.integration.soc import LiteXSoCArgumentParser
+    parser = LiteXSoCArgumentParser(description="LiteX SoC on Arty A7")
+    target_group = parser.add_argument_group(title="Target options")
+    target_group.add_argument("--toolchain",           default="vivado",                 help="FPGA toolchain (vivado, symbiflow or yosys+nextpnr).")
+    target_group.add_argument("--build",               action="store_true",              help="Build design.")
+    target_group.add_argument("--load",                action="store_true",              help="Load bitstream.")
+    target_group.add_argument("--flash",               action="store_true",              help="Flash bitstream.")
+    target_group.add_argument("--variant",             default="a7-35",                  help="Board variant (a7-35 or a7-100).")
+    target_group.add_argument("--sys-clk-freq",        default=100e6,                    help="System clock frequency.")
+    ethopts = target_group.add_mutually_exclusive_group()
+    ethopts.add_argument("--with-ethernet",      action="store_true",              help="Enable Ethernet support.")
+    ethopts.add_argument("--with-etherbone",     action="store_true",              help="Enable Etherbone support.")
+    ethopts.add_argument("--raw-eth",            action="store_true", help="use raw 10BASET ethernet on PMODA")
+    target_group.add_argument("--eth-ip",              default="192.168.1.50", type=str, help="Ethernet/Etherbone IP address.")
+    target_group.add_argument("--eth-dynamic-ip",      action="store_true",              help="Enable dynamic Ethernet IP addresses setting.")
+    sdopts = target_group.add_mutually_exclusive_group()
+    sdopts.add_argument("--with-spi-sdcard",     action="store_true",              help="Enable SPI-mode SDCard support.")
+    sdopts.add_argument("--with-sdcard",         action="store_true",              help="Enable SDCard support.")
+    target_group.add_argument("--sdcard-adapter",      type=str,                         help="SDCard PMOD adapter (digilent or numato).")
+    target_group.add_argument("--with-jtagbone",       action="store_true",              help="Enable JTAGbone support.")
+    target_group.add_argument("--with-spi-flash",      action="store_true",              help="Enable SPI Flash (MMAPed).")
+    target_group.add_argument("--with-pmod-gpio",      action="store_true",              help="Enable GPIOs through PMOD.") # FIXME: Temporary test.
+    builder_args(parser)
+    soc_core_args(parser)
+    vivado_build_args(parser)
+    args = parser.parse_args()
+
+    assert not (args.with_etherbone and args.eth_dynamic_ip)
+
+    soc = BenchSoC(
+        variant           = args.variant,
+        toolchain         = args.toolchain,
+        sys_clk_freq      = int(float(args.sys_clk_freq)),
+        with_ethernet     = args.with_ethernet,
+        with_etherbone    = args.with_etherbone,
+        eth_ip            = args.eth_ip,
+        eth_dynamic_ip    = args.eth_dynamic_ip,
+        with_jtagbone     = args.with_jtagbone,
+        with_spi_flash    = args.with_spi_flash,
+        with_pmod_gpio    = args.with_pmod_gpio,
+        with_raw_ethernet = args.raw_eth,
+        **soc_core_argdict(args)
+    )
+    if args.sdcard_adapter == "numato":
+        soc.platform.add_extension(digilent_arty._numato_sdcard_pmod_io)
+    else:
+        soc.platform.add_extension(digilent_arty._sdcard_pmod_io)
+    if args.with_spi_sdcard:
+        soc.add_spi_sdcard()
+    if args.with_sdcard:
+        soc.add_sdcard()
+
+    builder = Builder(soc, **builder_argdict(args))
+    builder_kwargs = vivado_build_argdict(args) if args.toolchain == "vivado" else {}
+    if args.build:
+        builder.build(**builder_kwargs)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(builder.get_bitstream_filename(mode="sram"))
+
+    if args.flash:
+        prog = soc.platform.create_programmer()
+        prog.flash(0, builder.get_bitstream_filename(mode="flash"))
+
+if __name__ == "__main__":
+    main()

--- a/bench/ulx3s.py
+++ b/bench/ulx3s.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+
+#
+# This file is part of LiteX-Boards.
+#
+# Copyright (c) 2018-2019 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2018 David Shah <dave@ds0.me>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import argparse
+import sys
+
+from migen import *
+
+from litex_boards.platforms import ulx3s
+from litex_boards.targets.ulx3s import _CRG
+
+from litex.build.lattice.trellis import trellis_args, trellis_argdict
+
+from litex.soc.cores.clock import *
+from litex.soc.integration.soc_core import *
+from litex.soc.integration.builder import *
+from litex.soc.cores.gpio import GPIOOut
+
+from litedram import modules as litedram_modules
+from litedram.phy import GENSDRPHY, HalfRateGENSDRPHY
+
+from litex.build.generic_platform import *
+from liteeth.phy import LiteEthPHYETHERNET
+
+
+# IOs ----------------------------------------------------------------------------------------------
+
+_eth_io = [
+    # Direct connect 10BASE-T, full-duplex Ethernet
+    ("eth", 0,
+        Subsignal("td_p", Pins("A2")), # J1 GP9  - Green/White
+        Subsignal("td_n", Pins("B1")), # J1 GN9  - Green
+        Subsignal("rd_p", Pins("C4"), IOStandard("LVDS"), Misc("DIFFRESISTOR=100")), # J1 GP10 - Orange/White
+        Subsignal("rd_n", Pins("B4")), # J1 GN10 - Orange
+        IOStandard("LVCMOS33"),
+    ),
+]
+
+
+# Bench SoC ----------------------------------------------------------------------------------------
+
+class BenchSoC(SoCCore):
+    def __init__(self, device="LFE5U-45F", revision="2.0", toolchain="trellis",
+        sys_clk_freq=int(40e6), **kwargs):
+        platform = ulx3s.Platform(device=device, revision=revision, toolchain=toolchain)
+        platform.add_extension(_eth_io)
+
+        # SoCCore ----------------------------------------------------------------------------------
+        SoCMini.__init__(self, platform, sys_clk_freq,
+            ident          = "LiteEth bench on ULX3S",
+            ident_version  = True,
+            **kwargs)
+
+        # CRG --------------------------------------------------------------------------------------
+        self.submodules.crg = _CRG(platform, sys_clk_freq)
+
+        # Etherbone --------------------------------------------------------------------------------
+        self.submodules.ethphy = LiteEthPHYETHERNET(
+            pads       = self.platform.request("eth"),
+            refclk_cd = "sys",
+            with_hw_init_reset = False)
+        self.add_csr("ethphy")
+        self.add_etherbone(phy=self.ethphy, buffer_depth=255)
+
+
+# Build --------------------------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="LiteX SoC on ULX3S")
+    parser.add_argument("--build",           action="store_true",   help="Build bitstream")
+    parser.add_argument("--load",            action="store_true",   help="Load bitstream")
+    parser.add_argument("--toolchain",       default="trellis",     help="FPGA toolchain: trellis (default) or diamond")
+    parser.add_argument("--device",          default="LFE5U-45F",   help="FPGA device: LFE5U-12F, LFE5U-25F, LFE5U-45F (default)  or LFE5U-85F")
+    parser.add_argument("--revision",        default="2.0",         help="Board revision: 2.0 (default) or 1.7")
+    parser.add_argument("--sys-clk-freq",    default=40e6,          help="System clock frequency  (default: 50MHz)")
+    builder_args(parser)
+    trellis_args(parser)
+    args = parser.parse_args()
+
+    soc = BenchSoC(
+        device           = args.device,
+        revision         = args.revision,
+        toolchain        = args.toolchain,
+        sys_clk_freq     = int(float(args.sys_clk_freq)))
+
+    builder = Builder(soc, **builder_argdict(args))
+    builder_kargs = trellis_argdict(args) if args.toolchain == "trellis" else {}
+    builder.build(**builder_kargs, run=args.build)
+
+    if args.load:
+        prog = soc.platform.create_programmer()
+        prog.load_bitstream(os.path.join(builder.gateware_dir, soc.build_name + (".svf" if args.toolchain == "trellis" else ".bit")))
+
+if __name__ == "__main__":
+    main()

--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -379,6 +379,10 @@ class PHYCore(SoCMini):
                 pads       = ethphy_pads,
                 dw         = 64,
             )
+        elif phy in [liteeth_phys.LiteEthPHYETHERNET]:
+            assert self.clk_freq >= 40e6
+            ethphy = phy(
+                pads               = platform.request("raw_eth"))
         else:
             raise ValueError("Unsupported PHY")
         self.ethphy = ethphy

--- a/liteeth/phy/__init__.py
+++ b/liteeth/phy/__init__.py
@@ -27,6 +27,7 @@ from liteeth.phy.rmii     import LiteEthPHYRMII
 from liteeth.phy.gmii     import LiteEthPHYGMII
 from liteeth.phy.gmii_mii import LiteEthPHYGMIIMII
 from liteeth.phy.xgmii    import LiteEthPHYXGMII
+from liteeth.phy.ethernet import LiteEthPHYETHERNET
 
 from liteeth.phy.s6rgmii   import LiteEthPHYRGMII as LiteEthS6PHYRGMII
 from liteeth.phy.s7rgmii   import LiteEthPHYRGMII as LiteEthS7PHYRGMII

--- a/liteeth/phy/ethernet.py
+++ b/liteeth/phy/ethernet.py
@@ -1,0 +1,220 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2015-2018 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2021 Charles-Henri Mousset <ch.mousset@gmail.com>
+# SPDX-License-Identifier: BSD-2-Clause
+
+from migen import *
+from migen.genlib.cdc import MultiReg
+from migen.genlib.resetsync import AsyncResetSynchronizer
+
+from litex.build.io import DDROutput
+
+from liteeth.common import *
+from liteeth.phy.common import *
+
+from litex.build.io import DifferentialInput
+from litex.soc.integration.doc import AutoDoc, ModuleDoc
+
+
+def converter_description(dw):
+    payload_layout = [("data", dw)]
+    return EndpointDescription(payload_layout)
+
+
+class LiteEthPHYETHERNETTX(Module):
+    def __init__(self, pads):
+        self.sink = sink = stream.Endpoint(eth_phy_description(8))
+        self.submodules.fsm = fsm = FSM("IDLE")
+
+        # # #
+        # deserializing
+        converter = stream.StrideConverter(converter_description(8),
+                                           converter_description(1))
+        self.submodules += converter
+        self.comb += [
+            converter.sink.valid.eq(sink.valid),
+            converter.sink.data.eq(sink.data),
+            sink.ready.eq(converter.sink.ready),
+            converter.source.ready.eq(fsm.ongoing("TX"))
+        ]
+
+        # Manchester encoding
+        tx_bit = Signal()
+        tx_cnt = Signal(2)
+        tx_bit_strb = Signal()
+        tx = Signal(reset_less=True)
+        txe = Signal(reset_less=True)
+        self.comb += tx_bit_strb.eq(tx_cnt == 0b11)
+        self.sync += [tx_cnt.eq(tx_cnt+1)]
+
+        # Output logic
+        if hasattr(pads, "tx") and hasattr(pads, "tx_en"): # RS485 half duplex mode
+            self.comb += [pads.tx.eq(tx), pads.txe.eq(txe)]
+        else: # A true differential output buffer is not necessary at 20Mbps(manchester)
+            self.comb += [pads.td_p.eq(tx & txe), pads.td_n.eq(~tx & txe)]
+
+
+        # Normal Link Pulse generation timer
+        NLP_PERIOD = int(40e6/1000*16)
+        nlp_timeout = Signal()
+        nlp_counter = Signal(max=NLP_PERIOD+1)
+        self.comb += [
+            nlp_timeout.eq(nlp_counter == NLP_PERIOD-1),
+        ]
+        self.sync += [
+            If(nlp_timeout,
+                nlp_counter.eq(0),
+            ).Else(
+                nlp_counter.eq(nlp_counter+1),
+            ),
+        ]
+
+        # Main FSM
+        fsm.act("IDLE",
+            # send the Normal Link Pulses
+            If(nlp_timeout & (tx_bit_strb),
+                NextState("NLP1"),
+            ),
+            converter.sink.ready.eq(tx_bit_strb),
+            If(converter.sink.valid & converter.sink.ready,
+                NextState("TX"),
+                NextValue(tx_bit, converter.sink.data),
+            ),
+        )
+        fsm.act("NLP1",
+            # we emit a '1' for 1 bit time
+            tx.eq(1),
+            txe.eq(1),
+            If(tx_bit_strb,
+                NextState("NLP2"),
+            )
+        )
+        fsm.act("NLP2",
+            # we emit a '0' for 1 bit time
+            tx.eq(0),
+            txe.eq(1),
+            If(tx_bit_strb,
+                NextState("IDLE"),
+            )
+        )
+        fsm.act("TX",
+            tx.eq(tx_bit ^ tx_cnt[1]),
+            txe.eq(converter.sink.valid), # should stay at 1
+            If(tx_bit_strb,
+                converter.sink.ready.eq(1),
+                NextValue(tx_bit, converter.sink.data),
+            ),
+            If(sink.last_be,
+                NextState("IDLE"),
+            )
+        )
+
+
+class LiteEthPHYETHERNETRX(Module):
+    def __init__(self, pads):
+        self.source = source = stream.Endpoint(eth_phy_description(8))
+
+        # # #
+
+        # Single Ended / Differential input
+        rx = Signal()
+        if not hasattr(pads, "rx"):
+            self.specials += DifferentialInput(pads.rd_p, pads.rd_n, rx)
+        else:
+            self.comb += rx.eq(pads.rx)
+
+        # Manchester input
+        mc_in_data = Signal(3)
+        mc_cnt = Signal(2)
+        bit_valid = Signal()
+        bit_value = Signal()
+        self.comb += [
+            bit_valid.eq((mc_in_data[2] ^ mc_in_data[1]) & (mc_cnt == 0b00)),
+            bit_value.eq(mc_in_data[2]),
+        ]
+        self.sync += [
+            mc_in_data.eq(Cat(rx, mc_in_data[0:1])),
+            If(bit_valid,
+                mc_cnt.eq(3),
+            ).Elif(mc_cnt,
+                mc_cnt.eq(mc_cnt-1),
+            ),
+        ]
+
+        # Receive timeout / NLP and noise filter
+        timeout_cnt = Signal(3)
+        timeout = Signal()
+        self.comb += [
+            timeout.eq(timeout_cnt == 0),
+        ]
+        self.sync += [
+            If(bit_valid,
+                timeout_cnt.eq(0b111),
+            ).Elif(timeout_cnt,
+                timeout_cnt.eq(timeout_cnt - 1),
+            )
+        ]
+
+        # bit to byte logic
+        bit_cnt = Signal(3)
+        byte = Signal(8)
+
+        self.sync += [
+            If(timeout,
+                bit_cnt.eq(0),
+            ).Elif(bit_valid,
+                bit_cnt.eq(bit_cnt+1),
+                byte.eq(Cat(byte[1:], bit_value)),
+            ),
+        ]
+        self.comb += [
+            self.source.valid.eq((bit_cnt == 7) & bit_valid),
+            self.source.data.eq(byte),
+        ]
+
+
+class LiteEthPHYETHERNETCRG(Module, AutoCSR):
+    def __init__(self, refclk_cd, with_hw_init_reset):
+        self._reset = CSRStorage()
+
+        # # #
+
+        # RX/TX clocks
+
+        self.clock_domains.cd_eth_rx = ClockDomain()
+        self.clock_domains.cd_eth_tx = ClockDomain()
+
+        # This is entirely clocked internally
+        assert refclk_cd
+
+        self.comb += self.cd_eth_rx.clk.eq(ClockSignal(refclk_cd))
+        self.comb += self.cd_eth_tx.clk.eq(ClockSignal(refclk_cd))
+
+        # Reset
+        self.reset = reset = Signal()
+        if with_hw_init_reset:
+            self.submodules.hw_reset = LiteEthPHYHWReset()
+            self.comb += reset.eq(self._reset.storage | self.hw_reset.reset)
+        else:
+            self.comb += reset.eq(self._reset.storage)
+        self.specials += [
+            AsyncResetSynchronizer(self.cd_eth_tx, reset),
+            AsyncResetSynchronizer(self.cd_eth_rx, reset),
+        ]
+
+
+class LiteEthPHYETHERNET(Module, AutoCSR, ModuleDoc):
+    """
+    Direct connection to a 10Base-T network, using only series capacitors with FPGIO IOs.
+    This probably violates some parts of the IEEE802.3 standard. Use at your own risk!
+    """
+    dw          = 8
+    tx_clk_freq = 40e6
+    rx_clk_freq = 40e6
+    def __init__(self, pads, refclk_cd="eth", with_hw_init_reset=True):
+        self.submodules.crg = LiteEthPHYETHERNETCRG(refclk_cd, with_hw_init_reset)
+        self.submodules.tx = ClockDomainsRenamer("eth_tx")(LiteEthPHYETHERNETTX(pads))
+        self.submodules.rx = ClockDomainsRenamer("eth_rx")(LiteEthPHYETHERNETRX(pads))
+        self.sink, self.source = self.tx.sink, self.rx.source

--- a/liteeth/phy/ethernet.py
+++ b/liteeth/phy/ethernet.py
@@ -162,7 +162,7 @@ class LiteEthPHYETHERNETRX(Module):
         self.comb += noise.eq(edge & (bit_period_cnt == 0))
 
         # Byte logic
-        bitcnt = Signal(max=8)
+        bitcnt = Signal(max=8 + 1)
         rx_inverted = Signal()
         half_bit = Signal()
         data_r = Signal(8)
@@ -172,7 +172,7 @@ class LiteEthPHYETHERNETRX(Module):
             ).Else(
                 source.data.eq(data_r),
             ),
-            source.last_be.eq(1),
+            source.last_be.eq(source.last),
         ]
 
         self.submodules.fsm = fsm = FSM("SYNC")
@@ -184,7 +184,7 @@ class LiteEthPHYETHERNETRX(Module):
         )
 
         fsm.act("SYNC",
-            NextValue(bitcnt, 0),
+            NextValue(bitcnt, 1),
             # Wait for the preamble to sync on byte-boundaries
             If(edge,
                 NextValue(half_bit, ~half_bit),
@@ -218,9 +218,9 @@ class LiteEthPHYETHERNETRX(Module):
                     NextValue(data_r, Cat(data_r[1:], rx_i)),
                     NextValue(bitcnt, bitcnt + 1),
                     NextValue(half_bit, 1),
-                    If(bitcnt == 7,
+                    If(bitcnt == 8,
                         source.valid.eq(1),
-                        NextValue(bitcnt, 0),
+                        NextValue(bitcnt, 1),
                     ),
                 ),
             ),

--- a/liteeth/phy/ethernet.py
+++ b/liteeth/phy/ethernet.py
@@ -8,14 +8,13 @@
 from migen import *
 from migen.genlib.cdc import MultiReg
 from migen.genlib.resetsync import AsyncResetSynchronizer
+from migen.genlib.misc import WaitTimer
 
-from litex.build.io import DDROutput
+from litex.soc.integration.doc import ModuleDoc
+from litex.build.io import DifferentialInput
 
 from liteeth.common import *
 from liteeth.phy.common import *
-
-from litex.build.io import DifferentialInput
-from litex.soc.integration.doc import AutoDoc, ModuleDoc
 
 
 def converter_description(dw):
@@ -23,148 +22,265 @@ def converter_description(dw):
     return EndpointDescription(payload_layout)
 
 
-class LiteEthPHYETHERNETTX(Module):
-    def __init__(self, pads):
-        self.sink = sink = stream.Endpoint(eth_phy_description(8))
-        self.submodules.fsm = fsm = FSM("IDLE")
+symbol_description = [("data", 2)]
+SYMBOL_FALLING     = 0b01
+SYMBOL_RISING      = 0b10
+SYMBOL_NL          = 0b00
+SYMBOL_NH          = 0b11
+
+
+class LiteEthPHYETHERNETTXBit(Module):
+    def __init__(self, tx_o, tx_oe, period_2):
+        # inputs
+        self.sink = stream.Endpoint(symbol_description)
 
         # # #
-        # deserializing
+
+        # buffer input (improves timing)
+        sink = stream.Endpoint(symbol_description)
+        self.sync += [
+            If(sink.valid,
+                If(sink.ready,
+                    sink.valid.eq(0),
+                    self.sink.ready.eq(1),
+                ),
+            ).Else(
+                If(self.sink.ready,
+                    If(self.sink.valid,
+                        sink.valid.eq(1),
+                        sink.data.eq(self.sink.data),
+                        self.sink.ready.eq(0),
+                    )
+                ).Else(
+                    self.sink.ready.eq(1),
+                ),
+            )
+        ]
+
+        # output signal
+        tx = Signal()
+        txe = Signal()
+        self.sync += [
+            tx_o.eq(tx),
+            tx_oe.eq(txe),
+        ]
+        nibble_1 = Signal()
+        nibble_2 = Signal()
+        self.submodules.wt = wt = WaitTimer(period_2 - 1)
+        self.submodules.fsm = fsm = FSM("IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(nibble_1, sink.data[0]),
+                NextValue(nibble_2, sink.data[1]),
+                NextState("NIBBLE_1"),
+            ),
+        )
+        fsm.act("NIBBLE_1",
+            wt.wait.eq(~wt.done),
+            txe.eq(1),
+            tx.eq(nibble_1),
+            If(wt.done,
+                NextState("NIBBLE_2"),
+            ),
+        )
+        fsm.act("NIBBLE_2",
+            wt.wait.eq(~wt.done),
+            txe.eq(1),
+            tx.eq(nibble_2),
+            If(wt.done,
+                sink.ready.eq(1),
+                If(sink.valid,
+                    NextValue(nibble_1, sink.data[0]),
+                    NextValue(nibble_2, sink.data[1]),
+                    NextState("NIBBLE_1"),
+                ).Else(
+                    NextState("IDLE"),
+                ),
+            ),
+        )
+
+
+class LiteEthPHYETHERNETTX(Module):
+    def __init__(self, pads, sys_clk_freq, period_2):
+        # Inputs
+        self.sink = sink = stream.Endpoint(eth_phy_description(8))
+
+        # # #
+
+        # Deserializing
         converter = stream.StrideConverter(converter_description(8),
                                            converter_description(1))
         self.submodules += converter
-        self.comb += [
-            converter.sink.valid.eq(sink.valid),
-            converter.sink.data.eq(sink.data),
-            sink.ready.eq(converter.sink.ready),
-            converter.source.ready.eq(fsm.ongoing("TX"))
-        ]
-
-        # Manchester encoding
-        tx_bit = Signal()
-        tx_cnt = Signal(2)
-        tx_bit_strb = Signal()
-        self.tx = tx = Signal(reset_less=True)
-        txe = Signal(reset_less=True)
-        self.comb += tx_bit_strb.eq(tx_cnt == 0b11)
-        self.sync += [tx_cnt.eq(tx_cnt+1)]
+        self.comb += sink.connect(converter.sink, omit=["last_be", "error"])
 
         # Output logic
-        if hasattr(pads, "tx") and hasattr(pads, "tx_en"): # RS485 half duplex mode
+        tx = Signal()
+        txe = Signal()
+        if hasattr(pads, "tx") and hasattr(pads, "txe"):
+            # Differential transmission handled externally
             self.comb += [pads.tx.eq(tx), pads.txe.eq(txe)]
-        else: # A true differential output buffer is not necessary at 20Mbps(manchester)
+        else:
             self.specials += Tristate(pads.td_p, tx, txe)
             self.specials += Tristate(pads.td_n, ~tx, txe)
 
+        # Manchester encoding
+        self.submodules.tx_bit = bit_tx = ClockDomainsRenamer("eth_tx")(
+            LiteEthPHYETHERNETTXBit(tx, txe, period_2))
+        self.submodules.fifo = fifo = ClockDomainsRenamer({"write": "sys", "read": "eth_tx"})(
+            stream.AsyncFIFO(symbol_description, 4))
+        self.comb += fifo.source.connect(bit_tx.sink)
+
         # Normal Link Pulse generation timer
-        NLP_PERIOD = int(40e6/1000*16)
-        nlp_timeout = Signal()
-        nlp_counter = Signal(max=NLP_PERIOD+1)
-        self.comb += [
-            nlp_timeout.eq(nlp_counter == NLP_PERIOD-1),
-        ]
-        self.sync += [
-            If(nlp_timeout,
-                nlp_counter.eq(0),
-            ).Else(
-                nlp_counter.eq(nlp_counter+1),
-            ),
-        ]
+        NLP_PERIOD = int(sys_clk_freq / 1000 * 16)  # 16ms
+        self.submodules.nlp_wt = nlp_wt = WaitTimer(NLP_PERIOD)
 
         # Main FSM
+        self.submodules.fsm = fsm = FSM("IDLE")
         fsm.act("IDLE",
             # send the Normal Link Pulses
-            If(nlp_timeout & (tx_bit_strb),
+            nlp_wt.wait.eq(1),
+            If(nlp_wt.done,
                 NextState("NLP1"),
             ),
-            converter.sink.ready.eq(tx_bit_strb),
-            If(converter.sink.valid & converter.sink.ready,
+            If(converter.source.valid,
                 NextState("TX"),
-                NextValue(tx_bit, converter.sink.data),
             ),
         )
         fsm.act("NLP1",
-            # we emit a '1' for 1 bit time
-            tx.eq(1),
-            txe.eq(1),
-            If(tx_bit_strb,
+            fifo.sink.data.eq(SYMBOL_NH),
+            fifo.sink.valid.eq(1),
+            If(fifo.sink.ready,
                 NextState("NLP2"),
-            )
+            ),
         )
         fsm.act("NLP2",
-            # we emit a '0' for 1 bit time
-            tx.eq(0),
-            txe.eq(1),
-            If(tx_bit_strb,
+            fifo.sink.data.eq(SYMBOL_NL),
+            fifo.sink.valid.eq(1),
+            If(fifo.sink.ready,
                 NextState("IDLE"),
-            )
+            ),
         )
         fsm.act("TX",
-            tx.eq((~tx_bit) ^ tx_cnt[1]),
-            txe.eq(converter.sink.valid), # should stay at 1
-            If(tx_bit_strb,
-                converter.sink.ready.eq(1),
-                NextValue(tx_bit, converter.sink.data),
+            converter.source.connect(fifo.sink, omit=["data"]),
+            If(converter.source.data,
+                fifo.sink.data.eq(SYMBOL_RISING),
+            ).Else(
+                fifo.sink.data.eq(SYMBOL_FALLING),
             ),
-            If(sink.last_be,
+            If(~converter.source.valid,
                 NextState("IDLE"),
-            )
+            ),
         )
+
+
+class ManchesterReceiver(Module):
+    def __init__(self, period_2):
+        # Parameters
+        self.period_2 = period_2
+        self.period = period_2 * 2
+
+        # Inputs
+        self.rx = rx = Signal()
+
+        # Outputs
+        self.source = stream.Endpoint([("data", 1)])
+        self.in_sync = Signal()
+
+        # # #
+
+        # receive shift register and edge detection
+        source = stream.Endpoint([("data", 1)])
+        sr = Signal(4)
+        rx_dff = Signal(3)
+        match_rising = Signal()
+        match_falling = Signal()
+        self.comb += [
+            sr.eq(Cat(rx, rx_dff)),
+        ]
+        self.comb += [
+            Case(sr, {
+                0b0011: [
+                    match_rising.eq(1),
+                    source.data.eq(1),
+                ],
+                0b1100: [
+                    match_falling.eq(1),
+                ],
+            }),
+        ]
+        self.sync += rx_dff.eq(sr)
+
+        # edge synchronization
+        self.submodules.wt_bit = wt_bit = WaitTimer(self.period - 2)
+        self.submodules.wt_edge = wt_edge = WaitTimer(2)  # valid edge is at period +- 1 clk cycle
+        self.submodules.fsm = fsm = FSM("WAIT_EDGE")
+        fsm.act("WAIT_EDGE",
+            wt_edge.wait.eq(1),
+            If(match_rising | match_falling,
+                source.valid.eq(1),
+                NextState("IN_BIT"),
+            ),
+        )
+        fsm.act("IN_BIT",
+            wt_bit.wait.eq(1),
+            If(wt_bit.done,
+                NextState("WAIT_EDGE"),
+            ),
+        )
+
+        # output stream buffer (improve timing)
+        # also fuse last valid data bit and end of frame detection
+        data = Signal()
+        self.sync += [
+            self.source.valid.eq(source.valid),
+            self.source.data.eq(data),
+            If(source.valid,
+                self.in_sync.eq(1),
+                self.source.last.eq(0),
+                data.eq(source.data),
+            ).Elif(wt_edge.done,
+                If(self.in_sync,
+                    self.in_sync.eq(0),
+                    self.source.valid.eq(1),
+                    self.source.last.eq(1),
+                ).Else(
+                    self.source.valid.eq(0),
+                    self.source.last.eq(0),
+                ),
+            ),
+        ]
 
 
 class LiteEthPHYETHERNETRX(Module):
-    def __init__(self, pads):
+    def __init__(self, pads, period_2):
         self.source = source = stream.Endpoint(eth_phy_description(8))
 
         # # #
 
         # Single Ended / Differential input
-        self.rx = rx = Signal()
-        self.rx_i = rx_i = Signal()
+        rx = Signal()
+        rx_i = Signal()
         if hasattr(pads, "rx"):
-            self.comb += rx.eq(pads.rx)
+            rx = pads.rx
         else:
             self.specials += DifferentialInput(pads.rd_p, pads.rd_n, rx)
-        self.specials += MultiReg(rx, rx_i)
+        self.specials += MultiReg(rx, rx_i, n=2, odomain="eth_rx")
 
-        # Timing edge logic
-        edge = Signal()
-        timeout = Signal()
-        bit_period = Signal()
-        rx_i_old = Signal()
-        timeout_cnt_max = 5
-        bit_period_cnt_max = 2
-        timeout_cnt = Signal(max=timeout_cnt_max + 1)
-        bit_period_cnt = Signal(max=bit_period_cnt_max + 1)
-
-        self.sync += [
-            rx_i_old.eq(rx_i),
-            If(edge,
-                bit_period_cnt.eq(0),
-                timeout_cnt.eq(0),
-            ).Else(
-                If(~timeout,
-                    timeout_cnt.eq(timeout_cnt + 1),
-                ),
-                If(~bit_period,
-                    bit_period_cnt.eq(bit_period_cnt + 1),
-                ),
-            ),
-        ]
+        # Manchester decoder
+        self.submodules.mrec = mrec = ClockDomainsRenamer("eth_rx")(
+            ManchesterReceiver(period_2))
+        self.submodules.fifo = fifo = ClockDomainsRenamer({"write": "eth_rx", "read": "sys"})(
+            stream.AsyncFIFO(converter_description(1), 4))
         self.comb += [
-            edge.eq(rx_i ^ rx_i_old),
-            bit_period.eq(bit_period_cnt == bit_period_cnt_max),
-            timeout.eq(timeout_cnt == timeout_cnt_max),
+            mrec.source.connect(fifo.sink, omit=["first"]),
+            mrec.rx.eq(rx_i),
+            fifo.source.ready.eq(1),
         ]
 
-        # noise detection
-        noise = Signal()
-        self.comb += noise.eq(edge & (bit_period_cnt == 0))
-
-        # Byte logic
-        bitcnt = Signal(max=8 + 1)
+        # Bit deserialization, sync on preamble and output stream
+        bitcnt = Signal(max=8)
         rx_inverted = Signal()
-        half_bit = Signal()
         data_r = Signal(8)
         self.comb += [
             If(rx_inverted,
@@ -173,25 +289,18 @@ class LiteEthPHYETHERNETRX(Module):
                 source.data.eq(data_r),
             ),
             source.last_be.eq(source.last),
+
         ]
 
         self.submodules.fsm = fsm = FSM("SYNC")
-        fsm.act("IDLE",
-            # Wait for activity
-            If(edge,
-                NextState("SYNC"),
-            ),
-        )
-
         fsm.act("SYNC",
-            NextValue(bitcnt, 1),
-            # Wait for the preamble to sync on byte-boundaries
-            If(edge,
-                NextValue(half_bit, ~half_bit),
-                If(~half_bit | bit_period,
+            NextValue(bitcnt, 0),
+            If(fifo.source.valid,
+                If(fifo.source.last,
+                    NextValue(data_r, 0),
+                ).Else(
                     # shift data in
-                    NextValue(data_r, Cat(data_r[1:], rx_i)),
-                    NextValue(half_bit, 1),
+                    NextValue(data_r, Cat(data_r[1:8], rx_i)),
 
                     # detect preamble
                     If(data_r == (eth_preamble >> 56),
@@ -203,35 +312,28 @@ class LiteEthPHYETHERNETRX(Module):
                         NextState("RX"),
                         source.valid.eq(1),
                     ),
-                ),
-            ),
-            If(timeout | noise,
-                NextValue(data_r, 0),
+                )
             ),
         )
 
         fsm.act("RX",
-            If(edge,
-                NextValue(half_bit, ~half_bit),
-                If(~half_bit | bit_period,
+            If(fifo.source.valid,
+                If(fifo.source.last,
+                    source.valid.eq(1),
+                    source.last.eq(1),
+                    NextValue(data_r, 0),
+                    NextState("SYNC"),
+                ).Else(
                     # shift data in
                     NextValue(data_r, Cat(data_r[1:], rx_i)),
                     NextValue(bitcnt, bitcnt + 1),
-                    NextValue(half_bit, 1),
-                    If(bitcnt == 8,
+                    If(bitcnt == 7,
                         source.valid.eq(1),
-                        NextValue(bitcnt, 1),
+                        # NextValue(bitcnt, 0),  # implicit
                     ),
                 ),
             ),
-            # Wait for a timeout to go into idle
-            If(timeout,
-                source.valid.eq(1),
-                source.last.eq(1),
-                NextState("SYNC"),
-            ),
         )
-
 
 
 class LiteEthPHYETHERNETCRG(Module, AutoCSR):
@@ -241,7 +343,6 @@ class LiteEthPHYETHERNETCRG(Module, AutoCSR):
         # # #
 
         # RX/TX clocks
-
         self.clock_domains.cd_eth_rx = ClockDomain()
         self.clock_domains.cd_eth_tx = ClockDomain()
 
@@ -266,14 +367,25 @@ class LiteEthPHYETHERNETCRG(Module, AutoCSR):
 
 class LiteEthPHYETHERNET(Module, AutoCSR, ModuleDoc):
     """
-    Direct connection to a 10Base-T network, using only series capacitors with FPGIO IOs.
+    Direct connection to a 10Base-T network, using only series capacitors, termination resistors and
+    FPGIA IOs.
     This probably violates some parts of the IEEE802.3 standard. Use at your own risk!
+
+    Parameters:
+    - pads: either a Record or a Module for IO interface:
+      - Transmit path either has `tx` and `txe`, or `td_p` and `td_n` members.
+      - Receive path either has `rx` or `rd_p` and `rd_n`
+    - sys_clk_freq: clock frequency at which this module runs
+    - refclk_cd: ClockDomain from which the IO-facing part of the PHY runs.
+      Its frequency must be 60MHz.
     """
     dw          = 8
-    tx_clk_freq = 40e6
-    rx_clk_freq = 40e6
-    def __init__(self, pads, refclk_cd="eth", with_hw_init_reset=True):
+    tx_clk_freq = 60e6
+    rx_clk_freq = 60e6
+    period_2    = 3
+
+    def __init__(self, pads, sys_clk_freq, refclk_cd="eth", with_hw_init_reset=True):
         self.submodules.crg = LiteEthPHYETHERNETCRG(refclk_cd, with_hw_init_reset)
-        self.submodules.tx = ClockDomainsRenamer("eth_tx")(LiteEthPHYETHERNETTX(pads))
-        self.submodules.rx = ClockDomainsRenamer("eth_rx")(LiteEthPHYETHERNETRX(pads))
+        self.submodules.tx = LiteEthPHYETHERNETTX(pads, sys_clk_freq, self.period_2)
+        self.submodules.rx = LiteEthPHYETHERNETRX(pads, self.period_2)
         self.sink, self.source = self.tx.sink, self.rx.source


### PR DESCRIPTION
This  PR adds a 10BASE-T PHY which only requires 2 LVDS pairs, 6 resistors and 4 capacitors.
The PHY works in a 40MHz clock domain, both for RX and TX.
It is based on work from https://www.fpga4fun.com/10BASE-T1.html


Current status:
- RX path correctly decodes preamble and data (verified against logic analyzer and Wireshark)
- CRC checker correctly detects errors when 
- :-1: when receiving a ping packet, the IP does not answer.

I need some help to debug the higher layers...

To build the SoC:
```
python bench/arty_multi.py --uart-name uartbone --cpu-type None --csr-csv build/digilent_arty/csr.csv --raw-eth --build --load
```