### PR TITLE
liteeth/gen: Use hw_init_reset for rgmii

### DIFF
--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -204,7 +204,7 @@ class PHYCore(SoCMini):
                 pads               = platform.request("rgmii_eth"),
                 tx_delay           = core_config.get("phy_tx_delay", 2e-9),
                 rx_delay           = core_config.get("phy_rx_delay", 2e-9),
-                with_hw_init_reset = False) # FIXME: required since sys_clk = eth_rx_clk.
+            )
         else:
             raise ValueError("Unsupported PHY")
         self.submodules.ethphy = ethphy


### PR DESCRIPTION
I'm not sure of the original reason for this being marked FIXME, so if the `hw_init_reset` needs to remain I can instead make this a configuration option for `litedram_gen`. 

This re-enables hw_init_reset that was disabled in
ea24ff6 ("liteeth_gen:  improve readability and add clk_freq checks.")

A chip reset is necessary using the Microchip KSZ9031RNX
PHY on an antmicro-artix-dc-scm board (possibly depending on startup
power timing)