### PR TITLE
core/dhcp: Lease time support

### DIFF
--- a/examples/udp_raw_ecp5rgmii.yml
+++ b/examples/udp_raw_ecp5rgmii.yml
@@ -9,11 +9,11 @@ device: LFE5U-25F-6BG256C
 vendor: lattice
 toolchain: trellis
 # Core -------------------------------------------------------------------------
-clk_freq: 125e6
+clk_freq: 50e6
 core: udp
 
 mac_address: 0x10e2d5000000
-ip_address: 172.30.0.1
+dhcp: True
 
 tx_cdc_depth: 16
 tx_cdc_buffered: True

--- a/liteeth/core/__init__.py
+++ b/liteeth/core/__init__.py
@@ -93,6 +93,8 @@ class LiteEthUDPIPCore(LiteEthIPCore):
     ):
         # Ensure either IP is external or DHCP is used
         assert((ip_address is None) == with_dhcp)
+        # DHCP requres IP broadcast
+        assert(not with_dhcp or with_ip_broadcast)
 
         # Parameters.
         # -----------


### PR DESCRIPTION
This PR adds DHCP lease time support. To do that a DHCP OPTIONS parser is implemented.

At first I tried to do it fully in the 32-bit datapath. But it's simply too much. Header can be at any position, Multiple options per 32-bit packet are possible, padding which increases variety even more... If LiteX had some kind of function support It would be possible but I simply don't know how to express that.

So in the end I decided to just bite the bullet and do options parsing with 8-bit width.

Another problem that is fixed now is that `MESSAGETYPE` option no longer is assumed to be first option. The spec does not say it must be the first option so this could be very problematic for some Liteeth DHCP server combinations.

I did already add gateway and netmask parsing but they aren't wired up. 

TODOs:

- [x] Make it function correctly
- [x] Use received lease time to automatically restart DHCP process before the lease has expired
- [x] Make the DHCP module self contained. No longer have external `start`, `timeout` and `done` signals