### PR TITLE
phy/ecp5rgmii.py: In-Band Status CSRField("clock_speed") size fixed

### DIFF
--- a/liteeth/phy/ecp5rgmii.py
+++ b/liteeth/phy/ecp5rgmii.py
@@ -71,7 +71,7 @@ class LiteEthPHYRGMIIRX(LiteXModule):
                     ("``0b0``", "Link down."),
                     ("``0b1``", "Link up."),
                 ]),
-                CSRField("clock_speed", size=1, values=[
+                CSRField("clock_speed", size=2, values=[
                     ("``0b00``", "2.5MHz   (10Mbps)."),
                     ("``0b01``", "25MHz   (100MBps)."),
                     ("``0b10``", "125MHz (1000MBps)."),


### PR DESCRIPTION
clock_speed size increased to 2 otherwise 1 bit of data is lost