### PR TITLE
gen: add UDP raw listen-port selection

### DIFF
--- a/examples/udp_raw_ecp5rgmii.yml
+++ b/examples/udp_raw_ecp5rgmii.yml
@@ -41,13 +41,14 @@ rx_cdc_buffered : True
 # control of transmitted UDP packet sizes.
 udp_ports:
   raw:
-    data_width : 32
-    mode       : raw
+    data_width: 32
+    udp_port: 2000
+    mode: raw
   streamer1:
-    data_width : 32
-    port       : 1337
-    mode       : streamer
+    data_width: 32
+    udp_port: 1337
+    mode: streamer
   streamer2:
-    data_width : 32
-    port       : 6077
-    mode       : streamer
+    data_width: 32
+    udp_port: 6077
+    mode: streamer

--- a/examples/udp_raw_ecp5rgmii.yml
+++ b/examples/udp_raw_ecp5rgmii.yml
@@ -41,14 +41,14 @@ rx_cdc_buffered : True
 # control of transmitted UDP packet sizes.
 udp_ports:
   raw:
-    data_width: 32
-    udp_port: 2000
-    mode: raw
+    data_width : 32
+    udp_port   : 2000
+    mode       : raw
   streamer1:
-    data_width: 32
-    udp_port: 1337
-    mode: streamer
+    data_width : 32
+    udp_port   : 1337
+    mode       : streamer
   streamer2:
-    data_width: 32
-    udp_port: 6077
-    mode: streamer
+    data_width : 32
+    udp_port   : 6077
+    mode       : streamer

--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -196,13 +196,13 @@ def get_udp_port_ios(name, data_width, dynamic_params=False):
         ),
     ]
 
-def get_udp_raw_port_ios(name, data_width, dynamic_params=False):
+def get_udp_raw_port_ios(name, data_width, with_dynamic_listen_port=False):
     return [
         (f"{name}", 0,
-             # Parameters.
+            # Parameters.
             *([
-                Subsignal("udp_listen_port",   Pins(16)),
-            ] if dynamic_params else []),
+                Subsignal("udp_listen_port", Pins(16)),
+            ] if with_dynamic_listen_port else []),
 
             # Sink.
             Subsignal("sink_ip_address", Pins(32)),
@@ -542,24 +542,24 @@ class UDPCore(PHYCore):
         # Use default Data-Width of 8-bit when not specified.
         data_width = port_cfg.get("data_width", 8)
 
-        # Used dynamic UDP-Port when not specified.
+        # Use dynamic UDP listen port when not specified.
         udp_listen_port = port_cfg.get("udp_port", None)
-        dynamic_params = udp_listen_port is None
-
-        if dynamic_params:
-            udp_listen_port = port_ios.udp_listen_port
+        with_dynamic_listen_port = udp_listen_port is None
 
         if port_cfg.get("ip_address", None) is not None:
-            raise RuntimeWarning("\"ip_address\" config not supported on \"udpraw\" port")
+            raise ValueError("\"ip_address\" config is not supported on \"raw\" UDP ports")
 
         # Create/Add IOs.
-         # ---------------
+        # ---------------
         platform.add_extension(get_udp_raw_port_ios(name,
-            data_width     = data_width,
-            dynamic_params = dynamic_params
+            data_width                = data_width,
+            with_dynamic_listen_port  = with_dynamic_listen_port
          ))
 
         port_ios = platform.request(name)
+
+        if with_dynamic_listen_port:
+            udp_listen_port = port_ios.udp_listen_port
 
         raw_port = self.core.udp.crossbar.get_port(udp_listen_port, dw=data_width)
 

--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -196,9 +196,13 @@ def get_udp_port_ios(name, data_width, dynamic_params=False):
         ),
     ]
 
-def get_udp_raw_port_ios(name, data_width):
+def get_udp_raw_port_ios(name, data_width, dynamic_params=False):
     return [
         (f"{name}", 0,
+             # Parameters.
+            *([
+                Subsignal("udp_listen_port",   Pins(16)),
+            ] if dynamic_params else []),
 
             # Sink.
             Subsignal("sink_ip_address", Pins(32)),
@@ -538,15 +542,26 @@ class UDPCore(PHYCore):
         # Use default Data-Width of 8-bit when not specified.
         data_width = port_cfg.get("data_width", 8)
 
+        # Used dynamic UDP-Port when not specified.
+        udp_listen_port = port_cfg.get("udp_port", None)
+        dynamic_params = udp_listen_port is None
+
+        if dynamic_params:
+            udp_listen_port = port_ios.udp_listen_port
+
+        if port_cfg.get("ip_address", None) is not None:
+            raise RuntimeWarning("\"ip_address\" config not supported on \"udpraw\" port")
+
         # Create/Add IOs.
          # ---------------
         platform.add_extension(get_udp_raw_port_ios(name,
             data_width     = data_width,
+            dynamic_params = dynamic_params
          ))
 
         port_ios = platform.request(name)
 
-        raw_port = self.core.udp.crossbar.get_port(port_ios.sink_dst_port, dw=data_width)
+        raw_port = self.core.udp.crossbar.get_port(udp_listen_port, dw=data_width)
 
         # Connect IOs.
         # ------------

--- a/test/test_gen.py
+++ b/test/test_gen.py
@@ -8,7 +8,10 @@ import sys
 import shutil
 import unittest
 import subprocess
+import tempfile
 from pathlib import Path
+
+import yaml
 
 # Helper -------------------------------------------------------------------------------------------
 
@@ -16,15 +19,51 @@ _repo_root    = Path(__file__).resolve().parents[1]
 _examples_dir = _repo_root / "examples"
 _build_dir    = _examples_dir / "build"
 
+def generate_config(config_file, output_dir):
+    subprocess.run(
+        [
+            sys.executable,
+            str(_repo_root / "liteeth" / "gen.py"),
+            str(config_file),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd   = _examples_dir,
+        check = True,
+        stdout = subprocess.PIPE,
+        stderr = subprocess.STDOUT,
+        text   = True,
+    )
+    return output_dir / "gateware" / "liteeth_core.v"
+
+def generate_example_verilog(name):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        verilog = generate_config(
+            config_file = _examples_dir / f"{name}.yml",
+            output_dir  = Path(tmpdir) / "build",
+        )
+        return verilog.read_text(encoding="utf-8")
+
+def generate_config_dict_verilog(config):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmpdir      = Path(tmpdir)
+        config_file = tmpdir / "config.yml"
+        with config_file.open("w", encoding="utf-8") as f:
+            yaml.safe_dump(config, f)
+        verilog = generate_config(
+            config_file = config_file,
+            output_dir  = tmpdir / "build",
+        )
+        return verilog.read_text(encoding="utf-8")
+
 def build_config(name):
     shutil.rmtree(_build_dir, ignore_errors=True)
     try:
-        subprocess.run(
-            [sys.executable, str(_repo_root / "liteeth" / "gen.py"), f"{name}.yml"],
-            cwd   = _examples_dir,
-            check = True,
+        verilog = generate_config(
+            config_file = _examples_dir / f"{name}.yml",
+            output_dir  = _build_dir,
         )
-        return int(not (_build_dir / "gateware" / "liteeth_core.v").is_file())
+        return int(not verilog.is_file())
     finally:
         shutil.rmtree(_build_dir, ignore_errors=True)
 
@@ -42,3 +81,35 @@ class TestExamples(unittest.TestCase):
     def test_udp_raw_rgmii(self):
         errors = build_config("udp_raw_ecp5rgmii")
         self.assertEqual(errors, 0)
+
+    def test_udp_raw_static_listen_port(self):
+        verilog = generate_example_verilog("udp_raw_ecp5rgmii")
+        self.assertNotIn("raw_udp_listen_port", verilog)
+        self.assertRegex(verilog, r"crossbar_sink_param_dst_port == \d+'d2000")
+        self.assertNotIn("crossbar_sink_param_dst_port == raw_sink_dst_port", verilog)
+
+    def test_udp_raw_dynamic_listen_port(self):
+        with (_examples_dir / "udp_raw_ecp5rgmii.yml").open(encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        del config["udp_ports"]["raw"]["udp_port"]
+
+        verilog = generate_config_dict_verilog(config)
+        self.assertIn("raw_udp_listen_port", verilog)
+        self.assertIn("crossbar_sink_param_dst_port == raw_udp_listen_port", verilog)
+        self.assertNotIn("crossbar_sink_param_dst_port == raw_sink_dst_port", verilog)
+
+    def test_udp_raw_rejects_static_ip(self):
+        with (_examples_dir / "udp_raw_ecp5rgmii.yml").open(encoding="utf-8") as f:
+            config = yaml.safe_load(f)
+        config["udp_ports"]["raw"]["ip_address"] = "172.30.0.100"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmpdir      = Path(tmpdir)
+            config_file = tmpdir / "config.yml"
+            with config_file.open("w", encoding="utf-8") as f:
+                yaml.safe_dump(config, f)
+            with self.assertRaises(subprocess.CalledProcessError):
+                generate_config(
+                    config_file = config_file,
+                    output_dir  = tmpdir / "build",
+                )


### PR DESCRIPTION
This rebases Rowan Goemans' original `udpraw` listen-port fix on current master and adds a small cleanup commit on top.

Background: https://github.com/enjoy-digital/litex/pull/1733

## Purpose

`udpraw` should not use the TX-side `sink_dst_port` signal as its RX crossbar selector. The receive/listen port and transmitted destination port are different concepts:

- `udp_port` in the YAML config now selects the static UDP port received by the raw endpoint.
- If `udp_port` is omitted, the generated raw endpoint exposes a dynamic `udp_listen_port` IO.
- `sink_dst_port` remains per-packet TX metadata only.
- `ip_address` is rejected for raw ports since raw mode already carries per-packet IP metadata.

## Credit

- Original fix/idea by Rowan Goemans in the first commit.
- Follow-up cleanup/tests in the second commit.

## Tested

- `python3 -m unittest test.test_gen`
- `python3 -m py_compile liteeth/gen.py test/test_gen.py`
- `git diff --check`
