### PR TITLE
Update a7_gtp.py  transceiver resets have to stay low for 10us.

### DIFF
--- a/liteeth/phy/a7_gtp.py
+++ b/liteeth/phy/a7_gtp.py
@@ -90,7 +90,7 @@ class GTPTxInit(Module):
         # After configuration, transceiver resets have to stay low for
         # at least 500ns.
         # See https://www.xilinx.com/support/answers/43482.html
-        timer_max = ceil(500e-9*sys_clk_freq)
+        timer_max = ceil(10000e-9*sys_clk_freq)
         timer     = Signal(max=timer_max+1)
         tick      = Signal()
         self.sync += [


### PR DESCRIPTION
After testing several boards with XC7A200T chips, I found, that SFP works well only with setting more than 10us. The most of the XC7A200T chips works with 500ns, but some boards need 10us to 100% start work.