### PR TITLE
liteeth/gen: use add_csr to fix the order of banks

### DIFF
--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -385,6 +385,10 @@ def main():
 
     if core_config["core"] == "wishbone":
         soc = MACCore(platform, core_config)
+        # Ensure consistent bank addresses, keep this order
+        soc.add_csr("ctrl")
+        soc.add_csr("ethphy")
+        soc.add_csr("ethmac")
     elif core_config["core"] == "udp":
         soc = UDPCore(platform, core_config)
     else:


### PR DESCRIPTION
Device drivers (Linux etc) expect the banks to be at constant locations.
We fix them to the locations previously used for microwatt.dts, somewhat
arbitrarily.

or1klitex.dts is the other upstream kernel devicetree using liteeth, it
may need updating to these fixed addresses (it may not be consistent
with current liteeth anyway)