### PR TITLE
Tx write only

### DIFF
--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -18,6 +18,7 @@ class LiteEthMAC(Module, AutoCSR):
         with_preamble_crc = True,
         nrxslots          = 2,
         ntxslots          = 2,
+        tx_write_only     = False,
         hw_mac            = None,
         timestamp         = None,
         full_memory_we    = False,
@@ -55,6 +56,7 @@ class LiteEthMAC(Module, AutoCSR):
                 ntxslots   = ntxslots,
                 endianness = endianness,
                 timestamp  = timestamp,
+                tx_write_only = tx_write_only,
             )
             # On some targets (Intel/Altera), the complex ports aren't inferred
             # as block ram, but are created with LUTs.  FullMemoryWe splits such

--- a/liteeth/mac/wishbone.py
+++ b/liteeth/mac/wishbone.py
@@ -16,7 +16,7 @@ from litex.soc.interconnect import wishbone
 # MAC Wishbone Interface ---------------------------------------------------------------------------
 
 class LiteEthMACWishboneInterface(Module, AutoCSR):
-    def __init__(self, dw, nrxslots=2, ntxslots=2, endianness="big", timestamp=None):
+    def __init__(self, dw, nrxslots=2, ntxslots=2, endianness="big", timestamp=None, tx_write_only=False):
         self.sink   = stream.Endpoint(eth_phy_description(dw))
         self.source = stream.Endpoint(eth_phy_description(dw))
         self.bus    = wishbone.Interface(data_width=dw)
@@ -43,7 +43,7 @@ class LiteEthMACWishboneInterface(Module, AutoCSR):
         for n in range(ntxslots):
             wb_tx_sram_ifs.append(wishbone.SRAM(
                 mem_or_size = self.sram.reader.mems[n],
-                read_only   = False,
+                write_only  = tx_write_only,
                 bus         = wishbone.Interface(data_width = dw)
             ))
 


### PR DESCRIPTION
Allow liteeth txslots to be write only. Enable it in case the firmware does not need to read back the buffer. This can save a substantial amount of resources. Tested on Spartan6. Without it, txbuffers are implemented as distributed RAM, probably due to the 2 read ports. With this patch, it is implemented as BRAM.
Needs to be pulled in conjunction with the corresponding liteeth patch.