### PR TITLE
mac: Only use one CRC engine for Checker

### DIFF
--- a/liteeth/mac/crc.py
+++ b/liteeth/mac/crc.py
@@ -159,7 +159,7 @@ class LiteEthMACCRC32Inserter(LiteXModule):
         # Parameters.
         data_width  = len(sink.data)
         ratio       = 32//data_width
-        assert data_width in [8, 16, 32, 64]
+        assert data_width in [8, 32, 64]
 
         # Signals.
         crc_packet = Signal(32,            reset_less=True)
@@ -279,7 +279,7 @@ class LiteEthMACCRC32Checker(LiteXModule):
         # Parameters.
         data_width  = len(sink.data)
         ratio       = ceil(32/data_width)
-        assert data_width in [8, 16, 32, 64]
+        assert data_width in [8, 32, 64]
 
         # CRC32 Checker.
         self.crc = crc = LiteEthMACCRC32(data_width)

--- a/test/test_crc.py
+++ b/test/test_crc.py
@@ -1,0 +1,114 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2025 David Sawatzke <d-git@sawatzke.dev>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+import random
+
+from migen import *
+
+from liteeth.common import *
+from liteeth.mac.crc import *
+
+from litex.gen.sim import *
+
+from .test_stream import (
+    mask_last_be,
+    StreamPacket,
+    stream_inserter,
+    stream_collector,
+    compare_packets,
+)
+
+
+def get_stream_desc(dw):
+    return [
+        ("data", dw),
+        ("last_be", dw // 8),
+        ("error", dw // 8),
+    ]
+
+
+class DUT(Module):
+    def __init__(self, dw):
+        self.submodules.inserter = LiteEthMACCRC32Inserter(eth_phy_description(dw))
+        self.submodules.checker = LiteEthMACCRC32Checker(eth_phy_description(dw))
+        self.comb += self.inserter.source.connect(self.checker.sink)
+
+
+# -----------------------------------------------------------------------------
+# Simulation Test
+# -----------------------------------------------------------------------------
+
+
+class TestCRC(unittest.TestCase):
+    def crc_inserter_checker_test(self, dw=32, seed=42, npackets=2, debug_print=False):
+        prng = random.Random(seed + 5)
+
+        dut = DUT(dw)
+        desc = get_stream_desc(dw)
+        full_last_be = (1 << (dw // 8)) - 1
+
+        packets = []
+
+        for n in range(npackets):
+            header = {}
+            datas = [prng.randrange(2**8) for _ in range(prng.randrange(dw - 1) + 1)]
+            packets.append(StreamPacket(datas, header))
+
+        recvd_packets = []
+        run_simulation(
+            dut,
+            [
+                stream_inserter(
+                    dut.inserter.sink,
+                    src=packets,
+                    seed=seed,
+                    debug_print=debug_print,
+                    valid_rand=50,
+                ),
+                stream_collector(
+                    dut.checker.source,
+                    dest=recvd_packets,
+                    expect_npackets=npackets,
+                    seed=seed,
+                    debug_print=debug_print,
+                    ready_rand=50,
+                ),
+            ],
+            vcd_name="crc_test_{}bit_seed{}.vcd".format(dw, seed),
+        )
+
+        if not compare_packets(packets, recvd_packets):
+
+            print("crc_test_{}bit_seed{}".format(dw, seed))
+            print(len(packets))
+            for i in range(len(packets)):
+                print(i)
+                print(packets[i].data)
+                print(recvd_packets[i].data)
+            assert False
+
+    def test_8bit_loopback(self):
+        for seed in range(42, 48):
+            with self.subTest(seed=seed):
+                self.crc_inserter_checker_test(dw=8, seed=seed)
+
+    def test_32bit_loopback(self):
+        for seed in range(42, 48):
+            with self.subTest(seed=seed):
+                self.crc_inserter_checker_test(dw=32, seed=seed)
+
+    # TODO the 64 bit case has a few issues unrelated to LiteEthMACCRC32Check
+    # def test_64bit_loopback(self):
+    #     for seed in range(42, 70):
+    #         with self.subTest(seed=seed):
+    #             self.crc_inserter_checker_test(dw=64, seed=seed)
+
+    # 16 bit is completely broken
+    # def test_16bit_loopback(self):
+    #     for seed in range(42, 70):
+    #         with self.subTest(seed=seed):
+    #             self.crc_inserter_checker_test(dw=16, seed=seed)

--- a/test/test_packet.py
+++ b/test/test_packet.py
@@ -12,17 +12,7 @@ from migen import *
 from litex.soc.interconnect.stream import *
 from liteeth.packet import *
 
-from .test_stream import StreamPacket, stream_inserter, stream_collector, compare_packets
-
-def mask_last_be(dw, data, last_be):
-    masked_data = 0
-
-    for byte in range(dw // 8):
-        if 2**byte > last_be:
-            break
-        masked_data |= data & (0xFF << (byte * 8))
-
-    return masked_data
+from .test_stream import StreamPacket, stream_inserter, stream_collector, compare_packets, mask_last_be
 
 class TestPacket(unittest.TestCase):
     def loopback_test(self, dw, seed=42, with_last_be=False, debug_print=False):

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -22,6 +22,16 @@ def grouper(iterable, n, fillvalue=None):
     args = [iter(iterable)] * n
     return itertools.zip_longest(*args, fillvalue=fillvalue)
 
+def mask_last_be(dw, data, last_be):
+    masked_data = 0
+
+    for byte in range(dw // 8):
+        if 2**byte > last_be:
+            break
+        masked_data |= data & (0xFF << (byte * 8))
+
+    return masked_data
+
 class StreamPacket:
     def __init__(self, data, params={}):
         # Data must be a list of bytes
@@ -251,6 +261,7 @@ def stream_collector(
                 if (yield source.last) == 1:
                     read_last = True
                     if hasattr(source, "last_be") and \
+                       dw != 8 and \
                        2**byte > (yield source.last_be):
                         break
                 collected_bytes += [((data >> (byte * 8)) & 0xFF)]


### PR DESCRIPTION
As we have a certain crc value for a complete valid packet, additional 0 bytes lead to a predictable new crc value. Thus, for reception, we can only use a single, wide, engine and blank out the invalid bytes. Then compare it against a precomputed expected crc value for this last_be value.

To be certain that this works, add a test to verify it.

While using the test, I noticed that 16 bit support with last_be is completely broken.

64 bits also don't work with the test case, as a new packet can arrive which the old one isn't fully processed in checker, but this *might* not be a real issue on hardware.