### PR TITLE
core: Add buffers to IP and ICMP

### DIFF
--- a/liteeth/core/icmp.py
+++ b/liteeth/core/icmp.py
@@ -10,6 +10,7 @@ from litex.soc.interconnect.packet import PacketFIFO
 
 from liteeth.common import *
 from liteeth.packet import Depacketizer, Packetizer
+from litex.soc.interconnect.stream import BufferizeEndpoints, DIR_SOURCE, DIR_SINK
 
 # ICMP TX ------------------------------------------------------------------------------------------
 
@@ -160,6 +161,9 @@ class LiteEthICMP(LiteXModule):
     def __init__(self, ip, ip_address, dw=8, fifo_depth=128):
         self.tx   = tx   = LiteEthICMPTX(ip_address, dw)
         self.rx   = rx   = LiteEthICMPRX(ip_address, dw)
+
+        rx = BufferizeEndpoints({"source": DIR_SOURCE}, pipe_valid=True, pipe_ready=False)(rx)
+
         self.echo = echo = LiteEthICMPEcho(dw, fifo_depth=fifo_depth)
         self.comb += [
             rx.source.connect(echo.sink),

--- a/liteeth/core/ip.py
+++ b/liteeth/core/ip.py
@@ -6,6 +6,7 @@
 
 from litex.gen import *
 
+from litex.soc.interconnect.stream import BufferizeEndpoints, DIR_SOURCE, DIR_SINK
 from liteeth.common import *
 from liteeth.crossbar import LiteEthCrossbar
 
@@ -261,6 +262,9 @@ class LiteEthIP(LiteXModule):
     def __init__(self, mac, mac_address, ip_address, arp_table, with_broadcast=True, dw=8):
         self.tx = tx = LiteEthIPTX(mac_address, ip_address, arp_table, dw=dw)
         self.rx = rx = LiteEthIPRX(mac_address, ip_address, with_broadcast, dw=dw)
+
+        rx = BufferizeEndpoints({"source": DIR_SOURCE}, pipe_valid=True, pipe_ready=False)(rx)
+
         mac_port = mac.crossbar.get_port(ethernet_type_ip, dw)
         self.comb += [
             tx.source.connect(mac_port.sink),


### PR DESCRIPTION
This significantly improves timing on ECP5. This allows ECP5 to once again reach 50Mhz with ease.

It does burn a few FFs and LUTs though On a UDP echo design on a 25k ECP5 we go from

```
Info:             TRELLIS_FF:  2334/24288     9%
Info:           TRELLIS_COMB:  5432/24288    22%
Info:           TRELLIS_RAMW:   136/ 3036     4%
```

to

```
Info:             TRELLIS_FF:  2570/24288    10%
Info:           TRELLIS_COMB:  5752/24288    23%
Info:           TRELLIS_RAMW:   136/ 3036     4%
```

So if you want to make this configurable @enjoy-digital let me know