### PR TITLE
Make phy/usrgmii.py Ultrascale+ compatible

### DIFF
--- a/liteeth/phy/usrgmii.py
+++ b/liteeth/phy/usrgmii.py
@@ -52,7 +52,7 @@ class LiteEthPHYRGMIITX(Module):
 
 
 class LiteEthPHYRGMIIRX(Module):
-    def __init__(self, pads, rx_delay=2e-9):
+    def __init__(self, pads, rx_delay=2e-9, usp=False):
         self.source = source = stream.Endpoint(eth_phy_description(8))
 
         # # #
@@ -77,6 +77,7 @@ class LiteEthPHYRGMIIRX(Module):
                 p_REFCLK_FREQUENCY = 300.0,
                 p_DELAY_FORMAT     = "TIME",
                 p_UPDATE_MODE      = "ASYNC",
+                p_SIM_DEVICE       = "ULTRASCALE_PLUS" if usp else "ULTRASCALE",
                 i_CASC_IN     = 0,
                 i_CASC_RETURN = 0,
                 i_CE          = 0,
@@ -115,6 +116,7 @@ class LiteEthPHYRGMIIRX(Module):
                     p_REFCLK_FREQUENCY = 300.0,
                     p_UPDATE_MODE      = "ASYNC",
                     p_DELAY_FORMAT     = "TIME",
+                    p_SIM_DEVICE       = "ULTRASCALE_PLUS" if usp else "ULTRASCALE",
                     i_CASC_IN     = 0,
                     i_CASC_RETURN = 0,
                     i_CE          = 0,
@@ -217,10 +219,10 @@ class LiteEthPHYRGMII(Module, AutoCSR):
     dw          = 8
     tx_clk_freq = 125e6
     rx_clk_freq = 125e6
-    def __init__(self, clock_pads, pads, with_hw_init_reset=True, tx_delay=2e-9, rx_delay=2e-9):
+    def __init__(self, clock_pads, pads, with_hw_init_reset=True, tx_delay=2e-9, rx_delay=2e-9, usp=False):
         self.submodules.crg = LiteEthPHYRGMIICRG(clock_pads, pads, with_hw_init_reset, tx_delay)
         self.submodules.tx  = ClockDomainsRenamer("eth_tx")(LiteEthPHYRGMIITX(pads))
-        self.submodules.rx  = ClockDomainsRenamer("eth_rx")(LiteEthPHYRGMIIRX(pads, rx_delay))
+        self.submodules.rx  = ClockDomainsRenamer("eth_rx")(LiteEthPHYRGMIIRX(pads, rx_delay, usp))
         self.sink, self.source = self.tx.sink, self.rx.source
 
         if hasattr(pads, "mdc"):


### PR DESCRIPTION
Vivado Error's out just before bitstream genertation, if the p_SIM_DEVICE isn't set to ULTRASCALE_PLUS. FYI, tested on VUP