### PR TITLE
Fix etherbone reads

### DIFF
--- a/liteeth/frontend/etherbone.py
+++ b/liteeth/frontend/etherbone.py
@@ -251,6 +251,7 @@ class LiteEthEtherboneRecordReceiver(LiteXModule):
             source.last.eq(count == fifo.source.rcount-1),
             source.last_be.eq(source.last << 3),
             source.count.eq(fifo.source.rcount),
+            source.be.eq(fifo.source.byte_enable),
             source.base_addr.eq(base_addr),
             source.addr.eq(fifo.source.data[2:]),
             fifo.source.ready.eq(source.ready),


### PR DESCRIPTION
Since https://github.com/enjoy-digital/litex/pull/1999, etherbone reads might result in garbage being output. This is caused by `be` not being set during the read.

Fixes https://github.com/enjoy-digital/litex/issues/2031