### PR TITLE
wishbone rx data corruption

### DIFF
--- a/liteeth/mac/sram.py
+++ b/liteeth/mac/sram.py
@@ -91,7 +91,7 @@ class LiteEthMACSRAMWriter(Module, AutoCSR):
                     )
                 ).Else(
                     NextValue(errors, errors + 1),
-                    NextState("DISCARD-REMAINING")
+                    NextState("DISCARD-ALL")
                 )
             )
         )
@@ -101,6 +101,16 @@ class LiteEthMACSRAMWriter(Module, AutoCSR):
                     NextState("DISCARD")
                 ).Else(
                     NextState("TERMINATE")
+                )
+            )
+        )
+        fsm.act("DISCARD-ALL",
+            If(sink.valid & sink.last,
+                If((sink.last_be) != 0,
+                    NextState("DISCARD")
+                ).Else(
+                    NextValue(length, 0),
+                    NextState("WRITE")
                 )
             )
         )

--- a/liteeth/mac/wishbone.py
+++ b/liteeth/mac/wishbone.py
@@ -40,7 +40,7 @@ class LiteEthMACWishboneInterface(Module, AutoCSR):
 
         # Wishbone SRAM interfaces for the reader SRAM (i.e. Ethernet TX).
         wb_tx_sram_ifs = []
-        for n in range(nrxslots):
+        for n in range(ntxslots):
             wb_tx_sram_ifs.append(wishbone.SRAM(
                 mem_or_size = self.sram.reader.mems[n],
                 read_only   = False,


### PR DESCRIPTION
See commit message, this fixes a data corruption in the RX path. It also fixes a typo that prevented having a different number of rx and tx buffers.