### PR TITLE
phy/usp_gth/gty_1000basex: Set proper CPLLREFCLKSEL

### DIFF
--- a/liteeth/phy/usp_gth_1000basex.py
+++ b/liteeth/phy/usp_gth_1000basex.py
@@ -565,7 +565,7 @@ class USP_GTH_1000BASEX(LiteXModule):
             i_CPLLLOCKDETCLK       = 0b0,
             i_CPLLLOCKEN           = 0b1,
             i_CPLLPD               = pll_reset,
-            i_CPLLREFCLKSEL        = 0b001,
+            i_CPLLREFCLKSEL        = 0b111 if refclk_from_fabric else 0b001,
             i_CPLLRESET            = 0b0,
             i_DMONFIFORESET        = 0b0,
             i_DMONITORCLK          = 0b0,

--- a/liteeth/phy/usp_gty_1000basex.py
+++ b/liteeth/phy/usp_gty_1000basex.py
@@ -581,7 +581,7 @@ class USP_GTY_1000BASEX(LiteXModule):
             i_CPLLLOCKDETCLK       = 0b0,
             i_CPLLLOCKEN           = 0b1,
             i_CPLLPD               = pll_reset,
-            i_CPLLREFCLKSEL        = 0b001,
+            i_CPLLREFCLKSEL        = 0b111 if refclk_from_fabric else 0b001,
             i_CPLLRESET            = 0b0,
             i_DMONFIFORESET        = 0b0,
             i_DMONITORCLK          = 0b0,


### PR DESCRIPTION
As per Xilinx UG578 CPLLREFCLKSEL needs to be set to 111 when using GTGREFCLK as clock source.

Tested on VU13P.