### PR TITLE
Titanium LVDS 1000BaseX Cleanup.

### DIFF
--- a/liteeth/phy/titanium_lvds_1000basex.py
+++ b/liteeth/phy/titanium_lvds_1000basex.py
@@ -213,6 +213,14 @@ class Decoder8b10bIdleChecker(LiteXModule):
 # Efinix Aligner -----------------------------------------------------------------------------------
 
 class EfinixAligner(LiteXModule):
+    """
+    Sliding‑window byte aligner.
+
+    A 30‑bit window (`data`) is scanned by ten overlapping ``Decoder8b10bChecker`` instances
+    (bit offsets 0‑9).  When *align* is asserted, the highest offset that passes the checker is
+    loaded into *pos*, telling downstream logic how many bits to shift to achieve proper 10‑bit
+    boundary alignment.
+    """
     def __init__(self, align):
         self.data = data = Signal(30)
         self.pos  = pos  = Signal(4)

--- a/liteeth/phy/titanium_lvds_1000basex.py
+++ b/liteeth/phy/titanium_lvds_1000basex.py
@@ -190,10 +190,10 @@ class Decoder8b10bChecker(LiteXModule):
 
 class Decoder8b10bIdleChecker(LiteXModule):
     """
-    Detects idle ordered sets (/I1/: K28.5 D5.6 or /I2/: K28.5 D16.2).
+    Detects the /I2/ idle ordered set (K28.5 followed by D16.2).
 
     The two embedded combinatorial decoders analyse the lower and upper 10-bit symbols; *idle* is
-    asserted for one cycle when the pair is an idle set and both symbols are valid.
+    asserted for one cycle when the pair is exactly “K28.5, D16.2” and both symbols are valid.
     """
     def __init__(self, data):
         self.idle = Signal()
@@ -208,11 +208,10 @@ class Decoder8b10bIdleChecker(LiteXModule):
         ]
         self.submodules += decoders
 
-        # Idle Check (either /I1/ or /I2/).
+        # Idle I2 Check.
         _decoder0_k28_5 = ~decoders[0].invalid &  decoders[0].k & (decoders[0].d == K(28, 5))
         _decoder1_d16_2 = ~decoders[1].invalid & ~decoders[1].k & (decoders[1].d == D(16, 2))
-        _decoder1_d5_6  = ~decoders[1].invalid & ~decoders[1].k & (decoders[1].d == D(5, 6))
-        self.comb += self.idle.eq(_decoder0_k28_5 & (_decoder1_d16_2 | _decoder1_d5_6))
+        self.comb += self.idle.eq(_decoder0_k28_5 & _decoder1_d16_2)
 
 # Efinix Aligner -----------------------------------------------------------------------------------
 
@@ -249,7 +248,7 @@ class EfinixSerdesBuffer(LiteXModule):
 
     * Gathers variable-length slices from the deserializer.
     * Aligns them on a 10-bit boundary (``EfinixAligner``).
-    * Strips /I1/ or /I2/ idle ordered-sets when buffer fill is high.
+    * Strips /I2/ idle ordered-sets when buffer fill is high.
     * Delivers one aligned symbol per cycle when data is ready.
 
     Parameters:

--- a/liteeth/phy/titanium_lvds_1000basex.py
+++ b/liteeth/phy/titanium_lvds_1000basex.py
@@ -284,7 +284,7 @@ class EfinixSerdesBuffer(LiteXModule):
 
         # Idle Checker.
         # -------------
-        self.idle_checker = idle_checker = Decoder8b10bIdleChecker(data=data_out_aligner[:20])
+        self.idle_checker = idle_checker = Decoder8b10bIdleChecker(data=data_out_aligner[word_bits:])
 
         # Append Logic (comb, small case for data_in_len).
         # ------------------------------------------------

--- a/liteeth/phy/titanium_lvds_1000basex.py
+++ b/liteeth/phy/titanium_lvds_1000basex.py
@@ -148,6 +148,16 @@ class EfinixSerdesDiffRx(LiteXModule):
 # Decoder 8b10b Checker ----------------------------------------------------------------------------
 
 class Decoder8b10bChecker(LiteXModule):
+    """
+    Fast plausibility checker for a 20‑bit word (two 10‑bit symbols).
+
+    * Verifies each symbol’s pop‑count (must contain 4–6 ones).
+    * Checks combined running‑disparity window (total ones 9–11).
+    * Disallows a comma /K28/ character in the **second** symbol.
+
+    The output *valid* is asserted when **all** criteria pass, meaning the word could be a legally
+    encoded 8b/10b lane byte.
+    """
     def __init__(self, data_in, valid):
         # Symbol popcounts must be 4/5/6 ones.
         sym0_ones = Signal(4)
@@ -175,6 +185,12 @@ class Decoder8b10bChecker(LiteXModule):
 # Decoder 8b10b Idle Checker -----------------------------------------------------------------------
 
 class Decoder8b10bIdleChecker(LiteXModule):
+    """
+    Detects the /I2/ idle ordered set (K28.5 followed by D16.2).
+
+    The two embedded combinatorial decoders analyse the lower and upper 10‑bit symbols; *idle_i2* is
+    asserted for one cycle when the pair is exactly “K28.5, D16.2” and both symbols are valid.
+    """
     def __init__(self, data_in):
         self.idle_i2 = Signal()
 

--- a/liteeth/phy/titanium_lvds_1000basex.py
+++ b/liteeth/phy/titanium_lvds_1000basex.py
@@ -522,17 +522,19 @@ class EfinixTitaniumLVDS_1000BASEX(LiteXModule):
 
         # TX.
         # ---
-        self.tx = EfinixSerdesDiffTx(
+        tx = EfinixSerdesDiffTx(
             data     = pcs.tbi_tx,
             tx_p     = pads.tx_p,
             tx_n     = pads.tx_n,
             clk      = self.crg.cd_eth_tx.clk,
             fast_clk = self.crg.cd_eth_trx_fast.clk,
         )
+        self.tx = ClockDomainsRenamer("eth_tx")(tx)
+
 
         # RX.
         # ---
-        self.rx = ClockDomainsRenamer("eth_rx")(EfinixSerdesDiffRxClockRecovery(
+        rx = EfinixSerdesDiffRxClockRecovery(
             rx_p       = pads.rx_p,
             rx_n       = pads.rx_n,
             data       = pcs.tbi_rx,
@@ -542,8 +544,9 @@ class EfinixTitaniumLVDS_1000BASEX(LiteXModule):
             fast_clk   = self.crg.cd_eth_trx_fast.clk,
             delay      = rx_delay,
             rx_term    = rx_term,
-        ))
-        self.comb += self.rx.reset.eq(pcs.restart)
+        )
+        self.comb += rx.reset.eq(pcs.restart)
+        self.rx = ClockDomainsRenamer("eth_rx")(rx)
 
         # I2C.
         # ----

--- a/liteeth/phy/titanium_lvds_1000basex.py
+++ b/liteeth/phy/titanium_lvds_1000basex.py
@@ -602,7 +602,7 @@ class EfinixTitaniumLVDS_1000BASEX(LiteXModule):
         # ---------
         if crg is None:
             assert refclk is not None
-            self.crg = EfinixSerdesClocking(
+            self.crg = crg = EfinixSerdesClocking(
                 refclk      = refclk,
                 refclk_freq = refclk_freq,
             )
@@ -615,8 +615,8 @@ class EfinixTitaniumLVDS_1000BASEX(LiteXModule):
             data     = pcs.tbi_tx,
             tx_p     = pads.tx_p,
             tx_n     = pads.tx_n,
-            clk      = self.crg.cd_eth_tx.clk,
-            fast_clk = self.crg.cd_eth_trx_fast.clk,
+            clk      = crg.cd_eth_tx.clk,
+            fast_clk = crg.cd_eth_trx_fast.clk,
         )
         self.tx = ClockDomainsRenamer("eth_tx")(tx)
 
@@ -629,8 +629,8 @@ class EfinixTitaniumLVDS_1000BASEX(LiteXModule):
             data       = pcs.tbi_rx,
             data_valid = pcs.tbi_rx_ce,
             align      = pcs.align,
-            clk        = self.crg.cd_eth_rx.clk,
-            fast_clk   = self.crg.cd_eth_trx_fast.clk,
+            clk        = crg.cd_eth_rx.clk,
+            fast_clk   = crg.cd_eth_trx_fast.clk,
             delay      = rx_delay,
             rx_term    = rx_term,
         )

--- a/liteeth/phy/titanium_lvds_1000basex.py
+++ b/liteeth/phy/titanium_lvds_1000basex.py
@@ -240,14 +240,6 @@ class EfinixAligner(LiteXModule):
         for offset in range(10):
               self.sync += If(align & checkers[offset].valid, shift.eq(offset))
 
-# Efinix Serdes Diff Rx Dummy ----------------------------------------------------------------------
-
-class EfinixSerdesDiffRxDummy(LiteXModule):
-    def __init__(self, data):
-        self.data = Signal(10)
-
-        self.comb += data.eq(self.data)
-
 # Efinix Serdes Buffer -----------------------------------------------------------------------------
 
 class EfinixSerdesBuffer(LiteXModule):
@@ -348,7 +340,11 @@ class EfinixSerdesDiffRxClockRecovery(LiteXModule):
             data_before = Signal(len(data))
 
             if dummy:
-                serdesrx = EfinixSerdesDiffRxDummy(_data[i][10:])
+                class EfinixSerdesRxDummy(LiteXModule):
+                    def __init__(self, data):
+                        self.data = Signal(10)
+                        self.comb += data.eq(self.data)
+                serdesrx = EfinixSerdesRxDummy(_data[i][10:])
             else:
                 serdesrx = EfinixSerdesDiffRx(
                     rx_p     = rx_p[i],

--- a/test/test_1000basex.py
+++ b/test/test_1000basex.py
@@ -36,14 +36,14 @@ class SimQuadDeser(LiteXModule):
         self.end = Signal()
 
         self.rx = rx = EfinixSerdesDiffRxClockRecovery(
-            Signal(4),
-            Signal(4),
-            self.data_out,
-            self.data_out_valid,
-            False,
-            None,
-            None,
-            dummy=True,
+            rx_p       = Signal(4),
+            rx_n       = Signal(4),
+            data       = self.data_out,
+            data_valid = self.data_out_valid,
+            align      = False,
+            clk        = None,
+            fast_clk   = None,
+            dummy      = True,
         )
 
         self.comb += [


### PR DESCRIPTION
This PR refactors the Titanium LVDS 1000BaseX  PHY to improve readability, consistency, and maintainability:

- Refactored Serdes TX/RX, buffer, and clock recovery for consistent style and reduced resources.
- Added descriptions, comments, constants, and signal sections for clarity.
- Improved TX/RX symmetry and standardized decoder arguments.
- Removed unused dynamic delay/DPA and debug modes to simplify code.
- Switched to LiteX's combinatorial Decoder to reduce custom code (https://github.com/enjoy-digital/litex/commit/e3a9bc3be506305cd84fc60051b8bccb1476c2b1)
- Increased EfinixSerdesBuffer from 1000 bit to 1200 bit which prevent random link up time. Link up was previously taking a random time (Generally 3s to 10s) and now always done in 3-4s without random blinking when outputting link up status to a led.

Resource usage is also lowered:

Tested with: ` ./efinix_ti375_c529_dev_kit.py --with-etherbone --eth-phy=sfp0/1 --build --load`

< Before | After >
<img width="960" height="340" alt="image" src="https://github.com/user-attachments/assets/045c06cc-50d9-4af1-8c30-f2391315b0bf" />

Integration target have also been improved a bit: https://github.com/litex-hub/litex-boards/commit/d6666343c9ee7bc91d1d26e1f94af613a1e7ab21 and both SFPs have been tested successfully.
