### PR TITLE
Only import liteiclink when required

### DIFF
--- a/liteeth/phy/k7_1000basex.py
+++ b/liteeth/phy/k7_1000basex.py
@@ -12,8 +12,6 @@ from litex.gen import *
 
 from litex.soc.cores.clock import S7MMCM
 
-from liteiclink.transceiver.gtx_7series import GTXChannelPLL, GTXTXInit, GTXRXInit
-
 from liteeth.common import *
 from liteeth.phy.pcs_1000basex import *
 
@@ -26,6 +24,7 @@ class K7_1000BASEX(LiteXModule):
     rx_clk_freq = 125e6
     tx_clk_freq = 125e6
     def __init__(self, refclk_or_clk_pads, data_pads, sys_clk_freq, refclk_freq=200e6, with_csr=True, rx_polarity=0, tx_polarity=0):
+        from liteiclink.transceiver.gtx_7series import GTXChannelPLL, GTXTXInit, GTXRXInit
         assert refclk_freq in [200e6]
         self.pcs = pcs = PCS(lsb_first=True)
 

--- a/liteeth/phy/ku_1000basex.py
+++ b/liteeth/phy/ku_1000basex.py
@@ -11,8 +11,6 @@ from migen.genlib.cdc import PulseSynchronizer
 
 from litex.gen import *
 
-from liteiclink.serdes.gth3_ultrascale import GTHChannelPLL
-
 from liteeth.common import *
 from liteeth.phy.pcs_1000basex import *
 
@@ -25,6 +23,7 @@ class KU_1000BASEX(LiteXModule):
     rx_clk_freq = 125e6
     tx_clk_freq = 125e6
     def __init__(self, refclk_or_clk_pads, data_pads, sys_clk_freq, refclk_freq=200e6, with_csr=True, rx_polarity=0, tx_polarity=0):
+        from liteiclink.serdes.gth3_ultrascale import GTHChannelPLL
         assert refclk_freq in [200e6, 156.25e6]
         self.pcs = pcs = PCS(lsb_first=True)
 

--- a/liteeth/phy/usp_gth_1000basex.py
+++ b/liteeth/phy/usp_gth_1000basex.py
@@ -11,8 +11,6 @@ from migen.genlib.cdc import PulseSynchronizer
 
 from litex.gen import *
 
-from liteiclink.serdes.gth4_ultrascale import GTHChannelPLL
-
 from liteeth.common import *
 from liteeth.phy.pcs_1000basex import *
 
@@ -25,6 +23,7 @@ class USP_GTH_1000BASEX(LiteXModule):
     rx_clk_freq = 125e6
     tx_clk_freq = 125e6
     def __init__(self, refclk_or_clk_pads, data_pads, sys_clk_freq, refclk_freq=200e6, with_csr=True, rx_polarity=0, tx_polarity=0):
+        from liteiclink.serdes.gth4_ultrascale import GTHChannelPLL
         assert refclk_freq in [200e6, 156.25e6]
         self.pcs = pcs = PCS(lsb_first=True)
 

--- a/liteeth/phy/usp_gty_1000basex.py
+++ b/liteeth/phy/usp_gty_1000basex.py
@@ -11,8 +11,6 @@ from migen.genlib.cdc import PulseSynchronizer
 
 from litex.gen import *
 
-from liteiclink.serdes.gty_ultrascale import GTYChannelPLL
-
 from liteeth.common import *
 from liteeth.phy.pcs_1000basex import *
 
@@ -25,6 +23,7 @@ class USP_GTY_1000BASEX(LiteXModule):
     rx_clk_freq = 125e6
     tx_clk_freq = 125e6
     def __init__(self, refclk_or_clk_pads, data_pads, sys_clk_freq, refclk_freq=200e6, with_csr=True, rx_polarity=0, tx_polarity=0):
+        from liteiclink.serdes.gty_ultrascale import GTYChannelPLL
         assert refclk_freq in [200e6, 156.25e6]
         self.pcs = pcs = PCS(lsb_first=True)
 


### PR DESCRIPTION
As liteiclink is only used in the phy implementations of a few Xilinx/AMD FPGAs, it does not make sense that it would be required to build liteeth for any FPGA.