### PR TITLE
Implementing RoCEv2

### DIFF
--- a/liteeth/common.py
+++ b/liteeth/common.py
@@ -80,6 +80,7 @@ ipv4_header_fields = {
     "version":        HeaderField(0,  4,  4),
     "total_length":   HeaderField(2,  0, 16),
     "identification": HeaderField(4,  0, 16),
+    "dont_fragment":  HeaderField(6,  6,  1),
     "ttl":            HeaderField(8,  0,  8),
     "protocol":       HeaderField(9,  0,  8),
     "checksum":       HeaderField(10, 0, 16),

--- a/liteeth/common.py
+++ b/liteeth/common.py
@@ -16,6 +16,8 @@ from litex.soc.interconnect.csr import *
 
 from litex.soc.interconnect.packet import Header, HeaderField
 
+from enum import IntEnum, IntFlag
+
 # Ethernet Constants -------------------------------------------------------------------------------
 
 eth_mtu_default      = 1530
@@ -110,6 +112,529 @@ udp_header_fields = {
     "checksum": HeaderField(6, 0, 16)
 }
 udp_header = Header(udp_header_fields, udp_header_length, swap_field_bytes=True)
+
+# BTH Constants/Header --------------------------------------------------------------------------
+bth_header_length = 12
+bth_header_fields = {
+    "opcode":  HeaderField(0, 0, 8),  # Opcode
+    "se":      HeaderField(1, 7, 1),  # Solicited Event
+    "m":       HeaderField(1, 6, 1),  # MigReq
+    "pad":     HeaderField(1, 4, 2),  # Pad Count
+    "tver":    HeaderField(1, 0, 4),  # Transport Header Version
+    "p_key":   HeaderField(2, 0, 16), # Partition Key
+#   (reserved)
+    "dest_qp": HeaderField(5, 0, 24), # Destination QP
+    "a":       HeaderField(8, 7, 1),  # Acknowledge Request
+#   (reserved)
+    "psn":     HeaderField(9, 0, 24)  # Packet Sequence Number
+}
+bth_header = Header(bth_header_fields, bth_header_length, swap_field_bytes=True)
+
+reth_header_length = 16
+reth_header_fields = {
+    "va":      HeaderField(0,  0, 64), # Virtual Address
+    "r_key":   HeaderField(8,  0, 32), # Remote Key
+    "dma_len": HeaderField(12, 0, 32), # DMA Length
+}
+reth_header = Header(reth_header_fields, reth_header_length, swap_field_bytes=True)
+
+atomiceth_header_length = 28
+atomiceth_header_fields = {
+    "va":       HeaderField(0,  0, 64), # Virtual Address
+    "r_key":    HeaderField(8,  0, 32), # Remote Key
+    "sa_data":  HeaderField(12, 0, 64), # Swap (or Add) Data
+    "cmp_data": HeaderField(20, 0, 64)  # Compare Data
+}
+atomiceth_header = Header(atomiceth_header_fields, atomiceth_header_length, swap_field_bytes=True)
+
+aeth_header_length = 4
+aeth_header_fields = {
+    "syndrome": HeaderField(0, 0, 8),  # Syndrome
+    "msn":      HeaderField(1, 0, 24), # Message Sequence Number
+}
+aeth_header = Header(aeth_header_fields, aeth_header_length, swap_field_bytes=True)
+
+atomicacketh_header_length = 8
+atomicacketh_header_fields = {
+    "or_rem_data": HeaderField(0, 0, 64), # Original Remote Data
+}
+atomicacketh_header = Header(atomicacketh_header_fields, atomicacketh_header_length, swap_field_bytes=True)
+
+deth_header_length = 8
+deth_header_fields = {
+    "q_key":  HeaderField(0, 0, 32), # Queue Key
+#   (reserved)
+    "src_qp": HeaderField(5, 0, 24), # Source QP
+}
+deth_header = Header(deth_header_fields, deth_header_length, swap_field_bytes=True)
+
+immdt_header_length = 4
+immdt_header_fields = {
+    "immdt": HeaderField(0, 0, 32) # Immediate Data
+}
+immdt_header = Header(immdt_header_fields, immdt_header_length, swap_field_bytes=True)
+
+ieth_header_length = 4
+ieth_header_fields = {
+    "r_key": HeaderField(0, 0, 32) # Remote Key
+}
+ieth_header = Header(ieth_header_fields, ieth_header_length, swap_field_bytes=True)
+
+mad_header_length = 24
+mad_header_fields = {
+    "BaseVersion":       HeaderField(0, 0, 8),
+    "MgmtClass":         HeaderField(1, 0, 8),
+    "ClassVersion":      HeaderField(2, 0, 8),
+    "R":                 HeaderField(3, 7, 1),
+    "Method":            HeaderField(3, 0, 7),
+    "Status":            HeaderField(4, 0, 16),
+#   "ClassSpecific":     HeaderField(6, 0, 16), Unused
+    "TransactionID":     HeaderField(8, 0, 64),
+    "AttributeID":       HeaderField(16, 0, 16),
+    "AttributeModifier": HeaderField(20, 0, 32),
+}
+mad_header = Header(mad_header_fields, mad_header_length, swap_field_bytes=True)
+
+# ClassPortInfo
+cpi_header_length = 72
+cpi_header_fields = {
+    "BaseVersion":       HeaderField(0,  0, 8),
+    "ClassVersion":      HeaderField(1,  0, 8),
+    "CapabilityMask":    HeaderField(2,  0, 16),
+    "CapabilityMask2":   HeaderField(4,  0, 27),
+    "RespTimeValue":     HeaderField(7,  0, 5),
+#     "RedirectGID":       HeaderField(8,  0, 128),
+#     "RedirectTC":        HeaderField(24, 0, 8),
+#     "RedirectSL":        HeaderField(25, 4, 4),
+#     "RedirectFL":        HeaderField(25, 0, 20),
+#     "RedirectLID":       HeaderField(28, 0, 16),
+#     "RedirectP_Key":     HeaderField(30, 0, 16),
+# #   (reserved)
+#     "RedirectQP":        HeaderField(33, 0, 24),
+#     "RedirectQ_Key":     HeaderField(36, 0, 32),
+#     "TrapGID":           HeaderField(40, 0, 128),
+#     "TrapTC":            HeaderField(56, 0, 8),
+#     "TrapSL":            HeaderField(57, 0, 4),
+#     "TrapFL":            HeaderField(57, 4, 20),
+#     "TrapLID":           HeaderField(60, 0, 16),
+#     "TrapP_Key":         HeaderField(62, 0, 16),
+#     "TrapHL":            HeaderField(64, 0, 8),
+#     "TrapQP":            HeaderField(65, 0, 24),
+#     "TrapQ_Key":         HeaderField(68, 0, 32),
+}
+cpi_header = Header(cpi_header_fields, cpi_header_length, swap_field_bytes=True)
+
+req_header_length = 140
+req_header_fields = {
+    "Local_Communication_ID":      HeaderField(0,   0, 32),
+#   (reserved)
+    "ServiceID":                   HeaderField(8,   0, 64),
+    "Local_CA_GUID":               HeaderField(16,  0, 64),
+#   (reserved)
+    "Local_Q_Key":                 HeaderField(28,  0, 32),
+    "Local_QPN":                   HeaderField(32,  0, 24),
+    "Responder_Resources":         HeaderField(35,  0, 8),
+    # "Local_EECN":                  HeaderField(36,  0, 24),
+    "Initiator_Depth":             HeaderField(39,  0, 8),
+    # "Remote_EECN":                 HeaderField(40,  0, 24),
+    "Remote_CM_Response_Timeout":  HeaderField(43,  3, 5),
+    "Transport_Service_Type":      HeaderField(43,  1, 2),
+    # "End_to_End_Flow_Control":     HeaderField(43,  0, 1),
+    "Starting_PSN":                HeaderField(44,  0, 24),
+    "Local_CM_Response_Timeout":   HeaderField(47,  3, 5),
+    "Retry_Count":                 HeaderField(47,  0, 3),
+    "Partition_Key":               HeaderField(48,  0, 16),
+    "Path_Packet_Payload_MTU":     HeaderField(50,  4, 4),
+    # "RDC_Exists":                  HeaderField(50,  3, 1),
+    "RNR_Retry_Count":             HeaderField(50,  0, 3),
+    "Max_CM_Retries":              HeaderField(51,  4, 4),
+    # "SRQ":                         HeaderField(51,  3, 1),
+#   (reserved)
+###################################
+#   "Primary_Local_Port_LID":      HeaderField(52,  0, 16), # ignored RoCEv2
+#   "Primary_Remote_Port_LID":     HeaderField(54,  0, 16), # ignored RoCEv2
+    "Primary_Local_Port_GID":      HeaderField(56,  0, 128),
+    "Primary_Remote_Port_GID":     HeaderField(72,  0, 128),
+    # "Primary_Flow_Label":          HeaderField(88,  0, 20),
+#   (reserved)
+    # "Primary_Packet_Rate":         HeaderField(91,  0, 6),
+    # "Primary_Traffic_Class":       HeaderField(92,  0, 8),
+    # "Primary_Hop_Limit":           HeaderField(93,  0, 8),
+    # "Primary_SL":                  HeaderField(94,  4, 4),
+    # "Primary_Subnet_Local":        HeaderField(94,  3, 1),
+#   (reserved)
+    "Primary_Local_ACK_Timeout":   HeaderField(95,  3, 5),
+#   (reserved)
+###################################
+#   "Alternate_Local_Port_LID":    HeaderField(96,  0, 16), # ignored RoCEv2
+#   "Alternate_Remote_Port_LID":   HeaderField(98,  0, 16), # ignored RoCEv2
+    # "Alternate_Local_Port_GID":    HeaderField(100, 0, 128),
+    # "Alternate_Remote_Port_GID":   HeaderField(116, 0, 128),
+    # "Alternate_Flow_Label":        HeaderField(132, 0, 20),
+#   (reserved)
+    # "Alternate_Packet_Rate":       HeaderField(135, 0, 6),
+    # "Alternate_Traffic_Class":     HeaderField(136, 0, 8),
+    # "Alternate_Hop_Limit":         HeaderField(137, 0, 8),
+    # "Alternate_SL":                HeaderField(138, 4, 4),
+###################################
+    # "Alternate_Subnet_Local":      HeaderField(138, 3, 1),
+#   (reserved)
+###################################
+    # "Alternate_Local_ACK_Timeout": HeaderField(139, 3, 5),
+#   (reserved)
+}
+req_header = Header(req_header_fields, req_header_length, swap_field_bytes=True)
+
+mra_header_length = 10
+mra_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+    "Message_MRAed":           HeaderField(8, 0, 2),
+#   (reserved)
+    "ServiceTimeout":          HeaderField(9, 0, 5),
+#   (reserved)
+}
+mra_header = Header(mra_header_fields, mra_header_length, swap_field_bytes=True)
+
+rej_header_length = 84
+rej_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+    "Message_REJected":        HeaderField(8, 0, 2),
+#   (reserved)
+    "Reject_Info_Length":      HeaderField(9, 0, 7),
+#   (reserved)
+    "Reason":                  HeaderField(10, 0, 16),
+    # "ARI":                     HeaderField(12, 0, 576),
+}
+rej_header = Header(rej_header_fields, rej_header_length, swap_field_bytes=True)
+
+rep_header_length = 36
+rep_header_fields = {
+    "Local_Communication_ID":  HeaderField(0,  0, 32),
+    "Remote_Communication_ID": HeaderField(4,  0, 32),
+    "Local_Q_Key":             HeaderField(8,  0, 32),
+    "Local_QPN":               HeaderField(12, 0, 24),
+#   (reserved)
+    # "Local_EE_Context_Number": HeaderField(16, 0, 24),
+#   (reserved)
+    "Starting_PSN":            HeaderField(20, 0, 24),
+#   (reserved)
+    "Responder_Resources":     HeaderField(24, 0, 8),
+    "Initiator_Depth":         HeaderField(25, 0, 8),
+    "Target_ACK_Delay":        HeaderField(26, 3, 5),
+    # "Failover_Accepted":       HeaderField(26, 1, 2),
+    # "End_To_End_Flow_Control": HeaderField(26, 0, 1),
+    "RNR_Retry_Count":         HeaderField(27, 5, 3),
+    # "SRQ":                     HeaderField(27, 4, 1),
+#   (reserved)
+    # "Local_CA_GUID":           HeaderField(28, 0, 64),
+}
+rep_header = Header(rep_header_fields, rep_header_length, swap_field_bytes=True)
+
+rtu_header_length = 8
+rtu_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+}
+rtu_header = Header(rtu_header_fields, rtu_header_length, swap_field_bytes=True)
+
+dreq_header_length = 12
+dreq_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+    "Remote_QPN_EECN":         HeaderField(8, 0, 24),
+#   (reserved)
+}
+dreq_header = Header(dreq_header_fields, dreq_header_length, swap_field_bytes=True)
+
+drep_header_length = 8
+drep_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+}
+drep_header = Header(drep_header_fields, drep_header_length, swap_field_bytes=True)
+
+ipcm_header_length = 36
+ipcm_header_fields = {
+    "IP_CM_Minor_Version"  : HeaderField(0, 4, 4),
+    "IP_CM_Major_Version"  : HeaderField(0, 0, 4),
+    "IP_CM_IP_Version"     : HeaderField(1, 4, 4),
+#   (reserved)
+    "IP_CM_Source_Port"    : HeaderField(2, 0, 16),
+    "IP_CM_Source_IP"      : HeaderField(4, 0, 128),
+    "IP_CM_Destination_IP" : HeaderField(20, 0, 128),
+}
+ipcm_header = Header(ipcm_header_fields, ipcm_header_length, swap_field_bytes=True)
+
+
+class MAD_ATTRIB_ID(IntEnum):
+    ClassPortInfo         = 0x0001 ## unused
+    ConnectRequest        = 0x0010 # req
+    MsgRcptAck            = 0x0011 ## unused
+    ConnectReject         = 0x0012 # rej
+    ConnectReply          = 0x0013 # rep
+    ReadyToUse            = 0x0014 # rtu
+    DisconnectRequest     = 0x0015 # dreq
+    DisconnectReply       = 0x0016 # drep
+    ServiceIDResReq       = 0x0017 ## unused
+    ServiceIDResReqResp   = 0x0018 ## unused
+    LoadAlternatePath     = 0x0019 ## unused
+    AlternatePathResponse = 0x000A ## unused
+
+class CM_Methods(IntEnum):
+    ComMgtGet     = 0x01
+    ComMgtSet     = 0x02
+    ComMgtGetResp = 0x81
+    ComMgtSend    = 0x03
+
+mad_cm_opmap = {
+    MAD_ATTRIB_ID.ClassPortInfo         : 0b00000001,
+    MAD_ATTRIB_ID.ConnectRequest        : 0b00000010,
+    MAD_ATTRIB_ID.MsgRcptAck            : 0b00000100,
+    MAD_ATTRIB_ID.ConnectReject         : 0b00001000,
+    MAD_ATTRIB_ID.ConnectReply          : 0b00010000,
+    MAD_ATTRIB_ID.ReadyToUse            : 0b00100000,
+    MAD_ATTRIB_ID.DisconnectRequest     : 0b01000000,
+    MAD_ATTRIB_ID.DisconnectReply       : 0b10000000,
+    MAD_ATTRIB_ID.ServiceIDResReq       : 0b00000000,
+    MAD_ATTRIB_ID.ServiceIDResReqResp   : 0b00000000,
+    MAD_ATTRIB_ID.LoadAlternatePath     : 0b00000000,
+    MAD_ATTRIB_ID.AlternatePathResponse : 0b00000000,
+}
+mad_cm_headers = [mad_header, cpi_header, req_header, mra_header, rej_header, rep_header, rtu_header, dreq_header, drep_header]
+
+class QP_CONN_TYPE(IntEnum):
+    RC = 0b000
+    UC = 0b001 # Not implemented
+    RD = 0b010 # Not implemented
+    UD = 0b011
+
+class BTH_OPCODE_OP(IntEnum):
+    SEND_First                     = 0b00000
+    SEND_Middle                    = 0b00001
+    SEND_Last                      = 0b00010
+    SEND_Last_with_Immediate       = 0b00011
+    SEND_Only                      = 0b00100
+    SEND_Only_with_Immediate       = 0b00101
+    RDMA_WRITE_First               = 0b00110
+    RDMA_WRITE_Middle              = 0b00111
+    RDMA_WRITE_Last                = 0b01000
+    RDMA_WRITE_Last_with_Immediate = 0b01001
+    RDMA_WRITE_Only                = 0b01010
+    RDMA_WRITE_Only_with_Immediate = 0b01011
+    RDMA_READ_Request              = 0b01100
+    RDMA_READ_response_First       = 0b01101
+    RDMA_READ_response_Middle      = 0b01110
+    RDMA_READ_response_Last        = 0b01111
+    RDMA_READ_response_Only        = 0b10000
+    Acknowledge                    = 0b10001
+    # ATOMIC_Acknowledge             = 0b10010
+    # CmpSwap                        = 0b10011
+    # FetchAdd                       = 0b10100
+    # SEND_Last_with_Invalidate      = 0b10110
+    # SEND_Only_with_Invalidate      = 0b10111
+
+class BTH_OPCODE:
+    class RC(IntEnum):
+        SEND_First                     = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_First
+        SEND_Middle                    = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Middle
+        SEND_Last                      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Last
+        SEND_Last_with_Immediate       = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Last_with_Immediate
+        SEND_Only                      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Only
+        SEND_Only_with_Immediate       = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Only_with_Immediate
+        RDMA_WRITE_First               = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_First
+        RDMA_WRITE_Middle              = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Middle
+        RDMA_WRITE_Last                = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Last
+        RDMA_WRITE_Last_with_Immediate = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate
+        RDMA_WRITE_Only                = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Only
+        RDMA_WRITE_Only_with_Immediate = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+        RDMA_READ_Request              = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_Request
+        RDMA_READ_response_First       = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_response_First
+        RDMA_READ_response_Middle      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_response_Middle
+        RDMA_READ_response_Last        = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_response_Last
+        RDMA_READ_response_Only        = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_response_Only
+        Acknowledge                    = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.Acknowledge
+        # ATOMIC_Acknowledge             = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.ATOMIC_Acknowledge
+        # CmpSwap                        = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.CmpSwap
+        # FetchAdd                       = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.FetchAdd
+        # SEND_Last_with_Invalidate      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Last_with_Invalidate
+        # SEND_Only_with_Invalidate      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Only_with_Invalidate
+    class UD(IntEnum):
+        SEND_Only                      = (QP_CONN_TYPE.UD << 5) + BTH_OPCODE_OP.SEND_Only
+        SEND_Only_with_Immediate       = (QP_CONN_TYPE.UD << 5) + BTH_OPCODE_OP.SEND_Only_with_Immediate
+
+class ExtraHeaderFlag(IntFlag):
+    DETH  = 1 << 0
+    RETH  = 1 << 1
+    AETH  = 1 << 2
+    ImmDt = 1 << 3
+
+IBT_opmap = {
+    # Reliable connection
+    BTH_OPCODE.RC.SEND_First                     : 0,
+    BTH_OPCODE.RC.SEND_Middle                    : 0,
+    BTH_OPCODE.RC.SEND_Last                      : 0,
+    BTH_OPCODE.RC.SEND_Last_with_Immediate       : ExtraHeaderFlag.ImmDt,
+    BTH_OPCODE.RC.SEND_Only                      : 0,
+    BTH_OPCODE.RC.SEND_Only_with_Immediate       : ExtraHeaderFlag.ImmDt,
+    BTH_OPCODE.RC.RDMA_WRITE_First               : ExtraHeaderFlag.RETH,
+    BTH_OPCODE.RC.RDMA_WRITE_Middle              : 0,
+    BTH_OPCODE.RC.RDMA_WRITE_Last                : 0,
+    BTH_OPCODE.RC.RDMA_WRITE_Last_with_Immediate : ExtraHeaderFlag.ImmDt,
+    BTH_OPCODE.RC.RDMA_WRITE_Only                : ExtraHeaderFlag.RETH,
+    BTH_OPCODE.RC.RDMA_WRITE_Only_with_Immediate : ExtraHeaderFlag.RETH | ExtraHeaderFlag.ImmDt,
+    BTH_OPCODE.RC.RDMA_READ_Request              : ExtraHeaderFlag.RETH,
+    BTH_OPCODE.RC.RDMA_READ_response_First       : ExtraHeaderFlag.AETH,
+    BTH_OPCODE.RC.RDMA_READ_response_Middle      : 0,
+    BTH_OPCODE.RC.RDMA_READ_response_Last        : ExtraHeaderFlag.AETH,
+    BTH_OPCODE.RC.RDMA_READ_response_Only        : ExtraHeaderFlag.AETH,
+    BTH_OPCODE.RC.Acknowledge                    : ExtraHeaderFlag.AETH,
+
+    # Unreliable datagram - necessary for communication establishment
+    BTH_OPCODE.UD.SEND_Only                      : ExtraHeaderFlag.DETH,
+    BTH_OPCODE.UD.SEND_Only_with_Immediate       : ExtraHeaderFlag.DETH | ExtraHeaderFlag.ImmDt,
+}
+
+IBT_RC_OPS = [op.value & 0b11111 for op in BTH_OPCODE.RC]
+IBT_UD_OPS = [op.value & 0b11111 for op in BTH_OPCODE.UD]
+
+IBT_headers = [bth_header, deth_header, reth_header, aeth_header, immdt_header]
+# Complete RC list:
+# IBT_headers = [bth_header, deth_header, reth_header, atomiceth_header, aeth_header, atomicacketh_header, immdt_header, ieth_header]
+
+# Work request and work completion codes
+class WR_OPCODE(IntEnum):
+    SEND                = 0b00
+    RDMA_WRITE          = 0b01
+    RDMA_READ           = 0b10
+
+class WC:
+    class Status(IntEnum):
+        SUCCESS            = 0x00
+        LOC_LEN_ERR        = 0x01
+        LOC_QP_OP_ERR      = 0x02
+        # LOC_EEC_OP_ERR     = 0x03
+        LOC_PROT_ERR       = 0x04
+        WR_FLUSH_ERR       = 0x05
+        # MW_BIND_ERR        = 0x06
+        BAD_RESP_ERR       = 0x07
+        LOC_ACCESS_ERR     = 0x08
+        REM_INV_REQ_ERR    = 0x09
+        REM_ACCESS_ERR     = 0x0a
+        REM_OP_ERR         = 0x0b
+        RETRY_EXC_ERR      = 0x0c
+        RNR_RETRY_EXC_ERR  = 0x0d
+        LOC_RDD_VIOL_ERR   = 0x0e
+        # REM_INV_RD_REQ_ERR = 0x0f
+        # REM_ABORT_ERR      = 0x10
+        # INV_EECN_ERR       = 0x11
+        # INV_EEC_STATE_ERR  = 0x12
+        # FATAL_ERR          = 0x13
+        RESP_TIMEOUT_ERR   = 0x14
+        GENERAL_ERR        = 0x15
+        # TM_ERR             = 0x16
+        # TM_RNDV_INCOMPLETE = 0x17
+
+    class Opcode(IntEnum):
+        SEND               = 0
+        RDMA_WRITE         = 1
+        RDMA_READ          = 2
+        # COMP_SWAP        = 3
+        # FETCH_ADD        = 4
+        # BIND_MW          = 5
+        # LOCAL_INV        = 6
+        # TSO              = 7
+        FLUSH              = 8
+        # ATOMIC_WRITE     = 9
+
+        RECV               = 10
+        RECV_RDMA_WITH_IMM = 11
+
+ROCEV2_PORT = 4791 # Assigned by IANA
+DEFAULT_CM_Q_Key = 0x8001_0000
+DEFAULT_P_KEY = 0xffff
+
+PMTU_VALUES = {
+    1: 256,
+    2: 512,
+    3: 1024,
+    4: 2048,
+    5: 4096
+}
+PMTU_KEY = 3
+PMTU = PMTU_VALUES[PMTU_KEY] # Max size of transport layer packet payload
+PMTU_BITS = log2_int(PMTU)
+LOCAL_COMMUNICATION_ID = 0xfedcabed # MAD_CM Communication ID
+# Max number RDMA READ Requests that can be outstanding at once
+# (responder)
+RESPONDER_RESOURCES = 0x10
+# (requester)
+INITIATOR_DEPTH     = 0x10
+STARTING_PSN = 0xfedfed
+
+def add_params(description, params):
+    payload_layout = description.payload_layout.copy()
+    param_layout = description.param_layout.copy()
+    param_layout += params
+    return EndpointDescription(payload_layout, param_layout)
+
+def is_in(signal, array):
+    if len(array) == 0:
+        return 0
+    carray = [(el if isinstance(el, Constant) else Constant(el, len(signal))) for el in array]
+    v = signal == carray[0]
+    for e in carray[1:]:
+        v = v | (signal == e)
+    return v
+
+def is_in_flag(signal, array, flag, case=True):
+    bits = len(signal)
+    if not case:
+        return flag.eq(is_in(signal, array))
+    d = {Constant(el, bits): flag.eq(1) for el in array}
+    d.update({"default": flag.eq(0)})
+    return Case(signal, d)
+
+
+def is_in_do(signal, doarrays, *, default=None):
+    bits = len(signal)
+    out = []
+    d = {}
+    if isinstance(doarrays, tuple):
+        doarrays = [doarrays]
+    for array, do in doarrays:
+        helper = Signal()
+        for el in array:
+            if el in d:
+                d[el].append(helper.eq(1))
+            else:
+                d[el] = [helper.eq(1)]
+        out.append(If(helper, do))
+    cd = {Constant(key, bits): value for key, value in d.items()}
+    if not default:
+        default = []
+    cd.update({"default": default})
+    out.append(Case(signal, cd))
+    return out
+
+def IBT_get_header_length(opcode):
+    selection = IBT_opmap[opcode]
+    return IBT_headers[0].length + (sum([header.length for i, header in list(enumerate(IBT_headers))[1:] if (selection >> (i - 1)) & 1]))
+
+def IBT_header_length(opcode, header_length):
+    return Case(opcode, {
+        opcode: header_length.eq(
+            IBT_headers[0].length +
+            (
+                sum([header.length
+                for i, header in list(enumerate(IBT_headers))[1:]
+                if (selection >> (i - 1)) & 1])
+            )
+        )
+        for opcode, selection in IBT_opmap.items()
+    })
+
 
 # Etherbone Constants/Header -----------------------------------------------------------------------
 
@@ -271,6 +796,66 @@ def eth_udp_user_description(dw):
         ("error",   dw//8)
     ]
     return EndpointDescription(payload_layout, param_layout)
+
+# RoCEv2
+def eth_rocev2_description(dw):
+    # Get unique fields from the various headers
+    param_layout = list(set(sum([header.get_layout() for header in IBT_headers], []))) + [("length", 16)]
+    payload_layout = [("data", dw)]
+    return EndpointDescription(payload_layout, param_layout)
+
+def eth_mad_description(dw):
+    # Get unique fields from the various headers
+    param_layout = list(set(sum([header.get_layout() for header in mad_cm_headers], [])))
+    payload_layout = [("data", dw)]
+    return EndpointDescription(payload_layout, param_layout)
+
+def eth_ipcm_description(dw):
+    param_layout = ipcm_header.get_layout()
+    payload_layout = [("data", dw)]
+    return EndpointDescription(payload_layout, param_layout)
+
+def eth_rocev2_user_description(dw):
+    param_layout = [
+        ("dest_qp",  24),
+        ("immdt",    32),
+        ("length",   16)
+    ]
+    payload_layout = [("data", dw)]
+    return EndpointDescription(payload_layout, param_layout)
+
+def eth_rocev2_send_wr_description():
+    payload_layout = [
+        ("wr_opcode",  3),
+        ("w_immdt",    1),
+        ("immdt",     32),
+        ("va",        64),
+        ("dma_len",   32),
+        ("l_key",     32),
+        ("r_key",     32),
+        ("ack_req",    1)
+    ]
+    return EndpointDescription(payload_layout, [])
+
+def eth_rocev2_recv_wr_description():
+    payload_layout = [
+        ("va",        64),
+        ("dma_len",   32),
+        ("l_key",     32)
+    ]
+    return EndpointDescription(payload_layout, [])
+
+def eth_rocev2_cq_description():
+    payload_layout = [
+        ("status",     5),
+        ("opcode",     4),
+        ("w_immdt",    1),
+        ("immdt",     32),
+        ("dma_len",  32),
+        ("qp_num",    32),
+        ("src_qp",    32)
+    ]
+    return EndpointDescription(payload_layout, [])
 
 # Etherbone
 def eth_etherbone_packet_description(dw):

--- a/liteeth/common.py
+++ b/liteeth/common.py
@@ -16,6 +16,8 @@ from litex.soc.interconnect.csr import *
 
 from litex.soc.interconnect.packet import Header, HeaderField
 
+from enum import IntEnum, IntFlag
+
 # Ethernet Constants -------------------------------------------------------------------------------
 
 eth_mtu_default      = 1530
@@ -110,6 +112,532 @@ udp_header_fields = {
     "checksum": HeaderField(6, 0, 16)
 }
 udp_header = Header(udp_header_fields, udp_header_length, swap_field_bytes=True)
+
+# BTH Constants/Header --------------------------------------------------------------------------
+bth_header_length = 12
+bth_header_fields = {
+    "opcode":  HeaderField(0, 0, 8),  # Opcode
+    "se":      HeaderField(1, 7, 1),  # Solicited Event
+    "m":       HeaderField(1, 6, 1),  # MigReq
+    "pad":     HeaderField(1, 4, 2),  # Pad Count
+    "tver":    HeaderField(1, 0, 4),  # Transport Header Version
+    "p_key":   HeaderField(2, 0, 16), # Partition Key
+#   (reserved)
+    "dest_qp": HeaderField(5, 0, 24), # Destination QP
+    "a":       HeaderField(8, 7, 1),  # Acknowledge Request
+#   (reserved)
+    "psn":     HeaderField(9, 0, 24)  # Packet Sequence Number
+}
+bth_header = Header(bth_header_fields, bth_header_length, swap_field_bytes=True)
+
+reth_header_length = 16
+reth_header_fields = {
+    "va":      HeaderField(0,  0, 64), # Virtual Address
+    "r_key":   HeaderField(8,  0, 32), # Remote Key
+    "dma_len": HeaderField(12, 0, 32), # DMA Length
+}
+reth_header = Header(reth_header_fields, reth_header_length, swap_field_bytes=True)
+
+atomiceth_header_length = 28
+atomiceth_header_fields = {
+    "va":       HeaderField(0,  0, 64), # Virtual Address
+    "r_key":    HeaderField(8,  0, 32), # Remote Key
+    "sa_data":  HeaderField(12, 0, 64), # Swap (or Add) Data
+    "cmp_data": HeaderField(20, 0, 64)  # Compare Data
+}
+atomiceth_header = Header(atomiceth_header_fields, atomiceth_header_length, swap_field_bytes=True)
+
+aeth_header_length = 4
+aeth_header_fields = {
+    "syndrome": HeaderField(0, 0, 8),  # Syndrome
+    "msn":      HeaderField(1, 0, 24), # Message Sequence Number
+}
+aeth_header = Header(aeth_header_fields, aeth_header_length, swap_field_bytes=True)
+
+atomicacketh_header_length = 8
+atomicacketh_header_fields = {
+    "or_rem_data": HeaderField(0, 0, 64), # Original Remote Data
+}
+atomicacketh_header = Header(atomicacketh_header_fields, atomicacketh_header_length, swap_field_bytes=True)
+
+deth_header_length = 8
+deth_header_fields = {
+    "q_key":  HeaderField(0, 0, 32), # Queue Key
+#   (reserved)
+    "src_qp": HeaderField(5, 0, 24), # Source QP
+}
+deth_header = Header(deth_header_fields, deth_header_length, swap_field_bytes=True)
+
+immdt_header_length = 4
+immdt_header_fields = {
+    "immdt": HeaderField(0, 0, 32) # Immediate Data
+}
+immdt_header = Header(immdt_header_fields, immdt_header_length, swap_field_bytes=True)
+
+ieth_header_length = 4
+ieth_header_fields = {
+    "r_key": HeaderField(0, 0, 32) # Remote Key
+}
+ieth_header = Header(ieth_header_fields, ieth_header_length, swap_field_bytes=True)
+
+mad_header_length = 24
+mad_header_fields = {
+    "BaseVersion":       HeaderField(0, 0, 8),
+    "MgmtClass":         HeaderField(1, 0, 8),
+    "ClassVersion":      HeaderField(2, 0, 8),
+    "R":                 HeaderField(3, 7, 1),
+    "Method":            HeaderField(3, 0, 7),
+    "Status":            HeaderField(4, 0, 16),
+#   "ClassSpecific":     HeaderField(6, 0, 16), Unused
+    "TransactionID":     HeaderField(8, 0, 64),
+    "AttributeID":       HeaderField(16, 0, 16),
+    "AttributeModifier": HeaderField(20, 0, 32),
+}
+mad_header = Header(mad_header_fields, mad_header_length, swap_field_bytes=True)
+
+# ClassPortInfo
+cpi_header_length = 72
+cpi_header_fields = {
+    "BaseVersion":       HeaderField(0,  0, 8),
+    "ClassVersion":      HeaderField(1,  0, 8),
+    "CapabilityMask":    HeaderField(2,  0, 16),
+    "CapabilityMask2":   HeaderField(4,  0, 27),
+    "RespTimeValue":     HeaderField(7,  0, 5),
+#     "RedirectGID":       HeaderField(8,  0, 128),
+#     "RedirectTC":        HeaderField(24, 0, 8),
+#     "RedirectSL":        HeaderField(25, 4, 4),
+#     "RedirectFL":        HeaderField(25, 0, 20),
+#     "RedirectLID":       HeaderField(28, 0, 16),
+#     "RedirectP_Key":     HeaderField(30, 0, 16),
+# #   (reserved)
+#     "RedirectQP":        HeaderField(33, 0, 24),
+#     "RedirectQ_Key":     HeaderField(36, 0, 32),
+#     "TrapGID":           HeaderField(40, 0, 128),
+#     "TrapTC":            HeaderField(56, 0, 8),
+#     "TrapSL":            HeaderField(57, 0, 4),
+#     "TrapFL":            HeaderField(57, 4, 20),
+#     "TrapLID":           HeaderField(60, 0, 16),
+#     "TrapP_Key":         HeaderField(62, 0, 16),
+#     "TrapHL":            HeaderField(64, 0, 8),
+#     "TrapQP":            HeaderField(65, 0, 24),
+#     "TrapQ_Key":         HeaderField(68, 0, 32),
+}
+cpi_header = Header(cpi_header_fields, cpi_header_length, swap_field_bytes=True)
+
+req_header_length = 140
+req_header_fields = {
+    "Local_Communication_ID":      HeaderField(0,   0, 32),
+#   (reserved)
+    "ServiceID":                   HeaderField(8,   0, 64),
+    "Local_CA_GUID":               HeaderField(16,  0, 64),
+#   (reserved)
+    "Local_Q_Key":                 HeaderField(28,  0, 32),
+    "Local_QPN":                   HeaderField(32,  0, 24),
+    "Responder_Resources":         HeaderField(35,  0, 8),
+    # "Local_EECN":                  HeaderField(36,  0, 24),
+    "Initiator_Depth":             HeaderField(39,  0, 8),
+    # "Remote_EECN":                 HeaderField(40,  0, 24),
+    "Remote_CM_Response_Timeout":  HeaderField(43,  3, 5),
+    "Transport_Service_Type":      HeaderField(43,  1, 2),
+    # "End_to_End_Flow_Control":     HeaderField(43,  0, 1),
+    "Starting_PSN":                HeaderField(44,  0, 24),
+    "Local_CM_Response_Timeout":   HeaderField(47,  3, 5),
+    "Retry_Count":                 HeaderField(47,  0, 3),
+    "Partition_Key":               HeaderField(48,  0, 16),
+    "Path_Packet_Payload_MTU":     HeaderField(50,  4, 4),
+    # "RDC_Exists":                  HeaderField(50,  3, 1),
+    "RNR_Retry_Count":             HeaderField(50,  0, 3),
+    "Max_CM_Retries":              HeaderField(51,  4, 4),
+    # "SRQ":                         HeaderField(51,  3, 1),
+#   (reserved)
+###################################
+#   "Primary_Local_Port_LID":      HeaderField(52,  0, 16), # ignored RoCEv2
+#   "Primary_Remote_Port_LID":     HeaderField(54,  0, 16), # ignored RoCEv2
+    "Primary_Local_Port_GID":      HeaderField(56,  0, 128),
+    "Primary_Remote_Port_GID":     HeaderField(72,  0, 128),
+    # "Primary_Flow_Label":          HeaderField(88,  0, 20),
+#   (reserved)
+    # "Primary_Packet_Rate":         HeaderField(91,  0, 6),
+    # "Primary_Traffic_Class":       HeaderField(92,  0, 8),
+    # "Primary_Hop_Limit":           HeaderField(93,  0, 8),
+    # "Primary_SL":                  HeaderField(94,  4, 4),
+    # "Primary_Subnet_Local":        HeaderField(94,  3, 1),
+#   (reserved)
+    "Primary_Local_ACK_Timeout":   HeaderField(95,  3, 5),
+#   (reserved)
+###################################
+#   "Alternate_Local_Port_LID":    HeaderField(96,  0, 16), # ignored RoCEv2
+#   "Alternate_Remote_Port_LID":   HeaderField(98,  0, 16), # ignored RoCEv2
+    # "Alternate_Local_Port_GID":    HeaderField(100, 0, 128),
+    # "Alternate_Remote_Port_GID":   HeaderField(116, 0, 128),
+    # "Alternate_Flow_Label":        HeaderField(132, 0, 20),
+#   (reserved)
+    # "Alternate_Packet_Rate":       HeaderField(135, 0, 6),
+    # "Alternate_Traffic_Class":     HeaderField(136, 0, 8),
+    # "Alternate_Hop_Limit":         HeaderField(137, 0, 8),
+    # "Alternate_SL":                HeaderField(138, 4, 4),
+###################################
+    # "Alternate_Subnet_Local":      HeaderField(138, 3, 1),
+#   (reserved)
+###################################
+    # "Alternate_Local_ACK_Timeout": HeaderField(139, 3, 5),
+#   (reserved)
+}
+req_header = Header(req_header_fields, req_header_length, swap_field_bytes=True)
+
+mra_header_length = 10
+mra_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+    "Message_MRAed":           HeaderField(8, 0, 2),
+#   (reserved)
+    "ServiceTimeout":          HeaderField(9, 0, 5),
+#   (reserved)
+}
+mra_header = Header(mra_header_fields, mra_header_length, swap_field_bytes=True)
+
+rej_header_length = 84
+rej_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+    "Message_REJected":        HeaderField(8, 0, 2),
+#   (reserved)
+    "Reject_Info_Length":      HeaderField(9, 0, 7),
+#   (reserved)
+    "Reason":                  HeaderField(10, 0, 16),
+    # "ARI":                     HeaderField(12, 0, 576),
+}
+rej_header = Header(rej_header_fields, rej_header_length, swap_field_bytes=True)
+
+rep_header_length = 36
+rep_header_fields = {
+    "Local_Communication_ID":  HeaderField(0,  0, 32),
+    "Remote_Communication_ID": HeaderField(4,  0, 32),
+    "Local_Q_Key":             HeaderField(8,  0, 32),
+    "Local_QPN":               HeaderField(12, 0, 24),
+#   (reserved)
+    # "Local_EE_Context_Number": HeaderField(16, 0, 24),
+#   (reserved)
+    "Starting_PSN":            HeaderField(20, 0, 24),
+#   (reserved)
+    "Responder_Resources":     HeaderField(24, 0, 8),
+    "Initiator_Depth":         HeaderField(25, 0, 8),
+    "Target_ACK_Delay":        HeaderField(26, 3, 5),
+    # "Failover_Accepted":       HeaderField(26, 1, 2),
+    # "End_To_End_Flow_Control": HeaderField(26, 0, 1),
+    "RNR_Retry_Count":         HeaderField(27, 5, 3),
+    # "SRQ":                     HeaderField(27, 4, 1),
+#   (reserved)
+    # "Local_CA_GUID":           HeaderField(28, 0, 64),
+}
+rep_header = Header(rep_header_fields, rep_header_length, swap_field_bytes=True)
+
+rtu_header_length = 8
+rtu_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+}
+rtu_header = Header(rtu_header_fields, rtu_header_length, swap_field_bytes=True)
+
+dreq_header_length = 12
+dreq_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+    "Remote_QPN_EECN":         HeaderField(8, 0, 24),
+#   (reserved)
+}
+dreq_header = Header(dreq_header_fields, dreq_header_length, swap_field_bytes=True)
+
+drep_header_length = 8
+drep_header_fields = {
+    "Local_Communication_ID":  HeaderField(0, 0, 32),
+    "Remote_Communication_ID": HeaderField(4, 0, 32),
+}
+drep_header = Header(drep_header_fields, drep_header_length, swap_field_bytes=True)
+
+ipcm_header_length = 36
+ipcm_header_fields = {
+    "IP_CM_Minor_Version"  : HeaderField(0, 4, 4),
+    "IP_CM_Major_Version"  : HeaderField(0, 0, 4),
+    "IP_CM_IP_Version"     : HeaderField(1, 4, 4),
+#   (reserved)
+    "IP_CM_Source_Port"    : HeaderField(2, 0, 16),
+    "IP_CM_Source_IP"      : HeaderField(4, 0, 128),
+    "IP_CM_Destination_IP" : HeaderField(20, 0, 128),
+}
+ipcm_header = Header(ipcm_header_fields, ipcm_header_length, swap_field_bytes=True)
+
+
+class MAD_ATTRIB_ID(IntEnum):
+    ClassPortInfo         = 0x0001 ## unused
+    ConnectRequest        = 0x0010 # req
+    MsgRcptAck            = 0x0011 ## unused
+    ConnectReject         = 0x0012 # rej
+    ConnectReply          = 0x0013 # rep
+    ReadyToUse            = 0x0014 # rtu
+    DisconnectRequest     = 0x0015 # dreq
+    DisconnectReply       = 0x0016 # drep
+    ServiceIDResReq       = 0x0017 ## unused
+    ServiceIDResReqResp   = 0x0018 ## unused
+    LoadAlternatePath     = 0x0019 ## unused
+    AlternatePathResponse = 0x000A ## unused
+
+class CM_Methods(IntEnum):
+    ComMgtGet     = 0x01
+    ComMgtSet     = 0x02
+    ComMgtGetResp = 0x81
+    ComMgtSend    = 0x03
+
+mad_cm_opmap = {
+    MAD_ATTRIB_ID.ClassPortInfo         : 0b00000001,
+    MAD_ATTRIB_ID.ConnectRequest        : 0b00000010,
+    MAD_ATTRIB_ID.MsgRcptAck            : 0b00000100,
+    MAD_ATTRIB_ID.ConnectReject         : 0b00001000,
+    MAD_ATTRIB_ID.ConnectReply          : 0b00010000,
+    MAD_ATTRIB_ID.ReadyToUse            : 0b00100000,
+    MAD_ATTRIB_ID.DisconnectRequest     : 0b01000000,
+    MAD_ATTRIB_ID.DisconnectReply       : 0b10000000,
+    MAD_ATTRIB_ID.ServiceIDResReq       : 0b00000000,
+    MAD_ATTRIB_ID.ServiceIDResReqResp   : 0b00000000,
+    MAD_ATTRIB_ID.LoadAlternatePath     : 0b00000000,
+    MAD_ATTRIB_ID.AlternatePathResponse : 0b00000000,
+}
+mad_cm_headers = [mad_header, cpi_header, req_header, mra_header, rej_header, rep_header, rtu_header, dreq_header, drep_header]
+
+class QP_CONN_TYPE(IntEnum):
+    RC = 0b000
+    UC = 0b001 # Not implemented
+    RD = 0b010 # Not implemented
+    UD = 0b011
+
+class BTH_OPCODE_OP(IntEnum):
+    SEND_First                     = 0b00000
+    SEND_Middle                    = 0b00001
+    SEND_Last                      = 0b00010
+    SEND_Last_with_Immediate       = 0b00011
+    SEND_Only                      = 0b00100
+    SEND_Only_with_Immediate       = 0b00101
+    RDMA_WRITE_First               = 0b00110
+    RDMA_WRITE_Middle              = 0b00111
+    RDMA_WRITE_Last                = 0b01000
+    RDMA_WRITE_Last_with_Immediate = 0b01001
+    RDMA_WRITE_Only                = 0b01010
+    RDMA_WRITE_Only_with_Immediate = 0b01011
+    RDMA_READ_Request              = 0b01100
+    RDMA_READ_response_First       = 0b01101
+    RDMA_READ_response_Middle      = 0b01110
+    RDMA_READ_response_Last        = 0b01111
+    RDMA_READ_response_Only        = 0b10000
+    Acknowledge                    = 0b10001
+    # ATOMIC_Acknowledge             = 0b10010
+    # CmpSwap                        = 0b10011
+    # FetchAdd                       = 0b10100
+    # SEND_Last_with_Invalidate      = 0b10110
+    # SEND_Only_with_Invalidate      = 0b10111
+
+class BTH_OPCODE:
+    class RC(IntEnum):
+        SEND_First                     = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_First
+        SEND_Middle                    = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Middle
+        SEND_Last                      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Last
+        SEND_Last_with_Immediate       = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Last_with_Immediate
+        SEND_Only                      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Only
+        SEND_Only_with_Immediate       = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Only_with_Immediate
+        RDMA_WRITE_First               = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_First
+        RDMA_WRITE_Middle              = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Middle
+        RDMA_WRITE_Last                = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Last
+        RDMA_WRITE_Last_with_Immediate = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate
+        RDMA_WRITE_Only                = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Only
+        RDMA_WRITE_Only_with_Immediate = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+        RDMA_READ_Request              = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_Request
+        RDMA_READ_response_First       = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_response_First
+        RDMA_READ_response_Middle      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_response_Middle
+        RDMA_READ_response_Last        = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_response_Last
+        RDMA_READ_response_Only        = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.RDMA_READ_response_Only
+        Acknowledge                    = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.Acknowledge
+        # ATOMIC_Acknowledge             = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.ATOMIC_Acknowledge
+        # CmpSwap                        = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.CmpSwap
+        # FetchAdd                       = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.FetchAdd
+        # SEND_Last_with_Invalidate      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Last_with_Invalidate
+        # SEND_Only_with_Invalidate      = (QP_CONN_TYPE.RC << 5) + BTH_OPCODE_OP.SEND_Only_with_Invalidate
+    class UD(IntEnum):
+        SEND_Only                      = (QP_CONN_TYPE.UD << 5) + BTH_OPCODE_OP.SEND_Only
+        SEND_Only_with_Immediate       = (QP_CONN_TYPE.UD << 5) + BTH_OPCODE_OP.SEND_Only_with_Immediate
+
+class ExtraHeaderFlag(IntFlag):
+    DETH  = 1 << 0
+    RETH  = 1 << 1
+    AETH  = 1 << 2
+    ImmDt = 1 << 3
+
+IBT_opmap = {
+    # Reliable connection
+    BTH_OPCODE.RC.SEND_First                     : 0,
+    BTH_OPCODE.RC.SEND_Middle                    : 0,
+    BTH_OPCODE.RC.SEND_Last                      : 0,
+    BTH_OPCODE.RC.SEND_Last_with_Immediate       : ExtraHeaderFlag.ImmDt,
+    BTH_OPCODE.RC.SEND_Only                      : 0,
+    BTH_OPCODE.RC.SEND_Only_with_Immediate       : ExtraHeaderFlag.ImmDt,
+    BTH_OPCODE.RC.RDMA_WRITE_First               : ExtraHeaderFlag.RETH,
+    BTH_OPCODE.RC.RDMA_WRITE_Middle              : 0,
+    BTH_OPCODE.RC.RDMA_WRITE_Last                : 0,
+    BTH_OPCODE.RC.RDMA_WRITE_Last_with_Immediate : ExtraHeaderFlag.ImmDt,
+    BTH_OPCODE.RC.RDMA_WRITE_Only                : ExtraHeaderFlag.RETH,
+    BTH_OPCODE.RC.RDMA_WRITE_Only_with_Immediate : ExtraHeaderFlag.RETH | ExtraHeaderFlag.ImmDt,
+    BTH_OPCODE.RC.RDMA_READ_Request              : ExtraHeaderFlag.RETH,
+    BTH_OPCODE.RC.RDMA_READ_response_First       : ExtraHeaderFlag.AETH,
+    BTH_OPCODE.RC.RDMA_READ_response_Middle      : 0,
+    BTH_OPCODE.RC.RDMA_READ_response_Last        : ExtraHeaderFlag.AETH,
+    BTH_OPCODE.RC.RDMA_READ_response_Only        : ExtraHeaderFlag.AETH,
+    BTH_OPCODE.RC.Acknowledge                    : ExtraHeaderFlag.AETH,
+
+    # Unreliable datagram - necessary for communication establishment
+    BTH_OPCODE.UD.SEND_Only                      : ExtraHeaderFlag.DETH,
+    BTH_OPCODE.UD.SEND_Only_with_Immediate       : ExtraHeaderFlag.DETH | ExtraHeaderFlag.ImmDt,
+}
+
+IBT_RC_OPS = [op.value & 0b11111 for op in BTH_OPCODE.RC]
+IBT_UD_OPS = [op.value & 0b11111 for op in BTH_OPCODE.UD]
+
+IBT_headers = [bth_header, deth_header, reth_header, aeth_header, immdt_header]
+# Complete RC list:
+# IBT_headers = [bth_header, deth_header, reth_header, atomiceth_header, aeth_header, atomicacketh_header, immdt_header, ieth_header]
+
+# Work request and work completion codes
+class WR_OPCODE(IntEnum):
+    SEND                = 0b00
+    RDMA_WRITE          = 0b01
+    RDMA_READ           = 0b10
+
+class WC:
+    class Status(IntEnum):
+        SUCCESS            = 0x00
+        LOC_LEN_ERR        = 0x01
+        LOC_QP_OP_ERR      = 0x02
+        # LOC_EEC_OP_ERR     = 0x03
+        LOC_PROT_ERR       = 0x04
+        WR_FLUSH_ERR       = 0x05
+        # MW_BIND_ERR        = 0x06
+        BAD_RESP_ERR       = 0x07
+        LOC_ACCESS_ERR     = 0x08
+        REM_INV_REQ_ERR    = 0x09
+        REM_ACCESS_ERR     = 0x0a
+        REM_OP_ERR         = 0x0b
+        RETRY_EXC_ERR      = 0x0c
+        RNR_RETRY_EXC_ERR  = 0x0d
+        LOC_RDD_VIOL_ERR   = 0x0e
+        # REM_INV_RD_REQ_ERR = 0x0f
+        # REM_ABORT_ERR      = 0x10
+        # INV_EECN_ERR       = 0x11
+        # INV_EEC_STATE_ERR  = 0x12
+        # FATAL_ERR          = 0x13
+        RESP_TIMEOUT_ERR   = 0x14
+        GENERAL_ERR        = 0x15
+        # TM_ERR             = 0x16
+        # TM_RNDV_INCOMPLETE = 0x17
+
+    class Opcode(IntEnum):
+        SEND               = 0
+        RDMA_WRITE         = 1
+        RDMA_READ          = 2
+        # COMP_SWAP        = 3
+        # FETCH_ADD        = 4
+        # BIND_MW          = 5
+        # LOCAL_INV        = 6
+        # TSO              = 7
+        FLUSH              = 8
+        # ATOMIC_WRITE     = 9
+
+        RECV               = 10
+        RECV_RDMA_WITH_IMM = 11
+
+ROCEV2_PORT = 4791 # Assigned by IANA
+DEFAULT_CM_Q_Key = 0x8001_0000
+DEFAULT_P_KEY = 0xffff
+
+PMTU_VALUES = {
+    1: 256,
+    2: 512,
+    3: 1024,
+    4: 2048,
+    5: 4096
+}
+PMTU_KEY = 3
+PMTU = PMTU_VALUES[PMTU_KEY] # Max size of transport layer packet payload
+PMTU_BITS = log2_int(PMTU)
+LOCAL_COMMUNICATION_ID = 0xfedcabed # MAD_CM Communication ID
+MAX_OUTSTANDING = 0x20
+# Max number RDMA READ Requests that can be outstanding at once
+# (responder)
+RESPONDER_RESOURCES = 0x10
+# (requester)
+INITIATOR_DEPTH     = 0x10
+STARTING_PSN = 0xfedfed
+
+assert MAX_OUTSTANDING > INITIATOR_DEPTH
+
+def add_params(description, params):
+    payload_layout = description.payload_layout.copy()
+    param_layout = description.param_layout.copy()
+    param_layout += params
+    return EndpointDescription(payload_layout, param_layout)
+
+def is_in(signal, array):
+    if len(array) == 0:
+        return 0
+    carray = [(el if isinstance(el, Constant) else Constant(el, len(signal))) for el in array]
+    v = signal == carray[0]
+    for e in carray[1:]:
+        v = v | (signal == e)
+    return v
+
+def is_in_flag(signal, array, flag, case=True):
+    bits = len(signal)
+    if not case:
+        return flag.eq(is_in(signal, array))
+    d = {Constant(el, bits): flag.eq(1) for el in array}
+    d.update({"default": flag.eq(0)})
+    return Case(signal, d)
+
+
+def is_in_do(signal, doarrays, *, default=None):
+    bits = len(signal)
+    out = []
+    d = {}
+    if isinstance(doarrays, tuple):
+        doarrays = [doarrays]
+    for array, do in doarrays:
+        helper = Signal()
+        for el in array:
+            if el in d:
+                d[el].append(helper.eq(1))
+            else:
+                d[el] = [helper.eq(1)]
+        out.append(If(helper, do))
+    cd = {Constant(key, bits): value for key, value in d.items()}
+    if not default:
+        default = []
+    cd.update({"default": default})
+    out.append(Case(signal, cd))
+    return out
+
+def IBT_get_header_length(opcode):
+    selection = IBT_opmap[opcode]
+    return IBT_headers[0].length + (sum([header.length for i, header in list(enumerate(IBT_headers))[1:] if (selection >> (i - 1)) & 1]))
+
+def IBT_header_length(opcode, header_length):
+    return Case(opcode, {
+        opcode: header_length.eq(
+            IBT_headers[0].length +
+            (
+                sum([header.length
+                for i, header in list(enumerate(IBT_headers))[1:]
+                if (selection >> (i - 1)) & 1])
+            )
+        )
+        for opcode, selection in IBT_opmap.items()
+    })
+
 
 # Etherbone Constants/Header -----------------------------------------------------------------------
 
@@ -278,6 +806,66 @@ def eth_udp_user_description(dw):
         ("error",   dw//8)
     ]
     return EndpointDescription(payload_layout, param_layout)
+
+# RoCEv2
+def eth_rocev2_description(dw):
+    # Get unique fields from the various headers
+    param_layout = list(set(sum([header.get_layout() for header in IBT_headers], []))) + [("length", 16)]
+    payload_layout = [("data", dw)]
+    return EndpointDescription(payload_layout, param_layout)
+
+def eth_mad_description(dw):
+    # Get unique fields from the various headers
+    param_layout = list(set(sum([header.get_layout() for header in mad_cm_headers], [])))
+    payload_layout = [("data", dw)]
+    return EndpointDescription(payload_layout, param_layout)
+
+def eth_ipcm_description(dw):
+    param_layout = ipcm_header.get_layout()
+    payload_layout = [("data", dw)]
+    return EndpointDescription(payload_layout, param_layout)
+
+def eth_rocev2_user_description(dw):
+    param_layout = [
+        ("dest_qp",  24),
+        ("immdt",    32),
+        ("length",   16)
+    ]
+    payload_layout = [("data", dw)]
+    return EndpointDescription(payload_layout, param_layout)
+
+def eth_rocev2_send_wr_description():
+    payload_layout = [
+        ("wr_opcode",  3),
+        ("w_immdt",    1),
+        ("immdt",     32),
+        ("va",        64),
+        ("dma_len",   32),
+        ("l_key",     32),
+        ("r_key",     32),
+        ("ack_req",    1)
+    ]
+    return EndpointDescription(payload_layout, [])
+
+def eth_rocev2_recv_wr_description():
+    payload_layout = [
+        ("va",        64),
+        ("dma_len",   32),
+        ("l_key",     32)
+    ]
+    return EndpointDescription(payload_layout, [])
+
+def eth_rocev2_cq_description():
+    payload_layout = [
+        ("status",     5),
+        ("opcode",     4),
+        ("w_immdt",    1),
+        ("immdt",     32),
+        ("dma_len",  32),
+        ("qp_num",    32),
+        ("src_qp",    32)
+    ]
+    return EndpointDescription(payload_layout, [])
 
 # Etherbone
 def eth_etherbone_packet_description(dw):

--- a/liteeth/core/ip.py
+++ b/liteeth/core/ip.py
@@ -94,7 +94,7 @@ class LiteEthIPV4Packetizer(Packetizer):
 
 
 class LiteEthIPTX(LiteXModule):
-    def __init__(self, mac_address, ip_address, arp_table, dw=8, with_buffer=True):
+    def __init__(self, mac_address, ip_address, arp_table, dw=8, with_buffer=True, dont_fragment=False):
         self.sink   = sink   = stream.Endpoint(eth_ipv4_user_description(dw))
         self.source = source = stream.Endpoint(eth_mac_description(dw))
         self.target_unreachable = Signal()
@@ -127,6 +127,7 @@ class LiteEthIPTX(LiteXModule):
             packetizer.sink.total_length.eq(ipv4_header.length + sink.length),
             packetizer.sink.version.eq(0x4),     # ipv4
             packetizer.sink.ihl.eq(ipv4_header.length//4),
+            packetizer.sink.dont_fragment.eq(dont_fragment),
             packetizer.sink.identification.eq(0),
             packetizer.sink.ttl.eq(0x80),
             packetizer.sink.sender_ip.eq(ip_address),
@@ -264,8 +265,8 @@ class LiteEthIPRX(LiteXModule):
 # IP -----------------------------------------------------------------------------------------------
 
 class LiteEthIP(LiteXModule):
-    def __init__(self, mac, mac_address, ip_address, arp_table, with_broadcast=True, dw=8):
-        self.tx = tx = LiteEthIPTX(mac_address, ip_address, arp_table, dw=dw)
+    def __init__(self, mac, mac_address, ip_address, arp_table, with_broadcast=True, buffer_tx=True, dont_fragment=False, dw=8):
+        self.tx = tx = LiteEthIPTX(mac_address, ip_address, arp_table, dw=dw, with_buffer=buffer_tx, dont_fragment=dont_fragment)
         self.rx = rx = LiteEthIPRX(mac_address, ip_address, with_broadcast, dw=dw)
         mac_port = mac.crossbar.get_port(ethernet_type_ip, dw)
         self.comb += [

--- a/liteeth/core/ip.py
+++ b/liteeth/core/ip.py
@@ -95,8 +95,9 @@ class LiteEthIPV4Packetizer(Packetizer):
 
 class LiteEthIPTX(LiteXModule):
     def __init__(self, mac_address, ip_address, arp_table, dw=8, with_buffer=True,
-        gateway_ip = None,
-        netmask    = None,
+        gateway_ip    = None,
+        netmask       = None,
+        dont_fragment = False,
     ):
         ip_address = convert_ip(ip_address)
         assert (gateway_ip is None) == (netmask is None)
@@ -136,6 +137,7 @@ class LiteEthIPTX(LiteXModule):
             packetizer.sink.total_length.eq(ipv4_header.length + sink.length),
             packetizer.sink.version.eq(0x4),     # ipv4
             packetizer.sink.ihl.eq(ipv4_header.length//4),
+            packetizer.sink.dont_fragment.eq(dont_fragment),
             packetizer.sink.identification.eq(0),
             packetizer.sink.ttl.eq(0x80),
             packetizer.sink.sender_ip.eq(ip_address),
@@ -280,17 +282,20 @@ class LiteEthIPRX(LiteXModule):
 # IP -----------------------------------------------------------------------------------------------
 
 class LiteEthIP(LiteXModule):
-    def __init__(self, mac, mac_address, ip_address, arp_table, with_broadcast=True, dw=8,
-        gateway_ip = None,
-        netmask    = None,
+    def __init__(self, mac, mac_address, ip_address, arp_table, with_broadcast=True, buffer_tx=True, dw=8,
+        gateway_ip    = None,
+        netmask       = None,
+        dont_fragment = False,
     ):
         self.tx = tx = LiteEthIPTX(
-            mac_address = mac_address,
-            ip_address  = ip_address,
-            arp_table   = arp_table,
-            dw          = dw,
-            gateway_ip  = gateway_ip,
-            netmask     = netmask,
+            mac_address   = mac_address,
+            ip_address    = ip_address,
+            arp_table     = arp_table,
+            dw            = dw,
+            with_buffer   = buffer_tx,
+            gateway_ip    = gateway_ip,
+            netmask       = netmask,
+            dont_fragment = dont_fragment,
         )
         self.rx = rx = LiteEthIPRX(mac_address, ip_address, with_broadcast, dw=dw)
         mac_port = mac.crossbar.get_port(ethernet_type_ip, dw)

--- a/liteeth/core/rocev2/__init__.py
+++ b/liteeth/core/rocev2/__init__.py
@@ -1,0 +1,91 @@
+
+from litex.gen import *
+
+from liteeth.common import *
+
+from liteeth.mac       import LiteEthMAC
+from liteeth.core.arp  import LiteEthARP
+from liteeth.core.ip   import LiteEthIP
+from liteeth.core.udp  import LiteEthUDP
+from liteeth.core.icmp import LiteEthICMP
+
+from liteeth.core.rocev2.rocev2 import LiteEthIBTransport
+
+class LiteEthRoCEv2Core(LiteXModule):
+    def __init__(self, phy, mac_address, ip_address, mrs, clk_freq, arp_entries=1, dw=8,
+        with_icmp         = True, icmp_fifo_depth=128,
+        with_ip_broadcast = True,
+        with_sys_datapath = False,
+        tx_cdc_depth      = 32,
+        tx_cdc_buffered   = True,
+        rx_cdc_depth      = 32,
+        rx_cdc_buffered   = True,
+        interface         = "crossbar",
+        endianness        = "big",
+    ):
+        # Parameters.
+        # -----------
+        ip_address = convert_ip(ip_address)
+
+        # MAC.
+        # ----
+        self.mac = LiteEthMAC(
+            phy               = phy,
+            dw                = dw,
+            interface         = interface,
+            endianness        = endianness,
+            hw_mac            = mac_address,
+            with_preamble_crc = True,
+            with_sys_datapath = with_sys_datapath,
+            tx_cdc_depth      = tx_cdc_depth,
+            tx_cdc_buffered   = tx_cdc_buffered,
+            rx_cdc_depth      = rx_cdc_depth,
+            rx_cdc_buffered   = rx_cdc_buffered,
+        )
+
+        # ARP.
+        # ----
+        self.arp = LiteEthARP(
+            mac         = self.mac,
+            mac_address = mac_address,
+            ip_address  = ip_address,
+            clk_freq    = clk_freq,
+            entries     = arp_entries,
+            dw          = dw,
+        )
+
+        # IP.
+        # ---
+        self.ip  = LiteEthIP(
+            mac            = self.mac,
+            mac_address    = mac_address,
+            ip_address     = ip_address,
+            arp_table      = self.arp.table,
+            with_broadcast = with_ip_broadcast,
+            dw             = dw,
+            dont_fragment  = True,
+            buffer_tx      = False,
+        )
+        # ICMP (Optional).
+        # ----------------
+        if with_icmp:
+            self.icmp = LiteEthICMP(
+                ip         = self.ip,
+                ip_address = ip_address,
+                dw         = dw,
+                fifo_depth = icmp_fifo_depth,
+            )
+
+        # ----
+        self.udp = LiteEthUDP(
+            ip         = self.ip,
+            ip_address = ip_address,
+            dw         = dw,
+        )
+
+        self.rocev2 = LiteEthIBTransport(
+            ip          = self.ip,
+            udp         = self.udp,
+            mrs         = mrs,
+            clk_freq    = clk_freq,
+        )

--- a/liteeth/core/rocev2/ack.py
+++ b/liteeth/core/rocev2/ack.py
@@ -1,0 +1,58 @@
+from liteeth.common import *
+
+class _Acknowledge:
+    @staticmethod
+    def emit(leading_bits, code, dest_qp, msn, psn, ack_sink):
+        assert leading_bits < 4 # 2 bits
+        assert code < 32        # 5 bits
+        if leading_bits & 0b11 == 0b10:
+            print("Reserved pattern")
+            raise ValueError
+        return [
+            ack_sink.valid.eq(1),
+            ack_sink.last.eq(1),
+            ack_sink.psn.eq(psn),
+            ack_sink.opcode.eq(BTH_OPCODE.RC.Acknowledge),
+            ack_sink.dest_qp.eq(dest_qp),
+            ack_sink.syndrome.eq(Constant((leading_bits << 5) + code, 8)),
+            ack_sink.msn.eq(msn)
+        ]
+
+class ACK(_Acknowledge):
+    @staticmethod
+    def emit(dest_qp, msn, psn, ack_sink):
+        return super(__class__, __class__).emit(0b00, 0b00000, dest_qp, msn, psn, ack_sink)
+
+class RNR_NAK(_Acknowledge):
+    # Look at RNR ACK timer field times to know which value corresponds to what time
+    @staticmethod
+    def emit(time, dest_qp, msn, psn, ack_sink, qps):
+        return [
+            Case(dest_qp, {qp.id : [
+                If(~qp.nak_sent,
+                    NextValue(qp.nak_sent, 1),
+                    super(__class__, __class__).emit(0b01, time, dest_qp, msn, psn, ack_sink)
+                )
+            ] for qp in qps[1:]}),
+        ]
+
+class NAK(_Acknowledge):
+    class Code(IntEnum):
+        PSN_Sequence_Error       = 0
+        Invalid_Request          = 1
+        Remote_Access_Error      = 2
+        Remote_Operational_Error = 3
+        # Invalid_RD_Request       = 4
+
+    @staticmethod
+    def emit(code, dest_qp, msn, psn, ack_sink, duplicate, qps):
+        return [
+            If(~duplicate,
+                Case(dest_qp, {qp.id : [
+                    If(~qp.nak_sent,
+                        NextValue(qp.nak_sent, 1),
+                        super(__class__, __class__).emit(0b11, code, dest_qp, msn, psn, ack_sink)
+                    )
+                ] for qp in qps[1:]}),
+            )
+        ]

--- a/liteeth/core/rocev2/common.py
+++ b/liteeth/core/rocev2/common.py
@@ -1,0 +1,688 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Endpoint, Buffer
+
+class VarWaitTimer(Module):
+    """Variable Wait Timer
+
+    A timer whose wait time can be changed to a value in {4.096*2^i, i in [[0, 31]]} us
+    These times come from the specification
+
+    See section 12.7.5: LOCAL CM RESPONSE TIMEOUT
+
+    Parameters
+    ----------
+    clk_freq : int
+        Clock frequency.
+
+
+    Attributes
+    ----------
+    wait : in
+        Launch and wait for timer.
+    pow : in
+        The timer waits for 4.096*2^pow us
+    done : out
+        Time is out.
+    """
+    def __init__(self, clk_freq):
+        self.wait = Signal()
+        self.pow = Signal(5)
+        self.done = Signal()
+
+        # # #
+
+        bits = log2_int(
+            n = ceil(4.096e-6*(2**((1 << len(self.pow)) - 1))*clk_freq) + 1,
+            need_pow2 = False
+        )
+        # Cast t to int.
+        cnt_dict = {
+            Constant(i, len(self.pow)):
+                Constant(ceil(4.096e-6*(2**i)*clk_freq), bits)
+            for i in range(1 << len(self.pow))
+        }
+        rst_count = Signal(bits)
+        count = Signal(reset_less=True).like(rst_count)
+
+        self.comb += Case(self.pow, {i: rst_count.eq(v) for i, v in cnt_dict.items()})
+        self.comb += self.done.eq(count == 0)
+        self.sync += [
+            If(self.wait,
+                If(~self.done,
+                    count.eq(count - 1)
+                )
+            ).Else(
+                count.eq(rst_count)
+            )
+        ]
+
+class WaitPipe(LiteXModule):
+    """Wait Pipe
+
+    A block FIFO for packet payloads whose latest packet can be invalidated.
+
+    Parameters
+    ----------
+    layout : description
+        Description of the dataflow.
+    depth : int
+        Depth of the underlying FIFO.
+    block_size : int
+        Size of one packet payload (PMTU)
+    discarding : bool
+        When the fifo is full, if the WaitPipe is
+        discarding, it will clear the last incoming
+        packet instead of making sink wait by setting
+        ready to 0.
+    buffered_in : bool
+        Whether to buffer input to cut timing
+    buffered_out : bool
+        Whether to buffer output to cut timing
+    dw : int
+        Width of the data bus.
+
+
+    Attributes
+    ----------
+    sink : in
+        Incoming packet data.
+    validate_sink : in
+        sink for packet validation
+    header_only : in
+        Makes WaitPipe consider the output packet as
+        empty (only presents parameters and last until
+        ready is asserted)
+    source : out
+        Outgoing packet data
+    full: out
+        Indicates if the pipe is full
+    """
+    def __init__(self,
+                 layout,
+                 depth,
+                 block_size,
+                 discarding=True,
+                 buffered_in=True,
+                 buffered_out=True,
+                 dw=8
+        ):
+        layout = add_params(layout, [("header_only", 1)])
+        # invalidate
+        #    Invalidates current packet and gets ready for
+        #    the next one
+        # validate
+        #    Validates the last full packet and gets ready
+        #    for the next one
+        validate_layout = [
+            ("invalidate", 1, DIR_M_TO_S),
+            ("validate",   1, DIR_M_TO_S)
+        ]
+        # In
+        self.sink          = sink          = Endpoint(layout)
+        self.validate_sink = validate_sink = Record(validate_layout)
+
+        # Out
+        self.source = source = Endpoint(layout)
+        self.full   = full   = Signal()
+
+        # # #
+
+        # Check if block_size is power of 2
+        log2_int(block_size, need_pow2=True)
+
+        # Saved parameters
+        fifo_layout = layout.param_layout + [("last_addr", log2_int(block_size))]
+        records = []
+        for i in range(depth):
+            record = Record(fifo_layout, reset_less=True)
+            self.__setattr__(f"record{i + 1}", record)
+            records.append(record)
+        param_fifo = Array(records)
+
+        if buffered_in:
+            buff_in = Buffer(layout, pipe_ready=True)
+            self.submodules.buff_in = buff_in
+            self.comb += sink.connect(buff_in.sink)
+            sink = buff_in.source
+
+            buff_in_validate = Record(validate_layout)
+            self.sync += validate_sink.connect(buff_in_validate)
+            validate_sink = buff_in_validate
+
+        if buffered_out:
+            buff_out = Buffer(layout, pipe_ready=True)
+            self.submodules.buff_out = buff_out
+            self.comb += buff_out.source.connect(source)
+            source = buff_out.sink
+
+        # Internal ram
+        array = Memory(dw, block_size * depth, name="wait_pipe_mem")
+        in_port  = array.get_port(write_capable=True)
+        out_port = array.get_port()
+        self.specials += array, in_port, out_port
+
+        # Dump packet in in buffer
+        invalidate = Signal()
+        # Transfer packet from in to out buffer
+        validate    = Signal()
+        # Stays on after validate set and until out buffer is freed
+        validated = Signal()
+
+        self.comb += [
+            validate.eq(validate_sink.validate),
+            invalidate.eq(validate_sink.invalidate)
+        ]
+
+        # Pipe level logic
+        level = Signal(max=depth+1)
+        inc   = Signal()
+        dec   = Signal()
+
+        # Writing and reading position tracking
+        # Position inside block
+        local_in_addr  = Signal(max=block_size)
+        local_out_addr = Signal(max=block_size)
+
+        # Block position
+        in_block  = Signal(max=depth)
+        out_block = Signal(max=depth)
+
+        # Combined positions
+        real_in_addr  = Signal(max=depth*block_size)
+        real_out_addr = Signal(max=depth*block_size)
+
+        # Additionnal reading logic
+        reading_addr    = Signal().like(local_out_addr)
+        local_nout_addr = Signal().like(local_out_addr)
+
+        self.sync += [
+            If(validate,
+                # Write parameters to memory Record
+                [
+                    param_fifo[in_block].__getattr__(sig[0]).eq(sink.__getattr__(sig[0]))
+                    for sig in layout.param_layout
+                ]
+            ),
+            If(inc & ~dec,
+                level.eq(level + 1)
+            ).Elif(~inc & dec,
+                level.eq(level - 1)
+            )
+        ]
+
+        self.comb += [
+            real_in_addr.eq(Cat(local_in_addr, in_block)),
+            real_out_addr.eq(Cat(reading_addr, out_block))
+        ]
+
+        if hasattr(source, "length"):
+            self.comb += source.length.eq(param_fifo[out_block].last_addr + 1),
+        # Output signals logic
+        self.comb += [
+            [
+                source.__getattr__(sig[0]).eq(param_fifo[out_block].__getattr__(sig[0]))
+                for sig in layout.param_layout
+            ],
+            # Adding & ~dec would also work, but it would link output and input combinatorially
+            full.eq(level == depth - 1)
+        ]
+
+        # In buffer FSM logic
+        self.comb += [
+            in_port.adr.eq(real_in_addr),
+            in_port.dat_w.eq(sink.data)
+        ]
+
+        self.in_fsm = in_fsm = FSM(reset_state="WRITE")
+        in_fsm.act("WRITE",
+            sink.ready.eq(1),
+            If(sink.valid,
+                in_port.we.eq(1),
+                NextValue(local_in_addr, local_in_addr + 1),
+                If(invalidate,
+                    NextValue(local_in_addr, 0),
+                ).Elif(sink.last,
+                    NextValue(param_fifo[in_block].last_addr, local_in_addr),
+                    NextState("WAIT"),
+                )
+            )
+        )
+
+        self.sync += [
+            If(validate, validated.eq(1)),
+            If(in_fsm.ongoing("WAIT") & validated, validated.eq(0))
+        ]
+
+        if discarding:
+            in_fsm.act("WAIT",
+                NextValue(local_in_addr, 0),
+                If(validated,
+                    If((level == depth - 1) & ~dec,
+                        NextState("WRITE")
+                    ).Else(
+                        If(in_block == depth - 1,
+                            NextValue(in_block, 0)
+                        ).Else(
+                            NextValue(in_block, in_block + 1)
+                        ),
+                        inc.eq(1),
+                        NextState("WRITE")
+                    )
+                ).Elif(invalidate,
+                    NextState("WRITE")
+                )
+            )
+
+        else:
+            in_fsm.act("WAIT",
+                NextValue(local_in_addr, 0),
+                If(validated,
+                    If(in_block == depth - 1,
+                        NextValue(in_block, 0)
+                    ).Else(
+                        NextValue(in_block, in_block + 1)
+                    ),
+                    inc.eq(1),
+                    If((level == depth - 1) & ~dec,
+                        NextState("FULL")
+                    ).Else(
+                        NextState("WRITE")
+                    )
+                ).Elif(invalidate,
+                    NextState("WRITE")
+                )
+            )
+
+            in_fsm.act("FULL",
+                If(dec,
+                    NextState("WRITE")
+                )
+            )
+
+        # Out buffer FSM logic
+        self.out_fsm = out_fsm = FSM(reset_state="WAIT")
+        out_fsm.act("WAIT",
+            If(level != 0 | inc,
+                NextState("READ")
+            )
+        )
+
+        # Reading address logic
+        self.comb += [
+            local_nout_addr.eq(local_out_addr + 1),
+            If(out_fsm.ongoing("READ"),
+                If(source.ready,
+                    reading_addr.eq(local_nout_addr),
+                ).Else(
+                    reading_addr.eq(local_out_addr)
+                )
+            ).Else(
+                reading_addr.eq(local_out_addr)
+            ),
+
+            out_port.adr.eq(real_out_addr),
+            source.data.eq(out_port.dat_r)
+        ]
+        out_fsm.act("READ",
+            source.valid.eq(1),
+            source.last.eq((local_out_addr == param_fifo[out_block].last_addr) | source.header_only),
+            If(source.ready,
+                NextValue(local_out_addr, local_nout_addr),
+                If(source.last,
+                    If(out_block == depth-1,
+                        NextValue(out_block, 0)
+                    ).Else(
+                        NextValue(out_block, out_block + 1)
+                    ),
+                    dec.eq(1),
+                    NextValue(local_out_addr, 0),
+                    NextState("WAIT")
+                )
+            )
+        )
+
+# Variable Packetizer ---------------------------------------------------------------------------------------
+
+class VariablePacketizer(LiteXModule):
+    """Variable Packetizer
+
+    A packetizer that can handle headers that change depending on an opcode.
+
+    Parameters
+    ----------
+    sink_description : description
+        Headers + data.
+    source_description : description
+        Raw data.
+    headers : list[Header]
+        Possible headers in the packet
+        (including an always-present first header
+        that must contain the opcode).
+    opmap: dict[int, int]
+        Indicates which headers are selected depending on the opcode.
+    opcode_name : str
+        Name of the opcode signal.
+
+
+    Attributes
+    ----------
+    sink : in
+        Incoming packet data and parameters.
+    source : out
+        Outgoing packet data.
+
+    """
+    def __init__(self, sink_description, source_description, headers, opmap, opcode_name="opcode"):
+        self.sink   = sink   = Endpoint(add_params(sink_description, [("header_only", 1)]))
+        self.source = source = Endpoint(source_description)
+
+        # # #
+
+        assert hasattr(sink, opcode_name)
+
+        # Parameters.
+        data_width = len(sink.data)
+        base_header       = headers[0]
+        base_header_words = (base_header.length * 8) // data_width
+        header_words_dict = {
+            opcode:
+                base_header_words +
+                (sum([
+                    header.length
+                    for i, header in list(enumerate(headers))[1:]
+                    if (selection >> (i - 1)) & 1
+                ])*8) // data_width
+            for opcode, selection in opmap.items()
+        }
+        max_size = max(header_words_dict.values())
+
+        # Signals.
+        header_length = Signal(bits_for(max_size))
+        header = Signal(max_size*8)
+
+        sr       = Signal(max(header_words_dict.values())*8, reset_less=True)
+        sr_load  = Signal()
+        sr_shift = Signal()
+        count    = Signal(max=max(*header_words_dict.values(), 2))
+        header_words = header_words = Signal(max=max(header_words_dict.values()))
+
+        # Determine header_words
+        self.comb += Case(sink.__getattr__(opcode_name), {
+            opcode: header_words.eq(length) for opcode, length in header_words_dict.items()
+        })
+        self.comb += header_length.eq(base_header_words + header_words)
+
+        # Header Encode/Load/Shift.
+        cases = {}
+        for opcode, selection in opmap.items():
+            cum = base_header_words
+            assignments = []
+            for i, extra_header in list(enumerate(headers))[1:]:
+                if (selection >> (i - 1)) & 1:
+                    assignments += extra_header.encode(sink, header, cum)
+                    cum += extra_header.length
+            cases[opcode] = assignments
+
+        self.comb += base_header.encode(sink, header)
+        self.comb += Case(sink.__getattr__(opcode_name), cases)
+        self.sync += If(sr_load, sr.eq(header))
+        self.sync += If(header_words != 1, If(sr_shift, sr.eq(sr[data_width:])))
+
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(0),
+            NextValue(count, 1),
+            If(sink.valid,
+                source.valid.eq(1),
+                source.last.eq((header_words == 1) & sink.header_only),
+                source.data.eq(header[:data_width]),
+                If(source.valid & source.ready,
+                    sr_load.eq(1),
+                    If(header_words == 1,
+                        NextState("ALIGNED-DATA-COPY"),
+                        If(sink.header_only,
+                           NextState("IDLE")
+                        )
+                    ).Else(
+                        NextState("HEADER-SEND")
+                    )
+               )
+            )
+        )
+        fsm.act("HEADER-SEND",
+            source.valid.eq(1),
+            source.last.eq((count == header_words - 1) & sink.header_only),
+            source.data.eq(sr[min(data_width, len(sr)-1):]),
+            If(source.valid & source.ready,
+                sr_shift.eq(1),
+                If(count == header_words - 1,
+                    sr_shift.eq(0),
+                    NextState("ALIGNED-DATA-COPY"),
+                    NextValue(count, count + 1),
+                    If(sink.header_only,
+                        sink.ready.eq(1),
+                        NextState("IDLE")
+                    )
+                ).Else(
+                    NextValue(count, count + 1),
+                )
+            )
+        )
+        fsm.act("ALIGNED-DATA-COPY",
+            sink.connect(source, keep={"valid", "ready", "last", "data"}),
+            If(source.valid & source.ready,
+                If(source.last,
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        # Error.
+        if hasattr(sink, "error") and hasattr(source, "error"):
+            self.comb += source.error.eq(sink.error)
+
+# Variable Depacketizer -------------------------------------------------------------------------------------
+
+class VariableDepacketizer(LiteXModule):
+    """Variable Depacketizer
+
+    A depacketizer that can handle headers that change depending on an opcode in the packet.
+
+    Parameters
+    ----------
+    sink_description : description
+        Raw data.
+    source_description : description
+        Headers + data.
+    headers : list[Header]
+        Possible headers in the packet
+        (including an always-present first header
+        that must contain the opcode).
+    opmap: dict[int, int]
+        Indicates which headers are selected depending on the opcode.
+    opcode_name : str
+        Name of the opcode signal.
+
+
+    Attributes
+    ----------
+    sink : in
+        Incoming packet data.
+    source : out
+        Outgoing packet data and parameters.
+
+    """
+    def __init__(self, sink_description, source_description, headers, opmap, opcode_name="opcode"):
+        self.sink   = sink   = Endpoint(sink_description)
+        self.source = source = Endpoint(add_params(source_description, [("header_only", 1)]))
+
+        # # #
+
+        assert hasattr(source, opcode_name)
+
+        # Parameters.
+        data_width        = len(sink.data)
+        bytes_per_clk     = data_width//8
+        base_header       = headers[0]
+        base_header_words = (base_header.length * 8) // data_width
+        # Does not include base header
+        header_words_dict = {
+            opcode:
+                (sum([
+                    header.length
+                    for i, header in list(enumerate(headers))[1:]
+                    if (selection >> (i - 1)) & 1
+                ])*8) // data_width
+            for opcode, selection in opmap.items()
+        }
+        max_header_words = max(header_words_dict.values())
+
+        # Signals.
+        header_length = Signal(
+            bits_for(
+                base_header_words +
+                max_header_words
+            )
+        )
+
+        sr                = Signal(max_header_words*8, reset_less=True)
+        sr_shift          = Signal()
+        bhsr              = Signal(base_header_words*8, reset_less=True)
+        bhsr_shift        = Signal()
+        count             = Signal(max=max(base_header_words + max_header_words, 2))
+        header_words      = Signal(max=base_header_words + max_header_words)
+
+        # Determine header_words
+        self.comb += Case(source.__getattr__(opcode_name), {
+            opcode: header_words.eq(length) for opcode, length in header_words_dict.items()
+        })
+        self.comb += header_length.eq(base_header_words + header_words)
+
+        # Header Shift/Decode.
+        self.sync += [
+            If(header_words == 1,
+                If(sr_shift, sr.eq(sink.data)),
+            ).Else(
+                If(sr_shift, sr.eq(Cat(sr[bytes_per_clk*8:], sink.data))),
+            )
+        ]
+        if base_header_words == 1:
+            self.sync += If(bhsr_shift, bhsr.eq(sink.data))
+        else:
+            self.sync += If(bhsr_shift, bhsr.eq(Cat(bhsr[bytes_per_clk*8:], sink.data)))
+
+        # Select decodes depending on opcode
+        decode_cases = {}
+        for opcode, selection in opmap.items():
+            # bits need to be shifted to end of register
+            shift = (max_header_words - header_words_dict[opcode])*8
+            cum = 0
+            decode_cases[opcode] = []
+            for i, header in list(enumerate(headers))[1:]:
+                if (selection >> (i - 1)) & 1:
+                    # Decode the appropriate header selection into the
+                    decode_cases[opcode] += header.decode(sr[shift:], source, cum)
+                    cum += header.length
+
+        self.comb += Case(source.__getattr__(opcode_name), decode_cases)
+        self.comb += base_header.decode(bhsr, source)
+
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(1),
+            NextValue(count, 1),
+            If(sink.valid,
+                bhsr_shift.eq(1),
+                If(base_header_words == 1,
+                    NextState("DECODE-OPCODE"),
+                    If(sink.last & sink.valid,
+                        NextState("HEADER-ONLY")
+                    )
+                ).Else(
+                    NextState("BASE-HEADER-RECEIVE"),
+                )
+            )
+        )
+
+        fsm.act("BASE-HEADER-RECEIVE",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(count, count + 1),
+                bhsr_shift.eq(1),
+                If(count == (base_header_words - 1),
+                    NextState("DECODE-OPCODE"),
+                    If(sink.last & sink.valid,
+                        NextState("HEADER-ONLY")
+                    )
+                )
+            )
+        )
+
+        fsm.act("DECODE-OPCODE",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(count, count + 1),
+                If(header_words == 0,
+                    source.valid.eq(sink.valid),
+                    source.last.eq(sink.last),
+                    sink.ready.eq(source.ready),
+                    source.data.eq(sink.data),
+                    NextState("ALIGNED-DATA-COPY"),
+                ).Elif(header_words == 1,
+                    sr_shift.eq(1),
+                    NextState("ALIGNED-DATA-COPY"),
+                    If(sink.last & sink.valid,
+                        NextState("HEADER-ONLY")
+                    )
+                ).Else(
+                    sr_shift.eq(1),
+                    NextValue(count, count + 1),
+                    NextState("HEADER-RECEIVE")
+                )
+            )
+        )
+
+        fsm.act("HEADER-RECEIVE",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(count, count + 1),
+                sr_shift.eq(1),
+                If(count == (base_header_words + header_words - 1),
+                    NextState("ALIGNED-DATA-COPY"),
+                    NextValue(count, count + 1),
+                    If(sink.last & sink.valid,
+                        NextState("HEADER-ONLY")
+                    )
+                )
+            )
+        )
+
+        fsm.act("ALIGNED-DATA-COPY",
+            source.valid.eq(sink.valid),
+            source.last.eq(sink.last),
+            sink.ready.eq(source.ready),
+            source.data.eq(sink.data),
+            If(source.valid & source.ready,
+                If(source.last,
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        fsm.act("HEADER-ONLY",
+            source.header_only.eq(1),
+            source.valid.eq(1),
+            source.last.eq(1),
+            If(source.ready,
+                NextState("IDLE")
+            )
+        )
+
+        # Error.
+        if hasattr(sink, "error") and hasattr(source, "error"):
+            self.comb += source.error.eq(sink.error)

--- a/liteeth/core/rocev2/common.py
+++ b/liteeth/core/rocev2/common.py
@@ -1,0 +1,701 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Endpoint, Buffer, SyncFIFO
+
+class VarWaitTimer(Module):
+    """Variable Wait Timer
+
+    A timer whose wait time can be changed to a value in {4.096*2^i, i in [[0, 31]]} us
+    These times come from the specification
+
+    See section 12.7.5: LOCAL CM RESPONSE TIMEOUT
+
+    Parameters
+    ----------
+    clk_freq : int
+        Clock frequency.
+
+
+    Attributes
+    ----------
+    wait : in
+        Launch and wait for timer.
+    pow : in
+        The timer waits for 4.096*2^pow us
+    done : out
+        Time is out.
+    """
+    def __init__(self, clk_freq):
+        self.wait = Signal()
+        self.pow = Signal(5)
+        self.done = Signal()
+
+        # # #
+
+        bits = log2_int(
+            n = ceil(4.096e-6*(2**((1 << len(self.pow)) - 1))*clk_freq) + 1,
+            need_pow2 = False
+        )
+        # Cast t to int.
+        cnt_dict = {
+            Constant(i, len(self.pow)):
+                Constant(ceil(4.096e-6*(2**i)*clk_freq), bits)
+            for i in range(1 << len(self.pow))
+        }
+        rst_count = Signal(bits)
+        count = Signal(reset_less=True).like(rst_count)
+
+        self.comb += Case(self.pow, {i: rst_count.eq(v) for i, v in cnt_dict.items()})
+        self.comb += self.done.eq(count == 0)
+        self.sync += [
+            If(self.wait,
+                If(~self.done,
+                    count.eq(count - 1)
+                )
+            ).Else(
+                count.eq(rst_count)
+            )
+        ]
+
+class WaitPipe(LiteXModule):
+    """Wait Pipe
+
+    A block FIFO for packet payloads whose latest packet can be invalidated.
+
+    Parameters
+    ----------
+    layout : description
+        Description of the dataflow.
+    depth : int
+        Depth of the underlying FIFO.
+    block_size : int
+        Size of one packet payload (PMTU)
+    discarding : bool
+        When the fifo is full, if the WaitPipe is
+        discarding, it will clear the last incoming
+        packet instead of making sink wait by setting
+        ready to 0.
+    buffered_in : bool
+        Whether to buffer input to cut timing
+    buffered_out : bool
+        Whether to buffer output to cut timing
+    dw : int
+        Width of the data bus.
+
+
+    Attributes
+    ----------
+    sink : in
+        Incoming packet data.
+    validate_sink : in
+        sink for packet validation
+    header_only : in
+        Makes WaitPipe consider the output packet as
+        empty (only presents parameters and last until
+        ready is asserted)
+    source : out
+        Outgoing packet data
+    full: out
+        Indicates if the pipe is full
+    """
+    def __init__(self,
+                 layout,
+                 depth,
+                 block_size,
+                 discarding=True,
+                 buffered_in=True,
+                 buffered_out=True,
+                 dw=8
+        ):
+        # Header only packets are treated slightly differently
+        layout = add_params(layout, [("header_only", 1)])
+        # invalidate
+        #    Invalidates current packet and gets ready for
+        #    the next one
+        # validate
+        #    Validates the last full packet and gets ready
+        #    for the next one
+        validate_layout = [
+            ("invalidate", 1, DIR_M_TO_S),
+            ("validate",   1, DIR_M_TO_S)
+        ]
+        # In
+        self.sink          = sink          = Endpoint(layout)
+        self.validate_sink = validate_sink = Record(validate_layout)
+
+        # Out
+        self.source = source = Endpoint(layout)
+        self.full   = full   = Signal()
+
+        # # #
+
+        # Check if block_size is power of 2
+        log2_int(block_size, need_pow2=True)
+
+        # Saved parameters
+        fifo_layout = layout.param_layout + [("last_addr", log2_int(block_size))]
+        self.param_fifo = param_fifo = SyncFIFO(fifo_layout, depth)
+
+        if buffered_in:
+            buff_in = Buffer(layout, pipe_ready=True)
+            self.submodules.buff_in = buff_in
+            self.comb += sink.connect(buff_in.sink)
+            sink = buff_in.source
+
+            buff_in_validate = Record(validate_layout)
+            self.sync += validate_sink.connect(buff_in_validate)
+            validate_sink = buff_in_validate
+
+        if buffered_out:
+            buff_out = Buffer(layout, pipe_ready=True)
+            self.submodules.buff_out = buff_out
+            self.comb += buff_out.source.connect(source)
+            source = buff_out.sink
+
+        # Internal ram
+        array = Memory(dw, block_size * depth, name="wait_pipe_mem")
+        in_port  = array.get_port(write_capable=True)
+        out_port = array.get_port()
+        self.specials += array, in_port, out_port
+
+        # Dump packet in in buffer
+        invalidate = Signal()
+        # Transfer packet from in to out buffer
+        validate    = Signal()
+        # Stays on after validate set and until out buffer is freed
+        validated = Signal()
+
+        self.comb += [
+            validate.eq(validate_sink.validate),
+            invalidate.eq(validate_sink.invalidate)
+        ]
+
+        # Pipe level logic
+        level = Signal(max=depth+1)
+        inc   = Signal()
+        dec   = Signal()
+
+        # Writing and reading position tracking
+        # Position inside block
+        local_in_addr  = Signal(max=block_size)
+        local_out_addr = Signal(max=block_size)
+
+        # Block position
+        in_block  = Signal(max=depth)
+        out_block = Signal(max=depth)
+
+        # Combined positions
+        real_in_addr  = Signal(max=depth*block_size)
+        real_out_addr = Signal(max=depth*block_size)
+
+        # Additionnal reading logic
+        reading_addr    = Signal().like(local_out_addr)
+        local_nout_addr = Signal().like(local_out_addr)
+
+        saved_last_addr = Signal(log2_int(block_size), reset_less=True)
+        choose_comb_last_addr = Signal()
+
+        self.comb += [
+            If(validate,
+                # Write parameters to memory Record
+                [
+                    param_fifo.sink.__getattr__(sig[0]).eq(sink.__getattr__(sig[0]))
+                    for sig in layout.param_layout
+                ],
+                If(choose_comb_last_addr,
+                    param_fifo.sink.last_addr.eq(local_in_addr),
+                ).Else(
+                    param_fifo.sink.last_addr.eq(saved_last_addr)
+                ),
+                param_fifo.sink.valid.eq(1)
+            )
+        ]
+
+        self.sync += [
+            If(inc & ~dec,
+                level.eq(level + 1)
+            ).Elif(~inc & dec,
+                level.eq(level - 1)
+            )
+        ]
+
+        self.comb += [
+            real_in_addr.eq(Cat(local_in_addr, in_block)),
+            real_out_addr.eq(Cat(reading_addr, out_block))
+        ]
+
+        # Output signals logic
+        self.comb += [
+            [
+                source.__getattr__(sig[0]).eq(param_fifo.source.__getattr__(sig[0]))
+                for sig in layout.param_layout
+            ],
+            # Adding & ~dec would also work, but it would link output and input combinatorially
+            full.eq(level == ((depth - 1) if discarding else (depth)))
+        ]
+
+        # In buffer FSM logic
+        self.comb += [
+            in_port.adr.eq(real_in_addr),
+            in_port.dat_w.eq(sink.data)
+        ]
+
+        self.in_fsm = in_fsm = FSM(reset_state="WRITE")
+        in_fsm.act("WRITE",
+            sink.ready.eq(1),
+            If(sink.valid,
+                in_port.we.eq(1),
+                NextValue(local_in_addr, local_in_addr + 1),
+                If(invalidate,
+                    NextValue(local_in_addr, 0),
+                ).Elif(sink.last,
+                    NextValue(saved_last_addr, local_in_addr),
+                    choose_comb_last_addr.eq(1),
+                    NextState("WAIT"),
+                )
+            )
+        )
+
+        self.sync += [
+            If(in_fsm.ongoing("WAIT"),
+                If(validated,
+                    validated.eq(0)
+                )
+            ).Else(
+                If(validate,
+                    validated.eq(1)
+                )
+            )
+        ]
+
+        if discarding:
+            in_fsm.act("WAIT",
+                NextValue(local_in_addr, 0),
+                If(validated | validate,
+                    If((level == depth - 1) & ~dec,
+                        NextState("WRITE")
+                    ).Else(
+                        If(in_block == depth - 1,
+                            NextValue(in_block, 0)
+                        ).Else(
+                            NextValue(in_block, in_block + 1)
+                        ),
+                        inc.eq(1),
+                        NextState("WRITE")
+                    )
+                ).Elif(invalidate,
+                    NextState("WRITE")
+                )
+            )
+
+        else:
+            in_fsm.act("WAIT",
+                NextValue(local_in_addr, 0),
+                If(validated | validate,
+                    If(in_block == depth - 1,
+                        NextValue(in_block, 0)
+                    ).Else(
+                        NextValue(in_block, in_block + 1)
+                    ),
+                    inc.eq(1),
+                    If((level == depth - 1) & ~dec,
+                        NextState("FULL")
+                    ).Else(
+                        NextState("WRITE")
+                    )
+                ).Elif(invalidate,
+                    NextState("WRITE")
+                )
+            )
+
+            in_fsm.act("FULL",
+                If(dec,
+                    NextState("WRITE")
+                )
+            )
+
+        # Out buffer FSM logic
+        self.out_fsm = out_fsm = FSM(reset_state="WAIT")
+        out_fsm.act("WAIT",
+            If(level != 0 | inc,
+                NextState("READ")
+            )
+        )
+
+        # Reading address logic
+        self.comb += [
+            local_nout_addr.eq(local_out_addr + 1),
+            If(out_fsm.ongoing("READ"),
+                If(source.ready,
+                    reading_addr.eq(local_nout_addr),
+                ).Else(
+                    reading_addr.eq(local_out_addr)
+                )
+            ).Else(
+                reading_addr.eq(local_out_addr)
+            ),
+
+            out_port.adr.eq(real_out_addr),
+            source.data.eq(out_port.dat_r)
+        ]
+        out_fsm.act("READ",
+            source.valid.eq(1),
+            source.last.eq((local_out_addr == param_fifo.source.last_addr) | source.header_only),
+            If(source.ready,
+                NextValue(local_out_addr, local_nout_addr),
+                If(source.last,
+                    param_fifo.source.ready.eq(1),
+                    If(out_block == depth-1,
+                        NextValue(out_block, 0)
+                    ).Else(
+                        NextValue(out_block, out_block + 1)
+                    ),
+                    dec.eq(1),
+                    NextValue(local_out_addr, 0),
+                    NextState("WAIT")
+                )
+            )
+        )
+
+# Variable Packetizer ---------------------------------------------------------------------------------------
+
+class VariablePacketizer(LiteXModule):
+    """Variable Packetizer
+
+    A packetizer that can handle headers that change depending on an opcode.
+
+    Parameters
+    ----------
+    sink_description : description
+        Headers + data.
+    source_description : description
+        Raw data.
+    headers : list[Header]
+        Possible headers in the packet
+        (including an always-present first header
+        that must contain the opcode).
+    opmap: dict[int, int]
+        Indicates which headers are selected depending on the opcode.
+    opcode_name : str
+        Name of the opcode signal.
+
+
+    Attributes
+    ----------
+    sink : in
+        Incoming packet data and parameters.
+    source : out
+        Outgoing packet data.
+
+    """
+    def __init__(self, sink_description, source_description, headers, opmap, opcode_name="opcode"):
+        self.sink   = sink   = Endpoint(add_params(sink_description, [("header_only", 1)]))
+        self.source = source = Endpoint(source_description)
+
+        # # #
+
+        assert hasattr(sink, opcode_name)
+
+        # Parameters.
+        data_width = len(sink.data)
+        base_header       = headers[0]
+        base_header_words = (base_header.length * 8) // data_width
+        header_words_dict = {
+            opcode:
+                base_header_words +
+                (sum(
+                    header.length
+                    for i, header in list(enumerate(headers))[1:]
+                    if (selection >> (i - 1)) & 1
+                )*8) // data_width
+            for opcode, selection in opmap.items()
+        }
+        max_size = max(header_words_dict.values())
+
+        # Signals.
+        header_length = Signal(bits_for(max_size))
+        header = Signal(max_size*8)
+
+        sr       = Signal(max(header_words_dict.values())*8, reset_less=True)
+        sr_load  = Signal()
+        sr_shift = Signal()
+        count    = Signal(max=max(*header_words_dict.values(), 2))
+        header_words = Signal(max=max(header_words_dict.values())+1)
+
+        # Determine header_words
+        self.comb += Case(sink.__getattr__(opcode_name), {
+            Constant(opcode, len(sink.__getattr__(opcode_name))):
+                header_words.eq(Constant(length, len(header_words))) for opcode, length in header_words_dict.items()
+        })
+        self.comb += header_length.eq(base_header_words + header_words)
+
+        # Header Encode/Load/Shift.
+        cases = {}
+        for opcode, selection in opmap.items():
+            cum = base_header_words
+            assignments = []
+            for i, extra_header in list(enumerate(headers))[1:]:
+                if (selection >> (i - 1)) & 1:
+                    assignments += extra_header.encode(sink, header, cum)
+                    cum += extra_header.length
+            cases[opcode] = assignments
+
+        self.comb += base_header.encode(sink, header)
+        self.comb += Case(sink.__getattr__(opcode_name), cases)
+        self.sync += If(sr_load, sr.eq(header))
+        self.sync += If(header_words != 1, If(sr_shift, sr.eq(sr[data_width:])))
+
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(0),
+            NextValue(count, 1),
+            If(sink.valid,
+                source.valid.eq(1),
+                source.last.eq((header_words == 1) & sink.header_only),
+                source.data.eq(header[:data_width]),
+                If(source.valid & source.ready,
+                    sr_load.eq(1),
+                    If(header_words == 1,
+                        NextState("ALIGNED-DATA-COPY"),
+                        If(sink.header_only,
+                           NextState("IDLE")
+                        )
+                    ).Else(
+                        NextState("HEADER-SEND")
+                    )
+               )
+            )
+        )
+        fsm.act("HEADER-SEND",
+            source.valid.eq(1),
+            source.last.eq((count == header_words - 1) & sink.header_only),
+            source.data.eq(sr[min(data_width, len(sr)-1):]),
+            If(source.valid & source.ready,
+                sr_shift.eq(1),
+                If(count == header_words - 1,
+                    sr_shift.eq(0),
+                    NextState("ALIGNED-DATA-COPY"),
+                    NextValue(count, count + 1),
+                    If(sink.header_only,
+                        sink.ready.eq(1),
+                        NextState("IDLE")
+                    )
+                ).Else(
+                    NextValue(count, count + 1),
+                )
+            )
+        )
+        fsm.act("ALIGNED-DATA-COPY",
+            sink.connect(source, keep={"valid", "ready", "last", "data"}),
+            If(source.valid & source.ready,
+                If(source.last,
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        # Error.
+        if hasattr(sink, "error") and hasattr(source, "error"):
+            self.comb += source.error.eq(sink.error)
+
+# Variable Depacketizer -------------------------------------------------------------------------------------
+
+class VariableDepacketizer(LiteXModule):
+    """Variable Depacketizer
+
+    A depacketizer that can handle headers that change depending on an opcode in the packet.
+
+    Parameters
+    ----------
+    sink_description : description
+        Raw data.
+    source_description : description
+        Headers + data.
+    headers : list[Header]
+        Possible headers in the packet
+        (including an always-present first header
+        that must contain the opcode).
+    opmap: dict[int, int]
+        Indicates which headers are selected depending on the opcode.
+    opcode_name : str
+        Name of the opcode signal.
+
+
+    Attributes
+    ----------
+    sink : in
+        Incoming packet data.
+    source : out
+        Outgoing packet data and parameters.
+
+    """
+    def __init__(self, sink_description, source_description, headers, opmap, opcode_name="opcode"):
+        self.sink   = sink   = Endpoint(sink_description)
+        self.source = source = Endpoint(add_params(source_description, [("header_only", 1)]))
+
+        # # #
+
+        assert hasattr(source, opcode_name)
+
+        # Parameters.
+        data_width        = len(sink.data)
+        bytes_per_clk     = data_width//8
+        base_header       = headers[0]
+        base_header_words = (base_header.length * 8) // data_width
+        # Does not include base header
+        header_words_dict = {
+            opcode:
+                (sum(
+                    header.length
+                    for i, header in list(enumerate(headers))[1:]
+                    if (selection >> (i - 1)) & 1
+                )*8) // data_width
+            for opcode, selection in opmap.items()
+        }
+        max_header_words = max(header_words_dict.values())
+
+        # Signals.
+
+        sr            = Signal(max_header_words*8, reset_less=True)
+        sr_shift      = Signal()
+        bhsr          = Signal(base_header_words*8, reset_less=True)
+        bhsr_shift    = Signal()
+        count         = Signal(max=max(base_header_words + max_header_words, 2))
+        header_words  = Signal(max=max_header_words + 1)
+        header_length = Signal(max=base_header_words + max_header_words + 1)
+
+        # Determine header_words
+
+        self.comb += Case(source.__getattr__(opcode_name), {
+            Constant(opcode, len(source.__getattr__(opcode_name))):
+                header_words.eq(Constant(length, len(header_words))) for opcode, length in header_words_dict.items()
+        })
+        self.comb += header_length.eq(base_header_words + header_words)
+
+        # Header Shift/Decode.
+        self.sync += [
+            If(header_words == 1,
+                If(sr_shift, sr.eq(sink.data))
+            ).Else(
+                If(sr_shift, sr.eq(Cat(sr[bytes_per_clk*8:], sink.data)))
+            )
+        ]
+        if base_header_words == 1:
+            self.sync += If(bhsr_shift, bhsr.eq(sink.data))
+        else:
+            self.sync += If(bhsr_shift, bhsr.eq(Cat(bhsr[bytes_per_clk*8:], sink.data)))
+
+        # Select decodes depending on opcode
+        decode_cases = {}
+        for opcode, selection in opmap.items():
+            # bits need to be shifted to end of register
+            shift = (max_header_words - header_words_dict[opcode])*8
+            cum = 0
+            decode_cases[opcode] = []
+            for i, header in list(enumerate(headers))[1:]:
+                if (selection >> (i - 1)) & 1:
+                    # Decode the appropriate header selection into the
+                    decode_cases[opcode] += header.decode(sr[shift:], source, cum)
+                    cum += header.length
+
+        self.comb += Case(source.__getattr__(opcode_name), decode_cases)
+        self.comb += base_header.decode(bhsr, source)
+
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            sink.ready.eq(1),
+            NextValue(count, 1),
+            If(sink.valid,
+                bhsr_shift.eq(1),
+                If(base_header_words == 1,
+                    NextState("DECODE-OPCODE"),
+                    If(sink.last & sink.valid,
+                        NextState("HEADER-ONLY")
+                    )
+                ).Else(
+                    NextState("BASE-HEADER-RECEIVE"),
+                )
+            )
+        )
+
+        fsm.act("BASE-HEADER-RECEIVE",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(count, count + 1),
+                bhsr_shift.eq(1),
+                If(count == (base_header_words - 1),
+                    NextState("DECODE-OPCODE"),
+                    If(sink.last & sink.valid,
+                        NextState("HEADER-ONLY")
+                    )
+                )
+            )
+        )
+
+        fsm.act("DECODE-OPCODE",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(count, count + 1),
+                If(header_words == 0,
+                    source.valid.eq(sink.valid),
+                    source.last.eq(sink.last),
+                    sink.ready.eq(source.ready),
+                    source.data.eq(sink.data),
+                    NextState("ALIGNED-DATA-COPY"),
+                ).Elif(header_words == 1,
+                    sr_shift.eq(1),
+                    NextState("ALIGNED-DATA-COPY"),
+                    If(sink.last & sink.valid,
+                        NextState("HEADER-ONLY")
+                    )
+                ).Else(
+                    sr_shift.eq(1),
+                    NextValue(count, count + 1),
+                    NextState("HEADER-RECEIVE")
+                )
+            )
+        )
+
+        fsm.act("HEADER-RECEIVE",
+            sink.ready.eq(1),
+            If(sink.valid,
+                NextValue(count, count + 1),
+                sr_shift.eq(1),
+                If(count == (base_header_words + header_words - 1),
+                    NextState("ALIGNED-DATA-COPY"),
+                    NextValue(count, count + 1),
+                    If(sink.last & sink.valid,
+                        NextState("HEADER-ONLY")
+                    )
+                )
+            )
+        )
+
+        fsm.act("ALIGNED-DATA-COPY",
+            source.valid.eq(sink.valid),
+            source.last.eq(sink.last),
+            sink.ready.eq(source.ready),
+            source.data.eq(sink.data),
+            If(source.valid & source.ready,
+                If(source.last,
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        fsm.act("HEADER-ONLY",
+            source.header_only.eq(1),
+            source.valid.eq(1),
+            source.last.eq(1),
+            If(source.ready,
+                NextState("IDLE")
+            )
+        )
+
+        # Error.
+        if hasattr(sink, "error") and hasattr(source, "error"):
+            self.comb += source.error.eq(sink.error)

--- a/liteeth/core/rocev2/cq.py
+++ b/liteeth/core/rocev2/cq.py
@@ -1,0 +1,73 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from collections import OrderedDict
+
+from litex.soc.interconnect.stream import SyncFIFO, Endpoint
+
+from litex.soc.interconnect.packet import Dispatcher
+
+class LiteEthIBCQMasterPort:
+    def __init__(self):
+        self.sink = Endpoint(eth_rocev2_cq_description())
+
+class LiteEthIBCQSlavePort:
+    def __init__(self):
+        self.source = Endpoint(eth_rocev2_cq_description())
+
+class LiteEthIBCQUserPort(LiteEthIBCQSlavePort):
+    def __init__(self):
+        LiteEthIBCQSlavePort.__init__(self)
+
+class LiteEthIBCQCrossbar(LiteXModule):
+    def __init__(self):
+        self.users = OrderedDict()
+        self.master = LiteEthIBCQMasterPort()
+
+    def get_port(self, qp_id, cd="sys", depth=None):
+        if qp_id in self.users.keys():
+            raise ValueError(f"QP with id {qp_id:#x} already assigned")
+
+        user_port     = LiteEthIBCQUserPort()
+        internal_port = LiteEthIBCQUserPort()
+
+        self.cdc = cdc = stream.ClockDomainCrossing(
+            layout  = eth_rocev2_cq_description(),
+            cd_from = "sys",
+            cd_to   = cd,
+            depth   = depth,
+        )
+        self.comb += [
+            internal_port.source.connect(cdc.sink),
+            cdc.source.connect(user_port.source)
+        ]
+
+        self.users[qp_id] = internal_port
+        return user_port
+
+    def do_finalize(self):
+        assert len(self.users) == 1
+
+        self.comb += self.master.sink.connect(list(self.users.values())[0].source)
+        # sources = [port.source for port in self.users.values()]
+        # self.dispatcher = Dispatcher(self.master.sink, sources)
+        # dispatch_sig = getattr(self.master.sink, self.dispatch_param)
+        # for i, k in enumerate(self.users.keys()):
+        #     self.comb += If(dispatch_sig == k, self.dispatcher.sel.eq(2**i))
+
+# Completion queue
+class LiteEthCQ(LiteXModule):
+    def __init__(self, depth, buffered=True):
+        self.sink     = sink     = Endpoint(eth_rocev2_cq_description())
+        self.crossbar = crossbar = LiteEthIBCQCrossbar()
+
+        # # #
+
+        fifo = SyncFIFO(eth_rocev2_cq_description(), depth, buffered)
+        self.submodules += fifo
+
+        self.comb += [
+            sink.connect(fifo.sink),
+            fifo.source.connect(crossbar.master.sink)
+        ]

--- a/liteeth/core/rocev2/icrc.py
+++ b/liteeth/core/rocev2/icrc.py
@@ -1,0 +1,324 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Endpoint
+
+from litex.gen.genlib.misc import chooser
+
+# ICRC ---------------------------------------------------------------------------------------------
+@ResetInserter()
+@CEInserter()
+class LiteEthInfinibandCRC32(LiteXModule):
+    """IEEE 802.3 CRC
+
+    Implement an IEEE 802.3 CRC generator/checker.
+
+    Parameters
+    ----------
+    data_width : int
+        Width of the data bus.
+
+    Attributes
+    ----------
+    data : in
+        Data input.
+    be : in
+        Data byte enable (optional, defaults to full word).
+    value : out
+        CRC value (used for generator).
+    error : out
+        CRC error (used for checker).
+    """
+    width   = 32
+    polynom = 0x04c11db7
+    # 8 0xff bytes are inserted into crc to simulate a dummy LRH (which isn't present in RoCEv2)
+    init    = 0xc704dd7b
+    xor_final = 0xFFFFFFFF
+    check   = 0xc704dd7b
+    def __init__(self, data_width):
+        self.data  = Signal(data_width)
+        self.be    = Signal(data_width//8, reset=2**data_width//8 - 1)
+        self.value = Signal(self.width)
+        self.error = Signal()
+
+        # # #
+
+        from liteeth.mac.crc import LiteEthMACCRCEngine
+        # Create a CRC Engine for each byte segment.
+        # Ex for a 32-bit Data-Path, we create 4 engines: 8, 16, 24 and 32-bit engines.
+        engines = []
+        for n in range(data_width//8):
+            engine = LiteEthMACCRCEngine(
+                data_width = (n + 1)*8,
+                width      = self.width,
+                polynom    = self.polynom,
+            )
+            engines.append(engine)
+        self.submodules += engines
+
+        # Register Full-Word CRC Engine (last one).
+        reg = Signal(self.width, reset=self.init)
+        self.sync += reg.eq(engines[-1].crc_next)
+
+        # Select CRC Engine/Result.
+        for n in range(data_width//8):
+            self.comb += [
+                engines[n].data.eq(self.data),
+                engines[n].crc_prev.eq(reg),
+                If(self.be[n],
+                    self.value.eq(engines[n].crc_next[::-1] ^ self.xor_final),
+                    self.error.eq(engines[n].crc_next != self.check),
+                )
+            ]
+
+@ResetInserter()
+class LiteEthInfinibandICRCCalculator(LiteXModule):
+    """CRC Calculator
+
+    Calculates CRC masking the correct IPv4 and UDP fields for RoCEv2.
+
+    Parameters
+    ----------
+    description : description
+        description of the dataflow.
+
+    Attributes
+    ----------
+    ce : in
+        Activates calculator for this cycle.
+    data : in
+        Packet data without CRC.
+    crc_packet : out
+        Resulting CRC value.
+    """
+    def __init__(self, dw):
+        self.ce         = ce         = Signal()
+        self.data       = data       = Signal(dw)
+        self.crc_packet = crc_packet = Signal(32, reset_less=True)
+
+        # # #
+
+        # Parameters.
+        assert dw in [8]
+
+        # Signals.
+        byte_cnt = Signal(16)
+
+        # CRC32 Generator.
+        crc = LiteEthInfinibandCRC32(dw)
+        self.submodules += crc
+
+        self.comb += [
+            # Variable bytes are masked in ICRC
+            If(is_in(byte_cnt, [1, 8, 10, 11, 26, 27, 32]),
+                crc.data.eq(0xff)
+            ).Else(
+                crc.data.eq(data)
+            ),
+            crc.ce.eq(ce),
+        ]
+
+        self.sync += [
+            If(ce,
+                byte_cnt.eq(byte_cnt + 1),
+                crc_packet.eq(crc.value)
+            ),
+        ]
+
+class LiteEthInfinibandICRCInserter(LiteXModule):
+    """CRC Inserter
+
+    Append a CRC at the end of each packet.
+
+    Parameters
+    ----------
+    listen_description : description
+        description of the dataflow at IP_TX's source.
+    description : description
+        description of the dataflow.
+
+    Attributes
+    ----------
+    sink : in
+        Packet data without CRC.
+    calculator_sink : in
+        Packet data without CRC after UDP and IP.
+    source : out
+        Packet data with CRC.
+    """
+    def __init__(self, listen_description, description):
+        self.sink            = sink            = Endpoint(description)
+        self.source          = source          = Endpoint(description)
+        self.calculator_sink = calculator_sink = Endpoint(listen_description)
+
+        # # #
+
+        # Parameters.
+        data_width  = len(sink.data)
+        ratio       = 32//data_width
+        assert data_width in [8]
+
+        self.crc_calc = crc_calc = LiteEthInfinibandICRCCalculator(len(calculator_sink.data))
+
+        crc            = Signal(32)
+        remembered_crc = Signal(32, reset_less=True)
+        rem_crc        = Signal()
+
+        # Combinatorial remembering logic
+        self.sync += If(rem_crc,
+            remembered_crc.eq(crc_calc.crc_packet)
+        )
+        self.comb += If(rem_crc,
+            crc.eq(crc_calc.crc_packet)
+        ).Else(
+            crc.eq(remembered_crc)
+        )
+
+        self.comb += [
+            crc_calc.data.eq(calculator_sink.data),
+        ]
+
+        self.fsm = fsm = FSM(reset_state="COPY")
+        fsm.act("COPY",
+            crc_calc.ce.eq(calculator_sink.valid & calculator_sink.ready),
+            sink.connect(source, omit={"last", "ready"}),
+            sink.ready.eq(~sink.last & source.ready),
+            If(sink.valid & source.ready & sink.last,
+                NextValue(rem_crc, 1),
+                NextState("CRC")
+            )
+        )
+
+        if ratio > 1:
+            cnt      = Signal(max=ratio, reset=ratio-1)
+            cnt_done = Signal()
+            fsm.act("CRC",
+                source.valid.eq(1),
+                crc_calc.reset.eq(1),
+                chooser(crc, cnt, source.data, reverse=True),
+                NextValue(rem_crc, 0),
+                If(cnt_done,
+                    source.last.eq(1),
+                    If(source.ready,
+                        sink.ready.eq(1),
+                        NextState("COPY")
+                    )
+                )
+            )
+            self.comb += cnt_done.eq(cnt == 0)
+            self.sync += \
+                If(fsm.ongoing("COPY"),
+                    cnt.eq(cnt.reset)
+                ).Elif(fsm.ongoing("CRC") & ~cnt_done,
+                    cnt.eq(cnt - source.ready)
+                )
+        else:
+            fsm.act("CRC",
+                NextValue(rem_crc, 0),
+                source.valid.eq(1),
+                source.last.eq(1),
+                source.data.eq(crc),
+                If(source.ready,
+                    sink.ready.eq(1),
+                    NextState("COPY")
+                )
+            )
+
+class LiteEthInfinibandICRCChecker(LiteXModule):
+    """CRC Checker
+
+    Check CRC at the end of each packet.
+
+    Parameters
+    ----------
+    description : description
+        description of the dataflow.
+
+    Attributes
+    ----------
+    sink : in
+        Packet data with CRC.
+    calculator_sink : in
+        Packet data with CRC before IP_RX.
+    source : out
+        Packet data without CRC and "error" set to 0
+        on last when CRC OK / set to 1 when CRC KO.
+    error : out
+        Pulses every time a CRC error is detected.
+    """
+    def __init__(self, listen_description, description):
+        self.sink            = sink            = Endpoint(description)
+        self.source          = source          = Endpoint(description)
+        self.calculator_sink = calculator_sink = Endpoint(listen_description)
+
+        self.valid_crc = valid_crc = Signal()
+
+        # Can be disabled for debug purposes
+        self.actual_check = CSRStorage(reset=1)
+
+        # # #
+
+        self.crc_calc = crc_calc = LiteEthInfinibandICRCCalculator(len(calculator_sink.data))
+
+        pipe      = Signal(32, reset_less=True)
+        calc_pipe = Signal(32, reset_less=True)
+
+        shift_pipe = Signal()
+
+        self.sync += [
+            If(calculator_sink.valid & calculator_sink.ready,
+                calc_pipe.eq(Cat(calc_pipe[8:], calculator_sink.data))
+            ),
+            If(shift_pipe, pipe.eq(Cat(pipe[8:], sink.data)))
+        ]
+
+        fill_cnt = Signal(2)
+        self.fsm = fsm = FSM(reset_state="FILL")
+        fsm.act("FILL",
+            sink.ready.eq(1),
+            If(sink.valid,
+                shift_pipe.eq(1),
+                NextValue(fill_cnt, fill_cnt + 1),
+                If(fill_cnt == 3,
+                    NextState("PASSTHROUGH")
+                )
+            )
+        )
+
+        fsm.act("PASSTHROUGH",
+            shift_pipe.eq(sink.valid & source.ready),
+            sink.connect(source, keep={"valid", "ready", "last"}),
+            If(sink.valid & source.ready & sink.last,
+                NextState("FILL")
+            )
+        )
+
+        calc_fill_cnt = Signal(2)
+        self.fsm_calc = fsm_calc = FSM(reset_state="FILL")
+        fsm_calc.act("FILL",
+            If(calculator_sink.valid & calculator_sink.ready,
+                NextValue(calc_fill_cnt, calc_fill_cnt + 1),
+                If(calc_fill_cnt == 3,
+                    NextState("CALCULATE")
+                )
+            )
+        )
+
+        fsm_calc.act("CALCULATE",
+            # Calculator connection
+            crc_calc.ce.eq(calculator_sink.valid & calculator_sink.ready),
+            If(calculator_sink.valid & calculator_sink.ready & calculator_sink.last,
+                crc_calc.reset.eq(1),
+                NextState("FILL")
+            )
+        )
+
+        self.comb += [
+            # Passthough connection (with delay)
+            source.data.eq(pipe[:8]),
+
+            crc_calc.data.eq(calc_pipe[:8]),
+
+            valid_crc.eq((~self.actual_check.storage) | (crc_calc.crc_packet == pipe))
+        ]

--- a/liteeth/core/rocev2/icrc.py
+++ b/liteeth/core/rocev2/icrc.py
@@ -1,0 +1,327 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Endpoint
+
+from litex.gen.genlib.misc import chooser
+
+# ICRC ---------------------------------------------------------------------------------------------
+@ResetInserter()
+@CEInserter()
+class LiteEthInfinibandCRC32(LiteXModule):
+    """IEEE 802.3 CRC
+
+    Implement an IEEE 802.3 CRC generator/checker.
+
+    Parameters
+    ----------
+    data_width : int
+        Width of the data bus.
+
+    Attributes
+    ----------
+    data : in
+        Data input.
+    be : in
+        Data byte enable (optional, defaults to full word).
+    value : out
+        CRC value (used for generator).
+    error : out
+        CRC error (used for checker).
+    """
+    width   = 32
+    polynom = 0x04c11db7
+    # 8 0xff bytes are inserted into crc to simulate a dummy LRH (which isn't present in RoCEv2)
+    init    = 0xc704dd7b
+    xor_final = 0xFFFFFFFF
+    check   = 0xc704dd7b
+    def __init__(self, data_width):
+        self.data  = Signal(data_width)
+        self.be    = Signal(data_width//8, reset=2**data_width//8 - 1)
+        self.value = Signal(self.width)
+        self.error = Signal()
+
+        # # #
+
+        from liteeth.mac.crc import LiteEthMACCRCEngine
+        # Create a CRC Engine for each byte segment.
+        # Ex for a 32-bit Data-Path, we create 4 engines: 8, 16, 24 and 32-bit engines.
+        engines = []
+        for n in range(data_width//8):
+            engine = LiteEthMACCRCEngine(
+                data_width = (n + 1)*8,
+                width      = self.width,
+                polynom    = self.polynom,
+            )
+            engines.append(engine)
+        self.submodules += engines
+
+        # Register Full-Word CRC Engine (last one).
+        reg = Signal(self.width, reset=self.init)
+        self.sync += reg.eq(engines[-1].crc_next)
+
+        # Select CRC Engine/Result.
+        for n in range(data_width//8):
+            self.comb += [
+                engines[n].data.eq(self.data),
+                engines[n].crc_prev.eq(reg),
+                If(self.be[n],
+                    self.value.eq(engines[n].crc_next[::-1] ^ self.xor_final),
+                    self.error.eq(engines[n].crc_next != self.check),
+                )
+            ]
+
+@ResetInserter()
+class LiteEthInfinibandICRCCalculator(LiteXModule):
+    """CRC Calculator
+
+    Calculates CRC masking the correct IPv4 and UDP fields for RoCEv2.
+
+    Parameters
+    ----------
+    description : description
+        description of the dataflow.
+
+    Attributes
+    ----------
+    ce : in
+        Activates calculator for this cycle.
+    data : in
+        Packet data without CRC.
+    crc_packet : out
+        Resulting CRC value.
+    """
+    def __init__(self, dw):
+        self.ce         = ce         = Signal()
+        self.data       = data       = Signal(dw)
+        self.crc_packet = crc_packet = Signal(32, reset_less=True)
+
+        # # #
+
+        # Parameters.
+        assert dw in [8]
+
+        # Signals.
+        byte_cnt = Signal(16)
+
+        # CRC32 Generator.
+        crc = LiteEthInfinibandCRC32(dw)
+        self.submodules += crc
+
+        self.comb += [
+            # Variable bytes are masked in ICRC
+            If(is_in(byte_cnt, [1, 8, 10, 11, 26, 27, 32]),
+                crc.data.eq(0xff)
+            ).Else(
+                crc.data.eq(data)
+            ),
+            crc.ce.eq(ce),
+        ]
+
+        self.sync += [
+            If(ce,
+                byte_cnt.eq(byte_cnt + 1),
+                crc_packet.eq(crc.value)
+            ),
+        ]
+
+class LiteEthInfinibandICRCInserter(LiteXModule):
+    """CRC Inserter
+
+    Append a CRC at the end of each packet.
+
+    Parameters
+    ----------
+    listen_description : description
+        description of the dataflow at IP_TX's source.
+    description : description
+        description of the dataflow.
+
+    Attributes
+    ----------
+    sink : in
+        Packet data without CRC.
+    calculator_sink : in
+        Packet data without CRC after UDP and IP.
+    source : out
+        Packet data with CRC.
+    """
+    def __init__(self, listen_description, description):
+        self.sink            = sink            = Endpoint(description)
+        self.source          = source          = Endpoint(description)
+        self.calculator_sink = calculator_sink = Endpoint(listen_description)
+
+        # # #
+
+        # Parameters.
+        data_width  = len(sink.data)
+        ratio       = 32//data_width
+        assert data_width in [8]
+
+        self.crc_calc = crc_calc = LiteEthInfinibandICRCCalculator(len(calculator_sink.data))
+
+        crc            = Signal(32)
+        remembered_crc = Signal(32, reset_less=True)
+        rem_crc        = Signal()
+
+        # Combinatorial remembering logic
+        self.sync += If(rem_crc,
+            remembered_crc.eq(crc_calc.crc_packet)
+        )
+        self.comb += If(rem_crc,
+            crc.eq(crc_calc.crc_packet)
+        ).Else(
+            crc.eq(remembered_crc)
+        )
+
+        self.comb += [
+            crc_calc.data.eq(calculator_sink.data),
+        ]
+
+        self.fsm = fsm = FSM(reset_state="COPY")
+        fsm.act("COPY",
+            crc_calc.ce.eq(calculator_sink.valid & calculator_sink.ready),
+            sink.connect(source, omit={"last", "ready"}),
+            sink.ready.eq(~sink.last & source.ready),
+            If(sink.valid & source.ready & sink.last,
+                NextValue(rem_crc, 1),
+                NextState("CRC")
+            ),
+            If(calculator_sink.valid & calculator_sink.ready & calculator_sink.last,
+                crc_calc.reset.eq(1)
+            )
+        )
+
+        if ratio > 1:
+            cnt      = Signal(max=ratio, reset=ratio-1)
+            cnt_done = Signal()
+            fsm.act("CRC",
+                source.valid.eq(1),
+                crc_calc.reset.eq(1),
+                chooser(crc, cnt, source.data, reverse=True),
+                NextValue(rem_crc, 0),
+                If(cnt_done,
+                    source.last.eq(1),
+                    If(source.ready,
+                        sink.ready.eq(1),
+                        NextState("COPY")
+                    )
+                )
+            )
+            self.comb += cnt_done.eq(cnt == 0)
+            self.sync += \
+                If(fsm.ongoing("COPY"),
+                    cnt.eq(cnt.reset)
+                ).Elif(fsm.ongoing("CRC") & ~cnt_done,
+                    cnt.eq(cnt - source.ready)
+                )
+        else:
+            fsm.act("CRC",
+                NextValue(rem_crc, 0),
+                source.valid.eq(1),
+                source.last.eq(1),
+                source.data.eq(crc),
+                If(source.ready,
+                    sink.ready.eq(1),
+                    NextState("COPY")
+                )
+            )
+
+class LiteEthInfinibandICRCChecker(LiteXModule):
+    """CRC Checker
+
+    Check CRC at the end of each packet.
+
+    Parameters
+    ----------
+    description : description
+        description of the dataflow.
+
+    Attributes
+    ----------
+    sink : in
+        Packet data with CRC.
+    calculator_sink : in
+        Packet data with CRC before IP_RX.
+    source : out
+        Packet data without CRC and "error" set to 0
+        on last when CRC OK / set to 1 when CRC KO.
+    error : out
+        Pulses every time a CRC error is detected.
+    """
+    def __init__(self, listen_description, description):
+        self.sink            = sink            = Endpoint(description)
+        self.source          = source          = Endpoint(description)
+        self.calculator_sink = calculator_sink = Endpoint(listen_description)
+
+        self.valid_crc = valid_crc = Signal()
+
+        # Can be disabled for debug purposes
+        self.actual_check = CSRStorage(reset=1)
+
+        # # #
+
+        self.crc_calc = crc_calc = LiteEthInfinibandICRCCalculator(len(calculator_sink.data))
+
+        pipe      = Signal(32, reset_less=True)
+        calc_pipe = Signal(32, reset_less=True)
+
+        shift_pipe = Signal()
+
+        self.sync += [
+            If(calculator_sink.valid & calculator_sink.ready,
+                calc_pipe.eq(Cat(calc_pipe[8:], calculator_sink.data))
+            ),
+            If(shift_pipe, pipe.eq(Cat(pipe[8:], sink.data)))
+        ]
+
+        fill_cnt = Signal(2)
+        self.fsm = fsm = FSM(reset_state="FILL")
+        fsm.act("FILL",
+            sink.ready.eq(1),
+            If(sink.valid,
+                shift_pipe.eq(1),
+                NextValue(fill_cnt, fill_cnt + 1),
+                If(fill_cnt == 3,
+                    NextState("PASSTHROUGH")
+                )
+            )
+        )
+
+        fsm.act("PASSTHROUGH",
+            shift_pipe.eq(sink.valid & source.ready),
+            sink.connect(source, keep={"valid", "ready", "last"}),
+            If(sink.valid & source.ready & sink.last,
+                NextState("FILL")
+            )
+        )
+
+        calc_fill_cnt = Signal(2)
+        self.fsm_calc = fsm_calc = FSM(reset_state="FILL")
+        fsm_calc.act("FILL",
+            If(calculator_sink.valid & calculator_sink.ready,
+                NextValue(calc_fill_cnt, calc_fill_cnt + 1),
+                If(calc_fill_cnt == 3,
+                    NextState("CALCULATE")
+                )
+            )
+        )
+
+        fsm_calc.act("CALCULATE",
+            # Calculator connection
+            crc_calc.ce.eq(calculator_sink.valid & calculator_sink.ready),
+            If(calculator_sink.valid & calculator_sink.ready & calculator_sink.last,
+                crc_calc.reset.eq(1),
+                NextState("FILL")
+            )
+        )
+
+        self.comb += [
+            # Passthough connection (with delay)
+            source.data.eq(pipe[:8]),
+
+            crc_calc.data.eq(calc_pipe[:8]),
+
+            valid_crc.eq((~self.actual_check.storage) | (crc_calc.crc_packet == pipe))
+        ]

--- a/liteeth/core/rocev2/ipcm.py
+++ b/liteeth/core/rocev2/ipcm.py
@@ -1,0 +1,38 @@
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Endpoint
+
+from liteeth.packet import Depacketizer
+
+class LiteEthIPCMDepacketizer(Depacketizer):
+    def __init__(self, dw=8):
+        Depacketizer.__init__(self,
+            eth_mad_description(dw),
+            eth_ipcm_description(dw),
+            ipcm_header
+        )
+
+# TODO : Add handling for ServiceID
+class LiteEthIPCM(LiteXModule):
+    def __init__(self, mad_rx, dw=8):
+        self.validate_sink = validate_sink = Endpoint([("validate", 1)])
+        self.source = source = Endpoint(EndpointDescription([("data", dw)], [("AttributeID", 16)]))
+
+        # # #
+
+        self.ipcm_depacketizer = ipcm_depacketizer = LiteEthIPCMDepacketizer(dw=dw)
+
+        # Data-path
+        self.comb += [
+            If(mad_rx.source.AttributeID == MAD_ATTRIB_ID.ConnectRequest,
+                mad_rx.source.connect(ipcm_depacketizer.sink, omit={"AttributeID"}),
+                ipcm_depacketizer.source.connect(source, keep={"valid", "ready", "last", "data"}),
+                source.AttributeID.eq(MAD_ATTRIB_ID.ConnectRequest)
+            ).Else(
+                mad_rx.source.connect(source)
+            )
+        ]
+
+        self.comb += [
+            validate_sink.connect(mad_rx.validate_sink)
+        ]

--- a/liteeth/core/rocev2/mad_cm.py
+++ b/liteeth/core/rocev2/mad_cm.py
@@ -1,0 +1,476 @@
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import SyncFIFO, Buffer, Endpoint
+
+from liteeth.core.rocev2.common import VariablePacketizer, VariableDepacketizer, VarWaitTimer
+from liteeth.core.rocev2.qp import LiteEthIBQP
+from liteeth.core.rocev2.mad_cm_msg import REP, REJ, DREP, DREQ, CPI, MAD_response, _CM_response
+from liteeth.core.rocev2.ipcm import LiteEthIPCM
+
+from litex.gen.genlib.misc import WaitTimer
+
+MAD_PMTU = 256 # The payload size for MAD is always 256 regardless of PMTU
+
+class LiteEthCMConn(LiteXModule):
+    def __init__(self):
+        self.qpn = Signal(24)
+        self.Remote_Communication_ID = Signal(32)
+
+        # C13-19.1.1: Transaction uniqueness is ensured by the combination of
+        # MgmtClass, TransactionID (and SGID or SLID, which don't exist for RoCEv2)
+        # Since we only support communication Managment, MgmtClass is always the same
+        self.TransactionID = Signal(64)
+
+        self.saved = Signal()
+
+class LiteEthCMDepacketizer(VariableDepacketizer):
+    def __init__(self, dw=8):
+        VariableDepacketizer.__init__(self,
+            eth_rocev2_user_description(dw),
+            eth_mad_description(dw),
+            mad_cm_headers,
+            mad_cm_opmap,
+            "AttributeID"
+        )
+
+class LiteEthCMPacketizer(VariablePacketizer):
+    def __init__(self, dw=8):
+        VariablePacketizer.__init__(self,
+            eth_mad_description(dw),
+            eth_rocev2_user_description(dw),
+            mad_cm_headers,
+            mad_cm_opmap,
+            "AttributeID"
+        )
+
+class LiteEthIBMADTX(LiteXModule):
+    def __init__(self, buffered_out=True, dw=8):
+        self.source = source = Endpoint(eth_rocev2_user_description(dw))
+        self.reply_sink = Endpoint(eth_mad_description(dw))
+
+        # # #
+
+        if buffered_out:
+            buff_out = Buffer(eth_rocev2_user_description(dw), pipe_ready=True)
+            self.submodules.buff_out = buff_out
+            self.comb += buff_out.source.connect(source)
+            source = buff_out.sink
+
+        # Buffer to get replies from LiteEthIBMADRX
+        reply_buf = Buffer(eth_mad_description(dw), pipe_ready=True)
+        self.submodules.reply_buf = reply_buf
+        self.comb += self.reply_sink.connect(reply_buf.sink)
+
+        # Packetizer.
+        self.packetizer = packetizer = LiteEthCMPacketizer(dw=dw)
+
+        self.comb += [
+            reply_buf.source.connect(packetizer.sink, omit={"ready"}),
+            packetizer.sink.header_only.eq(1)
+        ]
+
+        counter = Signal(max=MAD_PMTU, reset_less=True)
+
+        # FSM
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(packetizer.source.valid,
+                NextValue(counter, 0),
+                NextState("SEND")
+            )
+        )
+        fsm.act("SEND",
+            packetizer.source.connect(source, keep={"valid", "ready", "data"}),
+            If(source.valid & source.ready,
+                NextValue(counter, counter + 1),
+                If(packetizer.source.last,
+                    NextState("PAD"),
+                    reply_buf.source.ready.eq(1),
+                    If(counter == MAD_PMTU - 1,
+                        NextState("IDLE")
+                    )
+                )
+            )
+        )
+        # MAD packets are always the size of MAD_PMTU
+        fsm.act("PAD",
+            source.valid.eq(1),
+            source.last.eq(counter == MAD_PMTU - 1),
+            If(source.valid & source.ready,
+                NextValue(counter, counter + 1),
+                If(source.last,
+                    NextState("IDLE")
+                )
+            )
+        )
+
+# See page 698 of doc for reference
+class CMStateFSM(LiteXModule):
+    def __init__(self, qp, cm_conn, clk_freq, dw=8):
+        self.sink = sink = Endpoint(eth_mad_description(dw))
+        self.qp_rcv_wire = qp_rcv_wire = Signal()
+
+        # # #
+
+        # Buffer for incoming requests
+        buff_in = Buffer(eth_mad_description(dw))
+        self.submodules.buff_in = buff_in
+        self.comb += sink.connect(buff_in.sink)
+        sink = buff_in.source
+
+        # We are always consuming
+        self.comb += sink.ready.eq(1)
+
+        # The CM waits after certain operations
+        # (the time can change depending on REQ parameters)
+        cm_timer = VarWaitTimer(clk_freq)
+        self.submodules.cm_timer = cm_timer
+
+        local_cm_timeout = Signal(5, reset_less=True)
+
+        # CM FSM
+        self.fsm = fsm = FSM(reset_state="LISTEN")
+        fsm.act("LISTEN",
+            NextValue(qp.qp_state, LiteEthIBQP.INIT),
+            If(sink.valid &
+               (qp.qp_state == LiteEthIBQP.INIT) &
+               (sink.AttributeID == MAD_ATTRIB_ID.ConnectRequest),
+                NextValue(local_cm_timeout, sink.Local_CM_Response_Timeout),
+
+                NextValue(qp.other_id, sink.Local_QPN),
+                NextValue(qp.send_queue.psn, sink.Starting_PSN),
+                NextValue(qp.ip_address, sink.Primary_Local_Port_GID[:32]),
+
+                NextValue(qp.retry_cnt_rst, sink.Retry_Count),
+                NextValue(qp.retry_cnt_rnr_rst, sink.RNR_Retry_Count),
+
+                NextState("REQ Rcvd")
+            )
+        )
+
+        fsm.act("REQ Rcvd",
+            If((qp.qp_state == LiteEthIBQP.INIT) | (qp.qp_state == LiteEthIBQP.ERROR),
+                REP.emit(qp),
+                NextValue(qp.qp_state, LiteEthIBQP.RTR),
+                cm_timer.pow.eq(local_cm_timeout),
+                NextState("REP Sent")
+            ).Else(
+                REJ.emit(REJ.REASON.No_QP_available),
+                NextState("REJ Sent")
+            )
+        )
+
+        fsm.act("REJ Sent",
+            NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+            NextState("ERROR")
+        )
+
+        fsm.act("REP Sent",
+            cm_timer.wait.eq(1),
+            If(cm_timer.done,
+                NextState("RTU Timeout")
+            ).Else(
+                If((sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ReadyToUse)) | qp_rcv_wire,
+                    NextValue(qp.qp_state, LiteEthIBQP.RTS),
+                    NextState("ESTABLISHED")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.MsgRcptAck),
+                    cm_timer.pow.eq(sink.ServiceTimeout),
+                    NextState("MRA(REP) Rcvd")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ConnectReject),
+                    NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+                    NextState("ERROR")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ConnectRequest),
+                    REP.emit(qp),
+                )
+            )
+        )
+
+        fsm.act("MRA(REP) Rcvd",
+            cm_timer.wait.eq(1),
+            If(cm_timer.done,
+                NextState("RTU Timeout")
+            ).Else(
+                If((sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ReadyToUse)) | qp_rcv_wire,
+                    NextValue(qp.qp_state, LiteEthIBQP.RTS),
+                    NextState("ESTABLISHED")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ConnectReject),
+                    NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+                    NextState("ERROR")
+                )
+            )
+        )
+
+        fsm.act("ESTABLISHED",
+            If(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.DisconnectRequest) &
+              (sink.Local_Communication_ID == cm_conn.Remote_Communication_ID) &
+              (sink.Remote_Communication_ID == LOCAL_COMMUNICATION_ID) &
+              (sink.Remote_QPN_EECN == cm_conn.qpn),
+                NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+                NextState("DREQ Rcvd")
+            ).Elif(sink.valid &
+                 ((sink.AttributeID == MAD_ATTRIB_ID.ConnectReply) |
+                  (sink.AttributeID == MAD_ATTRIB_ID.ConnectRequest)),
+                If(sink.Local_QPN == qp.other_id,
+                    REJ.emit(REJ.REASON.Stale_connection),
+                    NextState("Send DREQ")
+                )
+            ).Elif(qp.local_error,
+                NextState("Send DREQ")
+            )
+        )
+
+        fsm.act("DREQ Rcvd",
+            DREP.emit(),
+            cm_timer.pow.eq(local_cm_timeout),
+            NextState("TimeWait")
+        )
+
+        # TODO Warning: Timers look at queue time not at send time
+        fsm.act("DREQ Sent",
+            cm_timer.wait.eq(1),
+            If(cm_timer.done,
+                NextState("DREP Timeout")
+            ).Else(
+                If(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.DisconnectRequest) &
+                    (sink.Local_Communication_ID == cm_conn.Remote_Communication_ID) &
+                    (sink.Remote_Communication_ID == LOCAL_COMMUNICATION_ID) &
+                    (sink.Remote_QPN_EECN == cm_conn.qpn),
+                    NextState("DREQ Rcvd")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.DisconnectReply),
+                    cm_timer.pow.eq(local_cm_timeout),
+                    NextState("TimeWait")
+                )
+            )
+        )
+
+        fsm.act("RTU Timeout",
+            REJ.emit(REJ.REASON.Timeout),
+            cm_timer.pow.eq(local_cm_timeout),
+            NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+            NextState("TimeWait")
+        )
+
+        fsm.act("TimeWait",
+            cm_timer.wait.eq(1),
+            If(cm_timer.done,
+                NextState("ERROR")
+            ).Else(
+                If(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.DisconnectRequest) &
+                (sink.Local_Communication_ID == cm_conn.Remote_Communication_ID) &
+                (sink.Remote_Communication_ID == LOCAL_COMMUNICATION_ID) &
+                (sink.Remote_QPN_EECN == cm_conn.qpn),
+                    DREP.emit()
+                )
+            )
+        )
+
+        fsm.act("DREP Timeout",
+            DREQ.emit(qp.other_id),
+            cm_timer.pow.eq(local_cm_timeout),
+            NextState("TimeWait")
+        )
+
+        # State added for convenience of treating the connection established
+        # and stale qp case (REQ Received)
+        fsm.act("Send DREQ",
+            DREQ.emit(qp.other_id),
+            cm_timer.pow.eq(local_cm_timeout),
+            NextState("DREQ Sent")
+        )
+
+        # FIXME: Rather arbitrary time choice
+        self.error_timer = error_timer = WaitTimer(PMTU)
+
+        fsm.act("ERROR",
+            NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+            error_timer.wait.eq(1),
+            If(error_timer.done,
+                NextState("RESET")
+            )
+        )
+
+        fsm.act("RESET",
+            NextValue(qp.qp_state, LiteEthIBQP.RESET),
+            NextState("LISTEN")
+        )
+
+
+class LiteEthIBMADRX(LiteXModule):
+    def __init__(self, qps, cm_conn, reply_sink, clk_freq, buffered_in=True, dw=8):
+        self.sink   = sink   = Endpoint(eth_rocev2_user_description(dw))
+        self.source = source = Endpoint(EndpointDescription([("data", 8)], [("AttributeID", 16)]))
+        self.validate_sink = validate_sink = Endpoint([("validate", 1)])
+        self.qp_rcv_wire = Signal()
+
+        # # #
+
+        if buffered_in:
+            buff_in = Buffer(eth_rocev2_user_description(dw), pipe_ready=True)
+            self.submodules.buff_in = buff_in
+            self.comb += sink.connect(buff_in.sink)
+            sink = buff_in.source
+
+        # Depacketizer.
+        self.depacketizer = depacketizer = LiteEthCMDepacketizer(dw=dw)
+        self.comb += sink.connect(depacketizer.sink)
+
+        self.reply_pipe = reply_pipe = SyncFIFO(eth_mad_description(dw), 3, buffered=True)
+        self.comb += reply_pipe.source.connect(reply_sink)
+        reply_sink = reply_pipe.sink
+
+        # To avoid setting sink and context on every emit CM response call
+        _CM_response.set_attrs(
+            reply_sink = reply_sink,
+            cm_ctx     = cm_conn
+        )
+
+        # CM state controller
+        cm_state = CMStateFSM(qps[1], cm_conn, clk_freq, dw=dw)
+        self.submodules += cm_state
+
+        new_request = Signal()
+
+        self.comb += [
+            If(new_request,
+                depacketizer.source.connect(cm_state.sink, omit={"ready", "header_only"})
+            )
+        ]
+        self.comb += cm_state.qp_rcv_wire.eq(self.qp_rcv_wire)
+
+        # Message validation flags
+        valid_base_version  = Signal()
+        valid_class_version = Signal()
+        valid_methattrcombo = Signal()
+        valid_meth          = Signal()
+        valid_conn_type     = Signal()
+
+        valid_pmtu            = Signal()
+        valid_initiator_depth = Signal()
+
+        self.comb += valid_base_version.eq(depacketizer.source.BaseVersion == 1)
+        self.comb += valid_class_version.eq(depacketizer.source.ClassVersion == 2)
+        self.comb += valid_methattrcombo.eq(
+            (
+                (depacketizer.source.Method == CM_Methods.ComMgtGet) &
+                (depacketizer.source.AttributeID == MAD_ATTRIB_ID.ClassPortInfo)
+            ) | (
+                (depacketizer.source.Method == CM_Methods.ComMgtSend) &
+                is_in(depacketizer.source.AttributeID, [
+                    MAD_ATTRIB_ID.ConnectRequest,
+                    MAD_ATTRIB_ID.MsgRcptAck,
+                    MAD_ATTRIB_ID.ConnectReject,
+                    MAD_ATTRIB_ID.ConnectReply,
+                    MAD_ATTRIB_ID.ReadyToUse,
+                    MAD_ATTRIB_ID.DisconnectRequest,
+                    MAD_ATTRIB_ID.DisconnectReply,
+                    MAD_ATTRIB_ID.ServiceIDResReq,
+                    MAD_ATTRIB_ID.ServiceIDResReqResp,
+                    MAD_ATTRIB_ID.LoadAlternatePath,
+                    MAD_ATTRIB_ID.AlternatePathResponse
+                ])
+            )
+        )
+        self.comb += valid_meth.eq(is_in(depacketizer.source.Method, [
+            CM_Methods.ComMgtGet,
+            CM_Methods.ComMgtSet,
+            CM_Methods.ComMgtGetResp,
+            CM_Methods.ComMgtSend
+        ]))
+        # We only support RC (and UD only for QP1)
+        self.comb += valid_conn_type.eq(depacketizer.source.Transport_Service_Type == QP_CONN_TYPE.RC)
+
+        self.comb += valid_pmtu.eq(depacketizer.source.Path_Packet_Payload_MTU == PMTU_KEY)
+        self.comb += valid_initiator_depth.eq(depacketizer.source.Initiator_Depth <= RESPONDER_RESOURCES)
+
+        # Transaction persistance checking
+        valid_transaction = Signal()
+
+        self.comb += valid_transaction.eq(~cm_conn.saved |
+            ((depacketizer.source.TransactionID == cm_conn.TransactionID) |
+             (depacketizer.source.MgmtClass == 0x7))
+        )
+
+        # MAD RX FSM
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(depacketizer.source.valid,
+                If(valid_base_version & valid_class_version & valid_meth & valid_methattrcombo & valid_conn_type &
+                    valid_transaction,
+                    If(depacketizer.source.AttributeID == MAD_ATTRIB_ID.ClassPortInfo,
+                        CPI.emit()
+                    ),
+                    If(depacketizer.source.AttributeID != MAD_ATTRIB_ID.ConnectRequest,
+                        new_request.eq(1),
+                    ),
+                    NextState("PRIVATE_DATA")
+                ).Else(
+                    If(depacketizer.source.AttributeID == MAD_ATTRIB_ID.ConnectRequest,
+                        If(~valid_base_version,
+                            REJ.emit(REJ.REASON.Unsupported_request, status=MAD_response.MAD_Status.BadVersion)
+                        ).Elif(~valid_class_version,
+                            REJ.emit(REJ.REASON.Unsupported_Class_Version, status=MAD_response.MAD_Status.BadVersion)
+                        ).Elif(~valid_meth,
+                            REJ.emit(REJ.REASON.Unsupported_request, status=MAD_response.MAD_Status.MethodNotSupported)
+                        ).Elif(~valid_methattrcombo,
+                            REJ.emit(REJ.REASON.Unsupported_request, status=MAD_response.MAD_Status.MethodAttributeComboNotSupported)
+                        ).Elif(~valid_pmtu,
+                            REJ.emit(REJ.REASON.Invalid_Path_MTU, status=MAD_response.MAD_Status.AttributeInvalidValue)
+                        ).Elif(~valid_initiator_depth,
+                            REJ.emit(REJ.REASON.Insufficient_Responder_Resources, status=MAD_response.MAD_Status.AttributeInvalidValue)
+                        )
+                    ),
+                    NextState("DROP")
+                )
+            )
+        )
+
+        fsm.act("PRIVATE_DATA",
+            depacketizer.source.connect(source, keep={"valid", "last", "data", "AttributeID"}),
+            depacketizer.source.ready.eq(
+                ((source.AttributeID != MAD_ATTRIB_ID.ConnectRequest) | ~source.last) &
+                source.ready
+            ),
+            If(source.valid & source.ready & source.last,
+                If(source.AttributeID == MAD_ATTRIB_ID.ConnectRequest,
+                    NextState("AWAIT_VALIDATION")
+                ).Else(
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        fsm.act("AWAIT_VALIDATION",
+            validate_sink.ready.eq(1),
+            If(validate_sink.valid,
+                depacketizer.source.ready.eq(1),
+                new_request.eq(validate_sink.validate),
+                If(validate_sink.validate,
+                    NextValue(cm_conn.qpn, qps[1].id),
+                    NextValue(cm_conn.Remote_Communication_ID, depacketizer.source.Local_Communication_ID),
+                    NextValue(cm_conn.TransactionID, depacketizer.source.TransactionID),
+                    NextValue(cm_conn.saved, 1)
+                ),
+                NextState("IDLE")
+            )
+        )
+
+        fsm.act("DROP",
+            depacketizer.source.ready.eq(1),
+            If(depacketizer.source.valid & depacketizer.source.ready & depacketizer.source.last,
+                NextState("IDLE")
+            )
+        )
+
+
+class LiteEthIBMAD(LiteXModule):
+    def __init__(self, qps, clk_freq, dw=8):
+        self.cm_conn = cm_conn = LiteEthCMConn()
+        self.tx = tx = LiteEthIBMADTX(buffered_out=True)
+        self.rx = rx = LiteEthIBMADRX(qps, cm_conn, tx.reply_sink, clk_freq, buffered_in=True)
+
+        self.ipcm = ipcm = LiteEthIPCM(rx)
+
+        self.comb += [
+            ipcm.validate_sink.validate.eq(1),
+            ipcm.validate_sink.valid.eq(1)
+        ]

--- a/liteeth/core/rocev2/mad_cm.py
+++ b/liteeth/core/rocev2/mad_cm.py
@@ -1,0 +1,486 @@
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import SyncFIFO, Buffer, Endpoint
+
+from liteeth.core.rocev2.common import VariablePacketizer, VariableDepacketizer, VarWaitTimer
+from liteeth.core.rocev2.qp import LiteEthIBQP
+from liteeth.core.rocev2.mad_cm_msg import REP, REJ, DREP, DREQ, CPI, MAD_response, _CM_response
+from liteeth.core.rocev2.ipcm import LiteEthIPCM
+
+from litex.gen.genlib.misc import WaitTimer
+
+MAD_PMTU = 256 # The payload size for MAD is always 256 regardless of PMTU
+
+class LiteEthCMConn(LiteXModule):
+    def __init__(self):
+        self.qpn = Signal(24)
+        self.Remote_Communication_ID = Signal(32)
+
+        # C13-19.1.1: Transaction uniqueness is ensured by the combination of
+        # MgmtClass, TransactionID (and SGID or SLID, which don't exist for RoCEv2)
+        # Since we only support communication Managment, MgmtClass is always the same
+        self.TransactionID = Signal(64)
+
+        self.saved = Signal()
+
+class LiteEthCMDepacketizer(VariableDepacketizer):
+    def __init__(self, dw=8):
+        VariableDepacketizer.__init__(self,
+            eth_rocev2_user_description(dw),
+            eth_mad_description(dw),
+            mad_cm_headers,
+            mad_cm_opmap,
+            "AttributeID"
+        )
+
+class LiteEthCMPacketizer(VariablePacketizer):
+    def __init__(self, dw=8):
+        VariablePacketizer.__init__(self,
+            eth_mad_description(dw),
+            eth_rocev2_user_description(dw),
+            mad_cm_headers,
+            mad_cm_opmap,
+            "AttributeID"
+        )
+
+class LiteEthIBMADTX(LiteXModule):
+    def __init__(self, buffered_out=True, dw=8):
+        self.source = source = Endpoint(eth_rocev2_user_description(dw))
+        self.reply_sink = Endpoint(eth_mad_description(dw))
+
+        # # #
+
+        if buffered_out:
+            buff_out = Buffer(eth_rocev2_user_description(dw), pipe_ready=True)
+            self.submodules.buff_out = buff_out
+            self.comb += buff_out.source.connect(source)
+            source = buff_out.sink
+
+        # Buffer to get replies from LiteEthIBMADRX
+        reply_buf = Buffer(eth_mad_description(dw), pipe_ready=True)
+        self.submodules.reply_buf = reply_buf
+        self.comb += self.reply_sink.connect(reply_buf.sink)
+
+        # Packetizer.
+        self.packetizer = packetizer = LiteEthCMPacketizer(dw=dw)
+
+        self.comb += [
+            reply_buf.source.connect(packetizer.sink, omit={"ready"}),
+            packetizer.sink.header_only.eq(1)
+        ]
+
+        counter = Signal(max=MAD_PMTU, reset_less=True)
+
+        # FSM
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(packetizer.source.valid,
+                NextValue(counter, 0),
+                NextState("SEND")
+            )
+        )
+        fsm.act("SEND",
+            packetizer.source.connect(source, keep={"valid", "ready", "data"}),
+            If(source.valid & source.ready,
+                NextValue(counter, counter + 1),
+                If(packetizer.source.last,
+                    NextState("PAD"),
+                    reply_buf.source.ready.eq(1),
+                    If(counter == MAD_PMTU - 1,
+                        NextState("IDLE")
+                    )
+                )
+            )
+        )
+        # MAD packets are always the size of MAD_PMTU
+        fsm.act("PAD",
+            source.valid.eq(1),
+            source.last.eq(counter == MAD_PMTU - 1),
+            If(source.valid & source.ready,
+                NextValue(counter, counter + 1),
+                If(source.last,
+                    NextState("IDLE")
+                )
+            )
+        )
+
+# See page 698 of doc for reference
+class CMStateFSM(LiteXModule):
+    def __init__(self, qp, cm_conn, clk_freq, dw=8):
+        self.sink = sink = Endpoint(eth_mad_description(dw))
+        self.qp_rcv_wire = qp_rcv_wire = Signal()
+
+        # # #
+
+        # Buffer for incoming requests
+        buff_in = Buffer(eth_mad_description(dw))
+        self.submodules.buff_in = buff_in
+        self.comb += sink.connect(buff_in.sink)
+        sink = buff_in.source
+
+        # We are always consuming
+        self.comb += sink.ready.eq(1)
+
+        # The CM waits after certain operations
+        # (the time can change depending on REQ parameters)
+        cm_timer = VarWaitTimer(clk_freq)
+        self.submodules.cm_timer = cm_timer
+
+        local_cm_timeout = Signal(5, reset_less=True)
+
+        # CM FSM
+        self.fsm = fsm = FSM(reset_state="LISTEN")
+        fsm.act("LISTEN",
+            NextValue(qp.qp_state, LiteEthIBQP.INIT),
+            If(sink.valid &
+               (qp.qp_state == LiteEthIBQP.INIT) &
+               (sink.AttributeID == MAD_ATTRIB_ID.ConnectRequest),
+                NextValue(local_cm_timeout, sink.Local_CM_Response_Timeout),
+
+                NextValue(qp.other_id, sink.Local_QPN),
+                NextValue(qp.send_queue.psn, sink.Starting_PSN),
+                NextValue(qp.ip_address, sink.Primary_Local_Port_GID[:32]),
+
+                NextValue(qp.retry_cnt_rst, sink.Retry_Count),
+                NextValue(qp.retry_cnt_rnr_rst, sink.RNR_Retry_Count),
+
+                NextState("REQ Rcvd")
+            )
+        )
+
+        fsm.act("REQ Rcvd",
+            If((qp.qp_state == LiteEthIBQP.INIT) | (qp.qp_state == LiteEthIBQP.ERROR),
+                REP.emit(qp),
+                NextValue(qp.qp_state, LiteEthIBQP.RTR),
+                cm_timer.pow.eq(local_cm_timeout),
+                NextState("REP Sent")
+            ).Else(
+                REJ.emit(REJ.REASON.No_QP_available),
+                NextState("REJ Sent")
+            )
+        )
+
+        fsm.act("REJ Sent",
+            NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+            NextState("ERROR")
+        )
+
+        fsm.act("REP Sent",
+            cm_timer.wait.eq(1),
+            If(cm_timer.done,
+                NextState("RTU Timeout")
+            ).Else(
+                If((sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ReadyToUse)) | qp_rcv_wire,
+                    NextValue(qp.qp_state, LiteEthIBQP.RTS),
+                    NextState("ESTABLISHED")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.MsgRcptAck),
+                    cm_timer.pow.eq(sink.ServiceTimeout),
+                    NextState("MRA(REP) Rcvd")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ConnectReject),
+                    NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+                    NextState("ERROR")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ConnectRequest),
+                    REP.emit(qp)
+                )
+            )
+        )
+
+        fsm.act("MRA(REP) Rcvd",
+            cm_timer.wait.eq(1),
+            If(cm_timer.done,
+                NextState("RTU Timeout")
+            ).Else(
+                If((sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ReadyToUse)) | qp_rcv_wire,
+                    NextValue(qp.qp_state, LiteEthIBQP.RTS),
+                    NextState("ESTABLISHED")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.ConnectReject),
+                    NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+                    NextState("ERROR")
+                )
+            )
+        )
+
+        fsm.act("ESTABLISHED",
+            cm_timer.wait.eq(1),
+            If(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.DisconnectRequest) &
+              (sink.Local_Communication_ID == cm_conn.Remote_Communication_ID) &
+              (sink.Remote_Communication_ID == LOCAL_COMMUNICATION_ID) &
+              (sink.Remote_QPN_EECN == cm_conn.qpn),
+                NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+                NextState("DREQ Rcvd")
+            ).Elif(sink.valid &
+                 ((sink.AttributeID == MAD_ATTRIB_ID.ConnectReply) |
+                  (sink.AttributeID == MAD_ATTRIB_ID.ConnectRequest)),
+                If(sink.Local_QPN == qp.other_id,
+                    If(~((sink.Local_Communication_ID == cm_conn.Remote_Communication_ID) &
+                         (sink.Remote_Communication_ID == LOCAL_COMMUNICATION_ID) &
+                         (~cm_timer.done)
+                    ),
+                        REJ.emit(REJ.REASON.Stale_connection,
+                            Remote_Communication_ID=sink.Remote_Communication_ID,
+                            TransactionID=sink.TransactionID
+                        ),
+                        NextState("Send DREQ")
+                    ) # Else it could be a valid REQ or REP resend
+                )
+            ).Elif(qp.local_error,
+                NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+                NextState("Send DREQ")
+            )
+        )
+
+        fsm.act("DREQ Rcvd",
+            DREP.emit(),
+            cm_timer.pow.eq(local_cm_timeout),
+            NextState("TimeWait")
+        )
+
+        # TODO Warning: Timers look at queue time not at send time
+        fsm.act("DREQ Sent",
+            cm_timer.wait.eq(1),
+            If(cm_timer.done,
+                NextState("DREP Timeout")
+            ).Else(
+                If(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.DisconnectRequest) &
+                    (sink.Local_Communication_ID == cm_conn.Remote_Communication_ID) &
+                    (sink.Remote_Communication_ID == LOCAL_COMMUNICATION_ID) &
+                    (sink.Remote_QPN_EECN == cm_conn.qpn),
+                    NextState("DREQ Rcvd")
+                ).Elif(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.DisconnectReply),
+                    cm_timer.pow.eq(local_cm_timeout),
+                    NextState("TimeWait")
+                )
+            )
+        )
+
+        fsm.act("RTU Timeout",
+            REJ.emit(REJ.REASON.Timeout),
+            cm_timer.pow.eq(local_cm_timeout),
+            NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+            NextState("TimeWait")
+        )
+
+        fsm.act("TimeWait",
+            cm_timer.wait.eq(1),
+            If(cm_timer.done,
+                NextState("ERROR")
+            ).Else(
+                If(sink.valid & (sink.AttributeID == MAD_ATTRIB_ID.DisconnectRequest) &
+                (sink.Local_Communication_ID == cm_conn.Remote_Communication_ID) &
+                (sink.Remote_Communication_ID == LOCAL_COMMUNICATION_ID) &
+                (sink.Remote_QPN_EECN == cm_conn.qpn),
+                    DREP.emit()
+                )
+            )
+        )
+
+        fsm.act("DREP Timeout",
+            DREQ.emit(qp.other_id),
+            cm_timer.pow.eq(local_cm_timeout),
+            NextState("TimeWait")
+        )
+
+        # State added for convenience of treating the connection established
+        # and stale qp case (REQ Received)
+        fsm.act("Send DREQ",
+            DREQ.emit(qp.other_id),
+            cm_timer.pow.eq(local_cm_timeout),
+            NextState("DREQ Sent")
+        )
+
+        # FIXME: Rather arbitrary time choice
+        self.error_timer = error_timer = WaitTimer(PMTU)
+
+        fsm.act("ERROR",
+            NextValue(qp.qp_state, LiteEthIBQP.ERROR),
+            error_timer.wait.eq(1),
+            If(error_timer.done,
+                NextState("RESET")
+            )
+        )
+
+        fsm.act("RESET",
+            NextValue(qp.qp_state, LiteEthIBQP.RESET),
+            NextState("LISTEN")
+        )
+
+
+class LiteEthIBMADRX(LiteXModule):
+    def __init__(self, qps, cm_conn, reply_sink, clk_freq, buffered_in=True, dw=8):
+        self.sink   = sink   = Endpoint(eth_rocev2_user_description(dw))
+        self.source = source = Endpoint(EndpointDescription([("data", 8)], [("AttributeID", 16)]))
+        self.validate_sink = validate_sink = Endpoint([("validate", 1)])
+        self.qp_rcv_wire = Signal()
+
+        # # #
+
+        if buffered_in:
+            buff_in = Buffer(eth_rocev2_user_description(dw), pipe_ready=True)
+            self.submodules.buff_in = buff_in
+            self.comb += sink.connect(buff_in.sink)
+            sink = buff_in.source
+
+        # Depacketizer.
+        self.depacketizer = depacketizer = LiteEthCMDepacketizer(dw=dw)
+        self.comb += sink.connect(depacketizer.sink)
+
+        self.reply_pipe = reply_pipe = SyncFIFO(eth_mad_description(dw), 3, buffered=True)
+        self.comb += reply_pipe.source.connect(reply_sink)
+        reply_sink = reply_pipe.sink
+
+        # To avoid setting sink and context on every emit CM response call
+        _CM_response.set_attrs(
+            reply_sink = reply_sink,
+            cm_ctx     = cm_conn
+        )
+
+        # CM state controller
+        cm_state = CMStateFSM(qps[1], cm_conn, clk_freq, dw=dw)
+        self.submodules += cm_state
+
+        new_request = Signal()
+
+        self.comb += [
+            If(new_request,
+                depacketizer.source.connect(cm_state.sink, omit={"ready", "header_only"})
+            )
+        ]
+        self.comb += cm_state.qp_rcv_wire.eq(self.qp_rcv_wire)
+
+        # Message validation flags
+        valid_base_version  = Signal()
+        valid_class_version = Signal()
+        valid_methattrcombo = Signal()
+        valid_meth          = Signal()
+        valid_conn_type     = Signal()
+
+        valid_pmtu            = Signal()
+        valid_initiator_depth = Signal()
+
+        self.comb += valid_base_version.eq(depacketizer.source.BaseVersion == 1)
+        self.comb += valid_class_version.eq(depacketizer.source.ClassVersion == 2)
+        self.comb += valid_methattrcombo.eq(
+            (
+                (depacketizer.source.Method == CM_Methods.ComMgtGet) &
+                (depacketizer.source.AttributeID == MAD_ATTRIB_ID.ClassPortInfo)
+            ) | (
+                (depacketizer.source.Method == CM_Methods.ComMgtSend) &
+                is_in(depacketizer.source.AttributeID, [
+                    MAD_ATTRIB_ID.ConnectRequest,
+                    MAD_ATTRIB_ID.MsgRcptAck,
+                    MAD_ATTRIB_ID.ConnectReject,
+                    MAD_ATTRIB_ID.ConnectReply,
+                    MAD_ATTRIB_ID.ReadyToUse,
+                    MAD_ATTRIB_ID.DisconnectRequest,
+                    MAD_ATTRIB_ID.DisconnectReply,
+                    MAD_ATTRIB_ID.ServiceIDResReq,
+                    MAD_ATTRIB_ID.ServiceIDResReqResp,
+                    MAD_ATTRIB_ID.LoadAlternatePath,
+                    MAD_ATTRIB_ID.AlternatePathResponse
+                ])
+            )
+        )
+        self.comb += valid_meth.eq(is_in(depacketizer.source.Method, [
+            CM_Methods.ComMgtGet,
+            CM_Methods.ComMgtSet,
+            CM_Methods.ComMgtGetResp,
+            CM_Methods.ComMgtSend
+        ]))
+        # We only support RC (and UD only for QP1)
+        self.comb += valid_conn_type.eq(depacketizer.source.Transport_Service_Type == QP_CONN_TYPE.RC)
+
+        self.comb += valid_pmtu.eq(depacketizer.source.Path_Packet_Payload_MTU == PMTU_KEY)
+        self.comb += valid_initiator_depth.eq(depacketizer.source.Initiator_Depth <= RESPONDER_RESOURCES)
+
+        # Transaction persistance checking
+        valid_transaction = Signal()
+
+        self.comb += valid_transaction.eq(~cm_conn.saved |
+            ((depacketizer.source.TransactionID == cm_conn.TransactionID) |
+             (depacketizer.source.MgmtClass == 0x7))
+        )
+
+        # MAD RX FSM
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(depacketizer.source.valid,
+                If(valid_base_version & valid_class_version & valid_meth & valid_methattrcombo & valid_conn_type &
+                    valid_transaction,
+                    If(depacketizer.source.AttributeID == MAD_ATTRIB_ID.ClassPortInfo,
+                        CPI.emit()
+                    ),
+                    If(depacketizer.source.AttributeID != MAD_ATTRIB_ID.ConnectRequest,
+                        new_request.eq(1),
+                    ),
+                    NextState("PRIVATE_DATA")
+                ).Else(
+                    If(depacketizer.source.AttributeID == MAD_ATTRIB_ID.ConnectRequest,
+                        If(~valid_base_version,
+                            REJ.emit(REJ.REASON.Unsupported_request, status=MAD_response.MAD_Status.BadVersion)
+                        ).Elif(~valid_class_version,
+                            REJ.emit(REJ.REASON.Unsupported_Class_Version, status=MAD_response.MAD_Status.BadVersion)
+                        ).Elif(~valid_meth,
+                            REJ.emit(REJ.REASON.Unsupported_request, status=MAD_response.MAD_Status.MethodNotSupported)
+                        ).Elif(~valid_methattrcombo,
+                            REJ.emit(REJ.REASON.Unsupported_request, status=MAD_response.MAD_Status.MethodAttributeComboNotSupported)
+                        ).Elif(~valid_pmtu,
+                            REJ.emit(REJ.REASON.Invalid_Path_MTU, status=MAD_response.MAD_Status.AttributeInvalidValue)
+                        ).Elif(~valid_initiator_depth,
+                            REJ.emit(REJ.REASON.Insufficient_Responder_Resources, status=MAD_response.MAD_Status.AttributeInvalidValue)
+                        )
+                    ),
+                    NextState("DROP")
+                )
+            )
+        )
+
+        fsm.act("PRIVATE_DATA",
+            depacketizer.source.connect(source, keep={"valid", "last", "data", "AttributeID"}),
+            depacketizer.source.ready.eq(
+                ((source.AttributeID != MAD_ATTRIB_ID.ConnectRequest) | ~source.last) &
+                source.ready
+            ),
+            If(source.valid & source.ready & source.last,
+                If(source.AttributeID == MAD_ATTRIB_ID.ConnectRequest,
+                    NextState("AWAIT_VALIDATION")
+                ).Else(
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        fsm.act("AWAIT_VALIDATION",
+            validate_sink.ready.eq(1),
+            If(validate_sink.valid,
+                depacketizer.source.ready.eq(1),
+                new_request.eq(validate_sink.validate),
+                If(validate_sink.validate & (qps[1].qp_state == LiteEthIBQP.INIT),
+                    NextValue(cm_conn.qpn, qps[1].id),
+                    NextValue(cm_conn.Remote_Communication_ID, depacketizer.source.Local_Communication_ID),
+                    NextValue(cm_conn.TransactionID, depacketizer.source.TransactionID),
+                    NextValue(cm_conn.saved, 1)
+                ),
+                NextState("IDLE")
+            )
+        )
+
+        fsm.act("DROP",
+            depacketizer.source.ready.eq(1),
+            If(depacketizer.source.valid & depacketizer.source.ready & depacketizer.source.last,
+                NextState("IDLE")
+            )
+        )
+
+@ResetInserter()
+class LiteEthIBMAD(LiteXModule):
+    def __init__(self, qps, clk_freq, dw=8):
+        self.cm_conn = cm_conn = LiteEthCMConn()
+        self.tx = tx = LiteEthIBMADTX(buffered_out=True)
+        self.rx = rx = LiteEthIBMADRX(qps, cm_conn, tx.reply_sink, clk_freq, buffered_in=True)
+
+        self.ipcm = ipcm = LiteEthIPCM(rx)
+
+        self.comb += [
+            ipcm.validate_sink.validate.eq(1),
+            ipcm.validate_sink.valid.eq(1)
+        ]

--- a/liteeth/core/rocev2/mad_cm_msg.py
+++ b/liteeth/core/rocev2/mad_cm_msg.py
@@ -1,0 +1,151 @@
+from liteeth.common import *
+
+from enum import IntFlag
+
+class MAD_response:
+    class MAD_Status(IntEnum):
+        Busy                             = 1 << 0
+        RedirectionRequired              = 1 << 1
+
+        NoInvalidFields                  = 0 << 2
+        BadVersion                       = 1 << 2
+        MethodNotSupported               = 2 << 2
+        MethodAttributeComboNotSupported = 3 << 2
+        AttributeInvalidValue            = 7 << 2
+
+    @classmethod
+    def emit(cls, attribID, BaseVersion, MgmtClass, ClassVersion, reply_sink, cm_ctx, status=0):
+        return [
+            reply_sink.valid.eq(1),
+            reply_sink.last.eq(1),
+
+            reply_sink.BaseVersion.eq(BaseVersion),
+            reply_sink.MgmtClass.eq(MgmtClass),
+            reply_sink.ClassVersion.eq(ClassVersion),
+            reply_sink.Status.eq(status),
+            reply_sink.TransactionID.eq(cm_ctx.TransactionID),
+            reply_sink.AttributeID.eq(attribID),
+        ]
+
+class _CM_response:
+    BASE_VERSION  = 0x01
+    MGMT_CLASS    = 0x07
+    CLASS_VERSION = 0x02
+
+    cm_ctx     = None
+    reply_sink = None
+    @classmethod
+    def set_attrs(cls, cm_ctx, reply_sink):
+        cls.cm_ctx     = cm_ctx
+        cls.reply_sink = reply_sink
+
+    @classmethod
+    def emit(cls, attribID, status=0):
+        return MAD_response.emit(
+            attribID     = attribID,
+            BaseVersion  = cls.BASE_VERSION,
+            MgmtClass    = cls.MGMT_CLASS,
+            ClassVersion = cls.CLASS_VERSION,
+            reply_sink   = cls.reply_sink,
+            cm_ctx       = cls.cm_ctx,
+            status       = status) + \
+        [
+            cls.reply_sink.Method.eq(CM_Methods.ComMgtGetResp) \
+            if attribID == MAD_ATTRIB_ID.ClassPortInfo \
+            else cls.reply_sink.Method.eq(CM_Methods.ComMgtSend)
+        ]
+
+class CPI:
+    class CapabilityMask(IntFlag):
+        IsReliableConnectionCapable   = 1 << 9
+        IsReliableDatagramCapable     = 1 << 10
+        IsUnreliableConnectionCapable = 1 << 12
+        IsSIDRCapable                 = 1 << 13
+
+    @classmethod
+    def emit(cls):
+        return _CM_response.emit(MAD_ATTRIB_ID.ClassPortInfo) + [
+            _CM_response.reply_sink.CapabilityMask.eq(
+                CPI.CapabilityMask.IsReliableConnectionCapable
+            )
+        ]
+
+class REP:
+    @classmethod
+    def emit(cls, qp):
+        return _CM_response.emit(MAD_ATTRIB_ID.ConnectReply) + [
+            _CM_response.reply_sink.Local_Communication_ID.eq(LOCAL_COMMUNICATION_ID),
+            _CM_response.reply_sink.Remote_Communication_ID.eq(_CM_response.cm_ctx.Remote_Communication_ID),
+            _CM_response.reply_sink.Responder_Resources.eq(RESPONDER_RESOURCES),
+            _CM_response.reply_sink.Initiator_Depth.eq(INITIATOR_DEPTH),
+            _CM_response.reply_sink.Target_ACK_Delay.eq(0x01),
+            _CM_response.reply_sink.Local_QPN.eq(qp.id),
+            _CM_response.reply_sink.Starting_PSN.eq(qp.receive_queue.psn),
+            _CM_response.reply_sink.RNR_Retry_Count.eq(7)
+        ]
+
+class REJ:
+    class REASON(IntEnum):
+        No_QP_available                    = 1
+        No_EEC_available                   = 2
+        No_resources_available             = 3
+        Timeout                            = 4
+        Unsupported_request                = 5
+        Invalid_Communication_ID           = 6
+        Invalid_Communication_Instance     = 7
+        Invalid_Service_ID                 = 8
+        Invalid_Transport_Service_Type     = 9
+        Stale_connection                   = 10
+        RDC_does_not_exist                 = 11
+        Primary_Remote_Port_GID_rejected   = 12
+        Primary_Remote_Port_LID_rejected   = 13
+        Invalid_Primary_SL                 = 14
+        Invalid_Primary_Traffic_Class      = 15
+        Invalid_Primary_Hop_Limit          = 16
+        Invalid_Primary_Packet_Rate        = 17
+        Alternate_Remote_Port_GID_rejected = 18
+        Alternate_Remote_Port_LID_rejected = 19
+        Invalid_Alternate_SL               = 20
+        Invalid_Alternate_Traffic_Class    = 21
+        Invalid_Alternate_Hop_Limit        = 22
+        Invalid_Alternate_Packet_Rate      = 23
+        Port_and_CM_Redirection            = 24
+        Port_Redirection                   = 25
+        Invalid_Path_MTU                   = 26
+        Insufficient_Responder_Resources   = 27
+        Consumer_Reject                    = 28
+        RNR_Retry_Count_Reject             = 29
+        Duplicate_Local_Communication_ID   = 30
+        Unsupported_Class_Version          = 31
+        Invalid_Primary_Flow_Label         = 32
+        Invalid_Alternate_Flow_Label       = 33
+
+    @classmethod
+    def emit(cls, reason, status=0):
+        return _CM_response.emit(
+            attribID   = MAD_ATTRIB_ID.ConnectReject,
+            status     = status
+        ) + [
+            _CM_response.reply_sink.Local_Communication_ID.eq(LOCAL_COMMUNICATION_ID),
+            _CM_response.reply_sink.Remote_Communication_ID.eq(_CM_response.cm_ctx.Remote_Communication_ID),
+            _CM_response.reply_sink.Message_REJected.eq(0x0),
+            _CM_response.reply_sink.Reject_Info_Length.eq(0x0),
+            _CM_response.reply_sink.Reason.eq(reason)
+        ]
+
+class DREP:
+    @classmethod
+    def emit(cls):
+        return _CM_response.emit(MAD_ATTRIB_ID.DisconnectReply) + [
+            _CM_response.reply_sink.Local_Communication_ID.eq(LOCAL_COMMUNICATION_ID),
+            _CM_response.reply_sink.Remote_Communication_ID.eq(_CM_response.cm_ctx.Remote_Communication_ID)
+        ]
+
+class DREQ:
+    @classmethod
+    def emit(cls, remote_qpn):
+        return _CM_response.emit(MAD_ATTRIB_ID.DisconnectRequest) + [
+            _CM_response.reply_sink.Local_Communication_ID.eq(LOCAL_COMMUNICATION_ID),
+            _CM_response.reply_sink.Remote_Communication_ID.eq(_CM_response.cm_ctx.Remote_Communication_ID),
+            _CM_response.reply_sink.Remote_QPN_EECN.eq(remote_qpn)
+        ]

--- a/liteeth/core/rocev2/mad_cm_msg.py
+++ b/liteeth/core/rocev2/mad_cm_msg.py
@@ -1,0 +1,164 @@
+from liteeth.common import *
+
+from enum import IntFlag
+
+class MAD_response:
+    class MAD_Status(IntEnum):
+        Busy                             = 1 << 0
+        RedirectionRequired              = 1 << 1
+
+        NoInvalidFields                  = 0 << 2
+        BadVersion                       = 1 << 2
+        MethodNotSupported               = 2 << 2
+        MethodAttributeComboNotSupported = 3 << 2
+        AttributeInvalidValue            = 7 << 2
+
+    @classmethod
+    def emit(cls, attribID, BaseVersion, MgmtClass, ClassVersion, reply_sink, cm_ctx, status=0, TransactionID=None):
+        return [
+            reply_sink.valid.eq(1),
+            reply_sink.last.eq(1),
+
+            reply_sink.BaseVersion.eq(BaseVersion),
+            reply_sink.MgmtClass.eq(MgmtClass),
+            reply_sink.ClassVersion.eq(ClassVersion),
+            reply_sink.Status.eq(status),
+            reply_sink.TransactionID.eq((
+                cm_ctx.TransactionID
+                if TransactionID is None
+                else TransactionID)
+            ),
+            reply_sink.AttributeID.eq(attribID),
+        ]
+
+class _CM_response:
+    BASE_VERSION  = 0x01
+    MGMT_CLASS    = 0x07
+    CLASS_VERSION = 0x02
+
+    cm_ctx     = None
+    reply_sink = None
+    @classmethod
+    def set_attrs(cls, cm_ctx, reply_sink):
+        cls.cm_ctx     = cm_ctx
+        cls.reply_sink = reply_sink
+
+    @classmethod
+    def emit(cls, attribID, status=0, TransactionID=None):
+        return MAD_response.emit(
+            attribID      = attribID,
+            BaseVersion   = cls.BASE_VERSION,
+            MgmtClass     = cls.MGMT_CLASS,
+            ClassVersion  = cls.CLASS_VERSION,
+            reply_sink    = cls.reply_sink,
+            cm_ctx        = cls.cm_ctx,
+            status        = status,
+            TransactionID = TransactionID) + \
+        [
+            cls.reply_sink.Method.eq(CM_Methods.ComMgtGetResp) \
+            if attribID == MAD_ATTRIB_ID.ClassPortInfo \
+            else cls.reply_sink.Method.eq(CM_Methods.ComMgtSend)
+        ]
+
+class CPI:
+    class CapabilityMask(IntFlag):
+        IsReliableConnectionCapable   = 1 << 9
+        IsReliableDatagramCapable     = 1 << 10
+        IsUnreliableConnectionCapable = 1 << 12
+        IsSIDRCapable                 = 1 << 13
+
+    @classmethod
+    def emit(cls):
+        return _CM_response.emit(MAD_ATTRIB_ID.ClassPortInfo) + [
+            _CM_response.reply_sink.CapabilityMask.eq(
+                CPI.CapabilityMask.IsReliableConnectionCapable
+            )
+        ]
+
+class REP:
+    @classmethod
+    def emit(cls, qp):
+        return _CM_response.emit(MAD_ATTRIB_ID.ConnectReply) + [
+            _CM_response.reply_sink.Local_Communication_ID.eq(LOCAL_COMMUNICATION_ID),
+            _CM_response.reply_sink.Remote_Communication_ID.eq(_CM_response.cm_ctx.Remote_Communication_ID),
+            _CM_response.reply_sink.Responder_Resources.eq(RESPONDER_RESOURCES),
+            _CM_response.reply_sink.Initiator_Depth.eq(INITIATOR_DEPTH),
+            _CM_response.reply_sink.Target_ACK_Delay.eq(0x01),
+            _CM_response.reply_sink.Local_QPN.eq(qp.id),
+            _CM_response.reply_sink.Starting_PSN.eq(qp.receive_queue.psn),
+            _CM_response.reply_sink.RNR_Retry_Count.eq(7)
+        ]
+
+class REJ:
+    class REASON(IntEnum):
+        No_QP_available                    = 1
+        No_EEC_available                   = 2
+        No_resources_available             = 3
+        Timeout                            = 4
+        Unsupported_request                = 5
+        Invalid_Communication_ID           = 6
+        Invalid_Communication_Instance     = 7
+        Invalid_Service_ID                 = 8
+        Invalid_Transport_Service_Type     = 9
+        Stale_connection                   = 10
+        RDC_does_not_exist                 = 11
+        Primary_Remote_Port_GID_rejected   = 12
+        Primary_Remote_Port_LID_rejected   = 13
+        Invalid_Primary_SL                 = 14
+        Invalid_Primary_Traffic_Class      = 15
+        Invalid_Primary_Hop_Limit          = 16
+        Invalid_Primary_Packet_Rate        = 17
+        Alternate_Remote_Port_GID_rejected = 18
+        Alternate_Remote_Port_LID_rejected = 19
+        Invalid_Alternate_SL               = 20
+        Invalid_Alternate_Traffic_Class    = 21
+        Invalid_Alternate_Hop_Limit        = 22
+        Invalid_Alternate_Packet_Rate      = 23
+        Port_and_CM_Redirection            = 24
+        Port_Redirection                   = 25
+        Invalid_Path_MTU                   = 26
+        Insufficient_Responder_Resources   = 27
+        Consumer_Reject                    = 28
+        RNR_Retry_Count_Reject             = 29
+        Duplicate_Local_Communication_ID   = 30
+        Unsupported_Class_Version          = 31
+        Invalid_Primary_Flow_Label         = 32
+        Invalid_Alternate_Flow_Label       = 33
+
+    @classmethod
+    def emit(cls, reason, status=0, Remote_Communication_ID=None, TransactionID=None):
+        if Remote_Communication_ID is None or TransactionID is None:
+            assert Remote_Communication_ID is None and TransactionID is None
+
+        return _CM_response.emit(
+            attribID      = MAD_ATTRIB_ID.ConnectReject,
+            status        = status,
+            TransactionID = TransactionID
+        ) + [
+            _CM_response.reply_sink.Local_Communication_ID.eq(LOCAL_COMMUNICATION_ID),
+            _CM_response.reply_sink.Remote_Communication_ID.eq(
+                (_CM_response.cm_ctx.Remote_Communication_ID
+                 if Remote_Communication_ID is None
+                 else Remote_Communication_ID)
+            ),
+            _CM_response.reply_sink.Message_REJected.eq(0x0),
+            _CM_response.reply_sink.Reject_Info_Length.eq(0x0),
+            _CM_response.reply_sink.Reason.eq(reason)
+        ]
+
+class DREP:
+    @classmethod
+    def emit(cls):
+        return _CM_response.emit(MAD_ATTRIB_ID.DisconnectReply) + [
+            _CM_response.reply_sink.Local_Communication_ID.eq(LOCAL_COMMUNICATION_ID),
+            _CM_response.reply_sink.Remote_Communication_ID.eq(_CM_response.cm_ctx.Remote_Communication_ID)
+        ]
+
+class DREQ:
+    @classmethod
+    def emit(cls, remote_qpn):
+        return _CM_response.emit(MAD_ATTRIB_ID.DisconnectRequest) + [
+            _CM_response.reply_sink.Local_Communication_ID.eq(LOCAL_COMMUNICATION_ID),
+            _CM_response.reply_sink.Remote_Communication_ID.eq(_CM_response.cm_ctx.Remote_Communication_ID),
+            _CM_response.reply_sink.Remote_QPN_EECN.eq(remote_qpn)
+        ]

--- a/liteeth/core/rocev2/mr.py
+++ b/liteeth/core/rocev2/mr.py
@@ -1,0 +1,470 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Buffer, Endpoint, SyncFIFO
+
+from litedram.frontend.dma import LiteDRAMDMAReader, LiteDRAMDMAWriter
+
+from litedram.common import LiteDRAMNativePort
+from litedram.frontend.axi import LiteDRAMAXIPort
+from migen.fhdl.specials import _MemoryPort
+
+from enum import Flag, auto
+
+class LiteBRAMReader(LiteXModule):
+    """BRAM Reader
+
+    Reads data out from block RAM.
+
+    Parameters
+    ----------
+    port : _MemoryPort
+        Read port to BRAM.
+
+    Attributes
+    ----------
+    sink : in
+        Address of data to be read.
+    source : out
+        Data being read.
+    """
+    def __init__(self, port):
+        self.sink   = sink = Endpoint([("address", len(port.adr))])
+        self.source = source = Endpoint([("data", len(port.dat_r))])
+
+        # # #
+
+        # Bufferize the data being output with fifo
+        out_fifo = SyncFIFO([("data", len(port.dat_r))], 32)
+        self.submodules.out_fifo = out_fifo
+        self.comb += port.adr.eq(sink.address)
+
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(sink.valid,
+                NextState("READ")
+            )
+        )
+        fsm.act("READ",
+            out_fifo.sink.data.eq(port.dat_r),
+            out_fifo.sink.last.eq(sink.last),
+            out_fifo.sink.valid.eq(1),
+            If(out_fifo.sink.ready,
+                sink.ready.eq(1),
+                NextState("IDLE")
+            )
+        )
+
+        self.comb += out_fifo.source.connect(source)
+
+class LiteBRAMWriter(LiteXModule):
+    """BRAM Writer
+
+    Writes data into block RAM.
+
+    Parameters
+    ----------
+    port : _MemoryPort
+        Write port to BRAM.
+
+    Attributes
+    ----------
+    sink : in
+        Address and data being written.
+    """
+    def __init__(self, port):
+        self.sink   = sink = Endpoint([
+            ("address", len(port.adr)),
+            ("data", len(port.dat_w))
+        ])
+
+        self.comb += [
+            sink.ready.eq(1),
+            port.adr.eq(sink.address),
+            port.we.eq(sink.valid),
+            port.dat_w.eq(sink.data),
+        ]
+
+# Memory management --------------------------------------------------------------------------------
+class LiteEthIBMemoryRegionReader(LiteXModule):
+    """Infiniband Memory Region Reader
+
+    A reader that accepts a virtual address and length and sends back the corresponding data from ram.
+    Virtual address 0 corresponds to start of memory region.
+
+    Parameters
+    ----------
+    region_start : int
+        Physical address of the start
+        of the memory region in the ram.
+    port : LiteDRAMNativePort | LiteDRAMAXIPort | _MemoryPort
+        Read port to physical ram.
+    buffered_in : bool
+        Whether to buffer input to cut timing
+    buffered_out : bool
+        Whether to buffer output to cut timing
+    dw : int
+        Width of the data bus.
+
+    Attributes
+    ----------
+    sink : in
+        Address and length of data to be read.
+    source : out
+        Data being read.
+    """
+    def __init__(self, region_start, port, buffered_in=True, buffered_out=True, dw=8):
+        self.sink   = sink   = Endpoint([("va", 64), ("len", bits_for(PMTU))])
+        self.source = source = Endpoint([("data", dw)])
+
+        # # #
+
+        assert isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort, _MemoryPort))
+
+        # Bufferize sink to cut timing path
+        if buffered_in:
+            buff_in = Buffer([("va", 64), ("len", bits_for(PMTU))])
+            self.submodules.buff_in = buff_in
+            self.comb += sink.connect(buff_in.sink)
+            sink = buff_in.source
+
+        if buffered_out:
+            buff_out = Buffer([("data", dw)])
+            self.submodules.buff_out = buff_out
+            self.comb += buff_out.source.connect(source)
+            source = buff_out.sink
+
+
+        if isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort)):
+            port_width = port.data_width
+        else:
+            port_width = len(port.dat_r)
+        ratio      = port_width // dw
+        ratio_bits = log2_int(ratio)
+
+        assert dw == 8
+        assert port_width % dw == 0
+
+        # Internal DMA reader
+        if isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort)):
+            inner_reader = LiteDRAMDMAReader(port, fifo_depth=PMTU)
+        else:
+            inner_reader = LiteBRAMReader(port)
+        self.submodules.inner_reader = inner_reader
+
+        # Address of word to be used for next read request
+        word_address = Signal(64 - ratio_bits)
+        # Byte being read from current returned word
+        reading_byte_local_address = Signal(ratio_bits)
+        # The number of the word being output from the DMA reader
+        reading_byte = Signal(bits_for(PMTU))
+
+        # Reader FSM
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(sink.valid,
+                NextValue(word_address, (region_start + sink.va)[ratio_bits:]),
+                NextValue(reading_byte_local_address, (region_start + sink.va)[:ratio_bits]),
+                NextValue(reading_byte, 1),
+                NextState("READING")
+            )
+        )
+
+        fsm.act("READING",
+            # Pipe in requests
+            inner_reader.sink.address.eq(word_address),
+            inner_reader.sink.valid.eq(1),
+            inner_reader.sink.last.eq(word_address == (region_start + sink.va + sink.len - 1)[ratio_bits:]),
+            If(inner_reader.sink.ready,
+                NextValue(word_address, word_address + 1),
+                If(inner_reader.sink.last,
+                    NextState("WAIT_READ")
+                )
+            ),
+            # Pipe out responses
+            If(source.valid & source.ready,
+                NextValue(reading_byte, reading_byte + 1),
+                NextValue(reading_byte_local_address, reading_byte_local_address + 1)
+            )
+        )
+
+        # Fetch remaining responses
+        fsm.act("WAIT_READ",
+            source.last.eq(reading_byte == sink.len),
+            If(source.valid & source.ready,
+                NextValue(reading_byte, reading_byte + 1),
+                NextValue(reading_byte_local_address, reading_byte_local_address + 1),
+                If(source.last,
+                    sink.ready.eq(1), # Consume incoming
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        self.comb += [
+            source.valid.eq(inner_reader.source.valid),
+            inner_reader.source.ready.eq(source.ready &
+                                       ((reading_byte_local_address == ratio - 1) | source.last)),
+            Case(reading_byte_local_address, {
+                Constant(i, ratio_bits):
+                    source.data.eq(inner_reader.source.data[dw*i:dw*(i+1)])
+                for i in range(ratio)
+            })
+        ]
+
+# Warning: Writing has to start at a 128bit-aligned (16 bytes) address
+class LiteEthIBMemoryRegionWriter(LiteXModule):
+    """Infiniband Memory Region Writer
+
+    A reader that accepts a virtual address and length and sends back the corresponding data from ram.
+    Virtual address 0 corresponds to start of memory region.
+
+    Parameters
+    ----------
+    region_start : int
+        Physical address of the start
+        of the memory region in the ram.
+    region_size : int
+        The size of the memory region.
+    port : LiteDRAMNativePort | LiteDRAMAXIPort | _MemoryPort
+        Write port to physical ram.
+    buffered_in : bool
+        Whether to buffer input to cut timing
+    buffered_out : bool
+        Whether to buffer output to cut timing
+    dw : int
+        Width of the data bus.
+
+    Attributes
+    ----------
+    sink : in
+        Address and data to be written.
+    """
+    def __init__(self, region_start, port, buffered_in=True, dw=8):
+        self.sink   = sink   = Endpoint([("data", dw), ("va", 64)])
+
+        # # #
+
+        assert isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort, _MemoryPort))
+
+        # Adding buffer at memory region sink
+        if buffered_in:
+            buff_in = Buffer([("data", dw), ("va", 64)])
+            self.submodules.buff_in = buff_in
+            self.comb += sink.connect(buff_in.sink)
+            sink = buff_in.source
+
+        # Parameters
+        if isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort)):
+            port_width = port.data_width
+        else: # isinstance(port, _MemoryPort)
+            port_width = len(port.dat_r)
+        ratio      = port_width // dw
+        ratio_bits = log2_int(ratio)
+
+        assert dw == 8
+        assert port_width % dw == 0
+
+        # Submodules
+        # Internal DMA writer
+        # WARNING: I modified LiteDRAMDMAWriter to accept a last signal
+        if isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort)):
+            inner_writer = LiteDRAMDMAWriter(port, fifo_depth=PMTU)
+        else: # isinstance(port, _MemoryPort)
+            inner_writer = LiteBRAMWriter(port)
+        self.submodules.inner_writer = inner_writer
+
+        # Assemble command and data for a larger memory port width
+        in_fifo = SyncFIFO(
+            layout = [
+                ("data", port_width),
+                ("address", 64 - ratio_bits)
+            ],
+            depth    = 2,
+            buffered = True
+        )
+        self.submodules.in_fifo = in_fifo
+
+        # Signals
+        # Current address we are writing to
+        write_address = Signal(64)
+        buffer        = Signal(port_width)
+        buffer_next   = Signal().like(buffer)
+        mask          = Signal(port_width)
+
+        # FSM
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(sink.valid,
+                NextValue(write_address, region_start + sink.va),
+                NextValue(buffer, 0),
+                NextState("WRITING")
+            )
+        )
+
+        # Pipe in writes
+        fsm.act("WRITING",
+            in_fifo.sink.valid.eq(sink.valid & ((write_address[:ratio_bits] == ratio - 1) | sink.last)),
+            sink.ready.eq(((write_address[:ratio_bits] != ratio - 1) & (~sink.last)) | in_fifo.sink.ready),
+            If(sink.valid & sink.ready,
+                NextValue(buffer, buffer_next),
+                NextValue(write_address, write_address + 1),
+                If(sink.last,
+                    NextState("FINISHING")
+                )
+            )
+        )
+
+        fsm.act("FINISHING",
+            If(in_fifo.source.valid & in_fifo.source.ready & in_fifo.source.last,
+                NextState("IDLE")
+            )
+        )
+
+        # Buffer logic
+        buffer_case = {}
+        mask_case = {}
+        for i in range(ratio):
+            buffer_case[i] = [buffer_next.eq(buffer),
+                              buffer_next[dw*i:dw*(i+1)].eq(sink.data)]
+            mask_case[i] = mask.eq(Replicate(0xff, i + 1))
+
+        # Commands piped into fifo
+        self.comb += [
+            Case(write_address[:ratio_bits], buffer_case),
+            Case(write_address[:ratio_bits], mask_case),
+            in_fifo.sink.last.eq(sink.last),
+            in_fifo.sink.data.eq(buffer_next),
+            in_fifo.sink.address.eq(write_address[ratio_bits:]),
+        ]
+
+        # Commands piped from fifo to inner_writer
+        self.comb += in_fifo.source.connect(inner_writer.sink)
+
+class PERM(Flag):
+    REMOTE_READ = auto()
+    REMOTE_WRITE = auto()
+    LOCAL_WRITE = auto()
+    NO_LOCAL_READ = auto() # We cannot send from this memory
+
+class LiteEthIBMemoryRegion(LiteXModule):
+    """Infiniband Memory Region
+
+    Keep track of memory region information and instantiate a reader and writer,
+    depending on permissions.
+
+    Parameters
+    ----------
+    region_start : int
+        Start of the memory region.
+    region_size : int
+        Size of the memory region.
+    permissions : PERM
+        Permissions for rdma to use the ram.
+    l_key : int
+        Local key that allows local operations
+        to reference the region.
+    r_key : int
+        Remote key that allows remote operations
+        to reference the region.
+    memory: Memory
+        A reference to the underlying physical
+        memory block.
+    read_port: LiteDRAMNativePort | LiteDRAMAXIPort | _MemoryPort
+        A port for reading from the underlying
+        physical memory block.
+    write_port: LiteDRAMNativePort | LiteDRAMAXIPort | _MemoryPort
+        A port for writing to the underlying
+        physical memory block.
+    dw: int
+        Datapath width.
+    """
+    def __init__(
+            self,
+            region_start,
+            region_size,
+            permissions,
+            l_key, r_key,
+            memory,
+            read_port=None,
+            write_port=None,
+            dw=8
+        ):
+        self.region_start = region_start
+        self.region_size = region_size
+        self.permissions = permissions
+        self.memory = memory
+        self.l_key = l_key
+        self.r_key = r_key
+
+        if PERM.NO_LOCAL_READ not in permissions or PERM.REMOTE_READ in permissions:
+            if read_port is None:
+                raise ValueError("Read port needed!")
+            self.submodules.reader = LiteEthIBMemoryRegionReader(
+                region_start = region_start,
+                port         = read_port,
+                dw           = dw
+            )
+
+        if PERM.REMOTE_WRITE in permissions or PERM.LOCAL_WRITE in permissions:
+            if write_port is None:
+                raise ValueError("Write port needed with current permissions!")
+            self.submodules.writer = LiteEthIBMemoryRegionWriter(
+                region_start = region_start,
+                port         = write_port,
+                dw           = dw
+            )
+
+
+# A dictionary linking r_keys with memory regions
+class LiteEthIBMemoryRegionsHandler(LiteXModule):
+    """Infiniband Memory Regions Handler
+
+    Keep track of memory regions information and maintaining unique l_keys and r_keys.
+    """
+    def __init__(self):
+        self._l_keys = set()
+        self._r_keys = set()
+        self.mrs = []
+
+    def reg_mr(self,
+               region_start,
+               region_size,
+               permissions,
+               l_key,
+               r_key,
+               memory,
+               read_port=None,
+               write_port=None,
+               dw=8
+        ):
+        # Ensure validity and uniqueness of l_key and r_key
+        assert l_key is not None and l_key not in self._l_keys
+        assert l_key >= 0 and l_key < 2**32
+
+        assert r_key is not None and r_key not in self._r_keys
+        assert r_key >= 0 and r_key < 2**32
+
+        # Instantiate memory region
+        mr = LiteEthIBMemoryRegion(
+            region_start = region_start,
+            region_size  = region_size,
+            permissions  = permissions,
+            l_key        = l_key,
+            r_key        = r_key,
+            memory       = memory,
+            read_port    = read_port,
+            write_port   = write_port,
+            dw           = dw
+        )
+        self.mrs.append(mr)
+        self._l_keys.add(l_key)
+        self._r_keys.add(r_key)
+        print(f"Added mr with l_key {l_key} and r_key {r_key}")
+
+        return mr
+
+    def do_finalize(self):
+        for i, memr in enumerate(self.mrs):
+            self.add_module(f"memory_region{i}", memr)

--- a/liteeth/core/rocev2/mr.py
+++ b/liteeth/core/rocev2/mr.py
@@ -1,0 +1,780 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Buffer, Endpoint, SyncFIFO, AsyncFIFO
+
+from litedram.frontend.dma import LiteDRAMDMAReader, LiteDRAMDMAWriter
+
+from litedram.common import LiteDRAMNativePort
+from litedram.frontend.axi import LiteDRAMAXIPort
+from migen.fhdl.specials import _MemoryPort
+
+from enum import Flag, auto
+
+class LiteEthDummyMRReader(LiteXModule):
+    """Dummy MR Reader
+
+    Reads data out from Dummy MR (a stream).
+
+    Parameters
+    ----------
+    port : ReadPort
+        Read port to Dummy MR.
+
+    Attributes
+    ----------
+    sink : in
+        Address of data to be read.
+        (address is only here for compatibility as the
+        stream has no addresses)
+    source : out
+        Data being read.
+    """
+    def __init__(self, port):
+        # The sink is a dummy, since there are no addresses in a FIFO
+        self.sink   = sink   = Endpoint([("address", 1)])
+        self.source = source = Endpoint([("data", port.data_width)])
+
+        # # #
+
+        self.buff_out = buff_out = Buffer([("data", port.data_width)])
+
+        self.sync += [
+            If(buff_out.sink.valid & buff_out.sink.ready & buff_out.sink.last,
+                port.lock.eq(0)
+            ).Elif(sink.valid,
+                port.lock.eq(1)
+            )
+        ]
+        self.comb += [
+            port.source.ready.eq(buff_out.sink.ready & buff_out.sink.valid),
+            sink.ready.eq(buff_out.sink.ready & buff_out.sink.valid),
+            buff_out.sink.valid.eq(sink.valid & port.source.valid),
+            buff_out.sink.data.eq(port.source.data),
+            buff_out.sink.last.eq(sink.last),
+            buff_out.source.connect(source)
+        ]
+
+class LiteEthDummyMRWriter(LiteXModule):
+    """Dummy MR Writer
+
+    Writes data into Dummy MR (a stream).
+
+    Parameters
+    ----------
+    port : WritePort
+        Write port to Dummy MR.
+
+    Attributes
+    ----------
+    sink : in
+        Address and data being written.
+        (address is only here for compatibility as the
+        stream has no addresses)
+    """
+    def __init__(self, port):
+        self.sink = sink = Endpoint([("address", 1), ("data", port.data_width)])
+
+        # # #
+
+        self.buff_in = buff_in = Buffer([("data", port.data_width)])
+
+        self.comb += [
+            sink.connect(buff_in.sink, omit={"address"}),
+            port.sink.data.eq(buff_in.source.data),
+            port.sink.valid.eq(buff_in.source.valid),
+            buff_in.source.ready.eq(port.sink.ready),
+            port.sink.last.eq(buff_in.source.last),
+        ]
+
+class ReadPort:
+    def __init__(self, dw):
+        self.data_width = dw
+        self.source = Endpoint([("data", dw)], name="read_port_source")
+        self.lock = Signal()
+
+class WritePort:
+    def __init__(self, dw):
+        self.data_width = dw
+        self.sink = Endpoint([("data", dw)])
+
+from litex.soc.interconnect.packet import Arbiter
+
+class MyDispatcher(LiteXModule):
+    def __init__(self, master, slaves, one_hot=False, discard=True, **kwargs):
+        if len(slaves) == 0:
+            self.sel = Signal()
+        elif len(slaves) == 1 and not one_hot:
+            self.comb += master.connect(slaves.pop(), **kwargs)
+            self.sel = Signal()
+        else:
+            if one_hot:
+                self.sel = Signal(len(slaves))
+            else:
+                self.sel = Signal(max=len(slaves))
+
+            # # #
+
+            sel = Signal.like(self.sel)
+            self.comb += sel.eq(self.sel)
+            # Hold the route from first beat to packet completion.
+            cases = {}
+            for i, slave in enumerate(slaves):
+                if one_hot:
+                    idx = 2**i
+                else:
+                    idx = i
+                cases[idx] = [master.connect(slave, **kwargs)]
+            cases["default"] = [master.ready.eq(discard)]
+            self.comb += Case(sel, cases)
+
+@ResetInserter(clock_domains=["sys"])
+class LiteEthDummyRXMR(LiteXModule):
+    def __init__(self, depth, dw):
+        self.dw = dw
+        self.fifo = fifo = AsyncFIFO(
+            layout = [("data", dw)],
+            depth  = depth
+        )
+
+        self.write_ports = []
+        self.read_port = read_port = ReadPort(dw)
+
+        self.comb += fifo.source.connect(read_port.source)
+
+    def get_write_port(self):
+        write_port = WritePort(self.dw)
+
+        self.write_ports.append(write_port)
+        return write_port
+
+    def do_finalize(self):
+        sinks = [write_port.sink for write_port in self.write_ports]
+        self.arbiter = Arbiter(sinks, self.fifo.sink)
+
+@ResetInserter(clock_domains=["sys"])
+class LiteEthDummyTXMR(LiteXModule):
+    def __init__(self, depth, dw):
+        self.dw = dw
+        self.fifo = fifo = AsyncFIFO(
+            layout = [("data", dw)],
+            depth  = depth
+        )
+
+        self.write_port = write_port = WritePort(dw)
+        self.read_ports = []
+
+        self.comb += write_port.sink.connect(fifo.sink)
+
+    def get_read_port(self):
+        read_port = ReadPort(self.dw)
+        self.read_ports.append(read_port)
+        return read_port
+
+    def do_finalize(self):
+        self.lock_fifo = lock_fifo = SyncFIFO([("lock", len(self.read_ports))], len(self.read_ports))
+
+        locks = Signal(len(self.read_ports))
+        locks_prev = Signal().like(locks, reset_less=True)
+        locks_new = Signal().like(locks)
+        unlocks_new = Signal().like(locks)
+
+        self.comb += [
+            locks.eq(Cat(*[read_port.lock for read_port in self.read_ports])),
+            locks_new.eq(~locks_prev & locks),
+            unlocks_new.eq(locks_prev & ~locks),
+            lock_fifo.sink.valid.eq(locks_new != 0),
+            Case(locks_new, {
+                Constant(1 << i, len(locks)):
+                lock_fifo.sink.lock.eq(locks_new)
+                for i in range(len(self.read_ports))
+            }),
+        ]
+        self.sync += locks_prev.eq(locks)
+
+        # Normal dispatcher discards incoming data when no source is selected.
+        # In our design, it needs to wait
+        sources = [read_port.source for read_port in self.read_ports]
+        self.dispatcher = dispatcher = MyDispatcher(self.fifo.source, sources, one_hot=True, discard=False)
+        self.comb += [
+            If(lock_fifo.source.valid,
+                dispatcher.sel.eq(lock_fifo.source.lock),
+            ),
+            lock_fifo.source.ready.eq(unlocks_new != 0)
+        ]
+
+class LiteBRAMReader(LiteXModule):
+    """BRAM Reader
+
+    Reads data out from block RAM.
+
+    Parameters
+    ----------
+    port : _MemoryPort
+        Read port to BRAM.
+
+    Attributes
+    ----------
+    sink : in
+        Address of data to be read.
+    source : out
+        Data being read.
+    """
+    def __init__(self, port):
+        self.sink   = sink = Endpoint([("address", len(port.adr))])
+        self.source = source = Endpoint([("data", len(port.dat_r))])
+
+        # # #
+
+        # Bufferize the data being output with fifo
+        out_fifo = SyncFIFO([("data", len(port.dat_r))], 32)
+        self.submodules.out_fifo = out_fifo
+        self.comb += port.adr.eq(sink.address)
+
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(sink.valid,
+                NextState("READ")
+            )
+        )
+        fsm.act("READ",
+            out_fifo.sink.data.eq(port.dat_r),
+            out_fifo.sink.last.eq(sink.last),
+            out_fifo.sink.valid.eq(1),
+            If(out_fifo.sink.ready,
+                sink.ready.eq(1),
+                NextState("IDLE")
+            )
+        )
+
+        self.comb += out_fifo.source.connect(source)
+
+class LiteBRAMWriter(LiteXModule):
+    """BRAM Writer
+
+    Writes data into block RAM.
+
+    Parameters
+    ----------
+    port : _MemoryPort
+        Write port to BRAM.
+
+    Attributes
+    ----------
+    sink : in
+        Address and data being written.
+    """
+    def __init__(self, port):
+        self.sink   = sink = Endpoint([
+            ("address", len(port.adr)),
+            ("data", len(port.dat_w))
+        ])
+
+        self.comb += [
+            sink.ready.eq(1),
+            port.adr.eq(sink.address),
+            port.we.eq(sink.valid),
+            port.dat_w.eq(sink.data),
+        ]
+
+# Memory management --------------------------------------------------------------------------------
+class LiteEthIBMemoryRegionReader(LiteXModule):
+    """Infiniband Memory Region Reader
+
+    A reader that accepts a virtual address and length and sends back the corresponding data from ram.
+    Virtual address 0 corresponds to start of memory region.
+
+    Parameters
+    ----------
+    region_start : int
+        Physical address of the start
+        of the memory region in the ram.
+    port : LiteDRAMNativePort | LiteDRAMAXIPort | _MemoryPort
+        Read port to physical ram.
+    buffered_in : bool
+        Whether to buffer input to cut timing
+    buffered_out : bool
+        Whether to buffer output to cut timing
+    dw : int
+        Width of the data bus.
+
+    Attributes
+    ----------
+    sink : in
+        Address and length of data to be read.
+    source : out
+        Data being read.
+    """
+    def __init__(self, region_start, port, buffered_in=True, buffered_out=True, dw=8):
+        self.sink   = sink   = Endpoint([("va", 64), ("len", bits_for(PMTU))])
+        self.source = source = Endpoint([("data", dw)])
+
+        # # #
+
+        assert dw in [8, 16, 32, 64]
+        assert isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort, _MemoryPort, ReadPort))
+
+        # Bufferize sink to cut timing path
+        if buffered_in:
+            buff_in = Buffer([("va", 64), ("len", bits_for(PMTU))])
+            self.submodules.buff_in = buff_in
+            self.comb += sink.connect(buff_in.sink)
+            sink = buff_in.source
+
+        if buffered_out:
+            buff_out = Buffer([("data", dw)])
+            self.submodules.buff_out = buff_out
+            self.comb += buff_out.source.connect(source)
+            source = buff_out.sink
+
+
+        if isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort, ReadPort)):
+            port_width = port.data_width
+        else: # isinstance(port, _MemoryPort)
+            port_width = len(port.dat_r)
+        assert port_width in [8, 16, 32, 64]
+
+        # Internal DMA reader
+        if isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort)):
+            inner_reader = LiteDRAMDMAReader(port, fifo_depth=PMTU)
+        elif isinstance(port, _MemoryPort):
+            inner_reader = LiteBRAMReader(port)
+        else: # isinstance(port, ReadPort)
+            inner_reader = LiteEthDummyMRReader(port)
+        self.inner_reader = inner_reader
+
+        if port_width > dw:
+            ratio          = port_width // dw
+            ratio_bits     = log2_int(ratio)
+
+            assert dw == 8
+
+            # Address of word to be used for next read request
+            word_address = Signal(64 - ratio_bits)
+            # Byte being read from current returned word
+            reading_byte_local_address = Signal(ratio_bits)
+            # The number of the word being output from the DMA reader
+            reading_byte = Signal(bits_for(PMTU))
+
+            # Reader FSM
+            self.fsm = fsm = FSM(reset_state="IDLE")
+            fsm.act("IDLE",
+                If(sink.valid,
+                    NextValue(word_address, (region_start + sink.va)[ratio_bits:]),
+                    NextValue(reading_byte_local_address, (region_start + sink.va)[:ratio_bits]),
+                    NextValue(reading_byte, 1),
+                    NextState("READING")
+                )
+            )
+
+            fsm.act("READING",
+                # Pipe in requests
+                inner_reader.sink.address.eq(word_address),
+                inner_reader.sink.valid.eq(1),
+                inner_reader.sink.last.eq(word_address == (region_start + sink.va + sink.len - 1)[ratio_bits:]),
+                If(inner_reader.sink.ready,
+                    NextValue(word_address, word_address + 1),
+                    If(inner_reader.sink.last,
+                        NextState("WAIT_READ")
+                    )
+                ),
+                # Pipe out responses
+                If(source.valid & source.ready,
+                    NextValue(reading_byte, reading_byte + 1),
+                    NextValue(reading_byte_local_address, reading_byte_local_address + 1)
+                )
+            )
+
+            # Fetch remaining responses
+            fsm.act("WAIT_READ",
+                source.last.eq(reading_byte == sink.len),
+                If(source.valid & source.ready,
+                    NextValue(reading_byte, reading_byte + 1),
+                    NextValue(reading_byte_local_address, reading_byte_local_address + 1),
+                    If(source.last,
+                        sink.ready.eq(1), # Consume incoming
+                        NextState("IDLE")
+                    )
+                )
+            )
+
+            self.comb += [
+                source.valid.eq(inner_reader.source.valid),
+                inner_reader.source.ready.eq(source.ready &
+                                        ((reading_byte_local_address == ratio - 1) | source.last)),
+                Case(reading_byte_local_address, {
+                    Constant(i, ratio_bits):
+                        source.data.eq(inner_reader.source.data[dw*i:dw*(i+1)])
+                    for i in range(ratio)
+                })
+            ]
+
+        elif port_width == dw:
+            assert dw == 8
+            # Address of word to be used for next read request
+            word_address = Signal(64)
+            # The number of the word being output from the DMA reader
+            reading_byte = Signal(bits_for(PMTU))
+
+            # Reader FSM
+            self.fsm = fsm = FSM(reset_state="IDLE")
+            fsm.act("IDLE",
+                If(sink.valid,
+                    NextValue(word_address, (region_start + sink.va)),
+                    NextValue(reading_byte, 1),
+                    NextState("READING")
+                )
+            )
+
+            fsm.act("READING",
+                # Pipe in requests
+                inner_reader.sink.address.eq(word_address),
+                inner_reader.sink.valid.eq(1),
+                inner_reader.sink.last.eq(word_address == region_start + sink.va + sink.len - 1),
+                If(inner_reader.sink.ready,
+                    NextValue(word_address, word_address + 1),
+                    If(inner_reader.sink.last,
+                        NextState("WAIT_READ")
+                    )
+                ),
+                # Pipe out responses
+                If(source.valid & source.ready,
+                    NextValue(reading_byte, reading_byte + 1)
+                )
+            )
+
+            # Fetch remaining responses
+            fsm.act("WAIT_READ",
+                source.last.eq(reading_byte == sink.len),
+                If(source.valid & source.ready,
+                    NextValue(reading_byte, reading_byte + 1),
+                    If(source.last,
+                        sink.ready.eq(1), # Consume incoming
+                        NextState("IDLE")
+                    )
+                )
+            )
+
+            self.comb += [
+                source.valid.eq(inner_reader.source.valid),
+                inner_reader.source.ready.eq(source.ready),
+                source.data.eq(inner_reader.source.data)
+            ]
+
+# Warning: Writing has to start at a 128bit-aligned (16 bytes) address
+class LiteEthIBMemoryRegionWriter(LiteXModule):
+    """Infiniband Memory Region Writer
+
+    A reader that accepts a virtual address and length and sends back the corresponding data from ram.
+    Virtual address 0 corresponds to start of memory region.
+
+    Parameters
+    ----------
+    region_start : int
+        Physical address of the start
+        of the memory region in the ram.
+    region_size : int
+        The size of the memory region.
+    port : LiteDRAMNativePort | LiteDRAMAXIPort | _MemoryPort
+        Write port to physical ram.
+    buffered_in : bool
+        Whether to buffer input to cut timing
+    buffered_out : bool
+        Whether to buffer output to cut timing
+    dw : int
+        Width of the data bus.
+
+    Attributes
+    ----------
+    sink : in
+        Address and data to be written.
+    """
+    def __init__(self, region_start, port, buffered_in=True, dw=8):
+        self.sink   = sink   = Endpoint([("data", dw), ("va", 64)])
+
+        # # #
+
+        assert dw in [8, 16, 32, 64]
+        assert isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort, _MemoryPort, WritePort))
+
+        # Adding buffer at memory region sink
+        if buffered_in:
+            buff_in = Buffer([("data", dw), ("va", 64)])
+            self.submodules.buff_in = buff_in
+            self.comb += sink.connect(buff_in.sink)
+            sink = buff_in.source
+
+        # Parameters
+        if isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort, WritePort)):
+            port_width = port.data_width
+        else: # isinstance(port, _MemoryPort)
+            port_width = len(port.dat_w)
+
+        assert port_width in [8, 16, 32, 64]
+
+        # Submodules
+        # Internal DMA writer
+        if isinstance(port, (LiteDRAMNativePort, LiteDRAMAXIPort)):
+            inner_writer = LiteDRAMDMAWriter(port, fifo_depth=PMTU)
+        elif isinstance(port, _MemoryPort):
+            inner_writer = LiteBRAMWriter(port)
+        else: # isinstance(port, WritePort)
+            inner_writer = LiteEthDummyMRWriter(port)
+        self.submodules.inner_writer = inner_writer
+
+        if port_width > dw:
+            assert dw == 8
+
+            ratio      = port_width // dw
+            ratio_bits = log2_int(ratio)
+
+            # Assemble command and data for a larger memory port width
+            in_fifo = SyncFIFO(
+                layout = [
+                    ("data", port_width),
+                    ("address", 64 - ratio_bits)
+                ],
+                depth    = 2,
+                buffered = True
+            )
+            self.in_fifo = in_fifo
+
+            # Signals
+            # Current address we are writing to
+            write_address = Signal(64)
+            buffer        = Signal(port_width)
+            buffer_next   = Signal().like(buffer)
+            mask          = Signal(port_width)
+
+            # FSM
+            self.fsm = fsm = FSM(reset_state="IDLE")
+            fsm.act("IDLE",
+                If(sink.valid,
+                    NextValue(write_address, region_start + sink.va),
+                    NextValue(buffer, 0),
+                    NextState("WRITING")
+                )
+            )
+
+            # Pipe in writes
+            fsm.act("WRITING",
+                in_fifo.sink.valid.eq(sink.valid & ((write_address[:ratio_bits] == ratio - 1) | sink.last)),
+                sink.ready.eq(((write_address[:ratio_bits] != ratio - 1) & (~sink.last)) | in_fifo.sink.ready),
+                If(sink.valid & sink.ready,
+                    NextValue(buffer, buffer_next),
+                    NextValue(write_address, write_address + 1),
+                    If(sink.last,
+                        NextState("FINISHING")
+                    )
+                )
+            )
+
+            fsm.act("FINISHING",
+                If(in_fifo.source.valid & in_fifo.source.ready & in_fifo.source.last,
+                    NextState("IDLE")
+                )
+            )
+
+            # Buffer logic
+            buffer_case = {}
+            mask_case = {}
+            for i in range(ratio):
+                buffer_case[i] = [buffer_next.eq(buffer),
+                                buffer_next[dw*i:dw*(i+1)].eq(sink.data)]
+                mask_case[i] = mask.eq(Replicate(0xff, i + 1))
+
+            # Commands piped into fifo
+            self.comb += [
+                Case(write_address[:ratio_bits], buffer_case),
+                Case(write_address[:ratio_bits], mask_case),
+                in_fifo.sink.last.eq(sink.last),
+                in_fifo.sink.data.eq(buffer_next),
+                in_fifo.sink.address.eq(write_address[ratio_bits:]),
+            ]
+
+            # Commands piped from fifo to inner_writer
+            self.comb += in_fifo.source.connect(inner_writer.sink)
+
+        elif port_width == dw:
+            assert dw == 8
+
+            # Assemble command and data for a larger memory port width
+            in_fifo = SyncFIFO(
+                layout = [
+                    ("data", port_width),
+                    ("address", 64)
+                ],
+                depth    = 2,
+                buffered = True
+            )
+            self.in_fifo = in_fifo
+
+            # Signals
+            # Current address we are writing to
+            write_address = Signal(64)
+
+            # FSM
+            self.fsm = fsm = FSM(reset_state="IDLE")
+            fsm.act("IDLE",
+                If(sink.valid,
+                    NextValue(write_address, region_start + sink.va),
+                    NextState("WRITING")
+                )
+            )
+
+            # Pipe in writes
+            fsm.act("WRITING",
+                in_fifo.sink.valid.eq(sink.valid),
+                sink.ready.eq(in_fifo.sink.ready),
+                If(sink.valid & sink.ready,
+                    NextValue(write_address, write_address + 1),
+                    If(sink.last,
+                        NextState("FINISHING")
+                    )
+                )
+            )
+
+            fsm.act("FINISHING",
+                If(in_fifo.source.valid & in_fifo.source.ready & in_fifo.source.last,
+                    NextState("IDLE")
+                )
+            )
+
+            # Commands piped into fifo
+            self.comb += [
+                in_fifo.sink.last.eq(sink.last),
+                in_fifo.sink.data.eq(sink.data),
+                in_fifo.sink.address.eq(write_address),
+            ]
+
+            # Commands piped from fifo to inner_writer
+            self.comb += in_fifo.source.connect(inner_writer.sink)
+
+class PERM(Flag):
+    REMOTE_READ = auto()
+    REMOTE_WRITE = auto()
+    LOCAL_WRITE = auto()
+    NO_LOCAL_READ = auto() # We cannot send from this memory
+
+@ResetInserter()
+class LiteEthIBMemoryRegion(LiteXModule):
+    """Infiniband Memory Region
+
+    Keep track of memory region information and instantiate a reader and writer,
+    depending on permissions.
+
+    Parameters
+    ----------
+    region_start : int
+        Start of the memory region.
+    region_size : int
+        Size of the memory region.
+    permissions : PERM
+        Permissions for rdma to use the ram.
+    l_key : int
+        Local key that allows local operations
+        to reference the region.
+    r_key : int
+        Remote key that allows remote operations
+        to reference the region.
+    memory: Memory
+        A reference to the underlying physical
+        memory block.
+    read_port: LiteDRAMNativePort | LiteDRAMAXIPort | _MemoryPort
+        A port for reading from the underlying
+        physical memory block.
+    write_port: LiteDRAMNativePort | LiteDRAMAXIPort | _MemoryPort
+        A port for writing to the underlying
+        physical memory block.
+    dw: int
+        Datapath width.
+    """
+    def __init__(
+            self,
+            region_start,
+            region_size,
+            permissions,
+            l_key, r_key,
+            read_port=None,
+            write_port=None,
+            dw=8
+        ):
+        self.region_start = region_start
+        self.region_size = region_size
+        self.permissions = permissions
+        self.l_key = l_key
+        self.r_key = r_key
+
+        if PERM.NO_LOCAL_READ not in permissions or PERM.REMOTE_READ in permissions:
+            if read_port is None:
+                raise ValueError("Read port needed!")
+            self.submodules.reader = LiteEthIBMemoryRegionReader(
+                region_start = region_start,
+                port         = read_port,
+                dw           = dw
+            )
+
+        if PERM.REMOTE_WRITE in permissions or PERM.LOCAL_WRITE in permissions:
+            if write_port is None:
+                raise ValueError("Write port needed with current permissions!")
+            self.submodules.writer = LiteEthIBMemoryRegionWriter(
+                region_start = region_start,
+                port         = write_port,
+                dw           = dw
+            )
+
+
+# A dictionary linking r_keys with memory regions
+class LiteEthIBMemoryRegionsHandler(LiteXModule):
+    """Infiniband Memory Regions Handler
+
+    Keep track of memory regions information and maintaining unique l_keys and r_keys.
+    """
+    def __init__(self):
+        self._l_keys = set()
+        self._r_keys = set()
+        self.mrs = []
+
+        self.reset = Signal(reset=1)
+        self.sync += self.reset.eq(0)
+
+    def reg_mr(self,
+               region_start,
+               region_size,
+               permissions,
+               l_key,
+               r_key,
+               read_port=None,
+               write_port=None,
+               dw=8
+        ):
+        # Ensure validity and uniqueness of l_key and r_key
+        assert l_key is not None and l_key not in self._l_keys
+        assert l_key >= 0 and l_key < 2**32
+
+        assert r_key is not None and r_key not in self._r_keys
+        assert r_key >= 0 and r_key < 2**32
+
+        # Instantiate memory region
+        mr = LiteEthIBMemoryRegion(
+            region_start = region_start,
+            region_size  = region_size,
+            permissions  = permissions,
+            l_key        = l_key,
+            r_key        = r_key,
+            read_port    = read_port,
+            write_port   = write_port,
+            dw           = dw
+        )
+        self.mrs.append(mr)
+        self._l_keys.add(l_key)
+        self._r_keys.add(r_key)
+        print(f"Added mr with l_key {l_key} and r_key {r_key}")
+
+        return mr
+
+    def do_finalize(self):
+        for i, memr in enumerate(self.mrs):
+            self.sync += memr.reset.eq(self.reset)
+            self.add_module(f"memory_region{i}", memr)

--- a/liteeth/core/rocev2/pad.py
+++ b/liteeth/core/rocev2/pad.py
@@ -1,0 +1,155 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Endpoint, Buffer
+
+# IBT Padding --------------------------------------------------------------------------------------
+
+class LiteEthIBTPaddingInserter(LiteXModule):
+    def __init__(self, dw):
+        self.sink   = sink   = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1)]))
+        self.source = source = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1)]))
+
+        # # #
+
+        assert dw in [8]
+
+        # Connect all parameter signals
+        self.comb += sink.connect(source, omit={"valid", "ready", "last", "data", "length", "pad"})
+        self.comb += [
+            source.length.eq(sink.length + (0x100 - sink.length[:2])[:2]),
+            source.pad.eq((0b100 - sink.length[:2])[:2])
+        ]
+
+        counter = Signal(2)
+
+        # FSM
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(~sink.header_only,
+                sink.connect(source, keep={"valid", "data"}),
+                source.last.eq(sink.last & (counter == 3)),
+                sink.ready.eq((~sink.last | (counter == 3)) & source.ready),
+                If(sink.valid & source.ready,
+                    NextValue(counter, counter + 1),
+                    If(sink.last & (counter != 3),
+                        NextState("PADDING")
+                    )
+                )
+            ).Else(
+                sink.connect(source, keep={"valid", "data", "ready", "last"})
+            ),
+        )
+        fsm.act("PADDING",
+            source.valid.eq(1),
+            # Pad with 0s
+            source.data.eq(0),
+            source.last.eq(counter == 3),
+            If(source.valid & source.ready,
+                NextValue(counter, counter + 1),
+                If(source.last,
+                    sink.ready.eq(1),
+                    NextState("IDLE")
+                )
+            )
+        )
+
+# Behaviour when a zero-length packet claims to have padding or when a packet is
+# not a multiple of 4 is not specified. In our case, we send a Invalid Request NAK
+class LiteEthIBTPaddingRemover(LiteXModule):
+    def __init__(self, dw):
+        self.sink   = sink   = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1)]))
+        self.source = source = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1)]))
+        self.error  = error  = Signal()
+
+        # # #
+
+        # Connect all parameter signals
+        self.comb += sink.connect(source, omit={"valid", "ready", "last", "data"})
+
+        # Signals
+        # We add a 4 byte latency to pipeline to detect last 4 bytes and treat them accordingly
+        pipe       = Signal(32, reset_less=True)
+        shift_pipe = Signal()
+        fill_cnt   = Signal(2)
+        dat_cnt    = Signal(2, reset_less=True)
+
+        self.sync += [
+            If(shift_pipe, pipe.eq(Cat(pipe[8:], sink.data)))
+        ]
+
+        # FSM
+        self.fsm = fsm = FSM(reset_state="FILL")
+        fsm.act("FILL",
+            If(sink.header_only,
+                sink.connect(source, keep={"valid", "ready", "last", "data"}),
+                If(sink.pad != 0,
+                    NextState("ERROR")
+                )
+            ).Else(
+                shift_pipe.eq(sink.valid & source.ready),
+                sink.ready.eq(1),
+                If(sink.valid,
+                    If(source.ready,
+                        NextValue(fill_cnt, fill_cnt + 1),
+                        If(fill_cnt == 3,
+                            NextState("PASSTHROUGH"),
+                            If(sink.last,
+                                NextValue(dat_cnt, 3 - sink.pad),
+                                NextState("PAD")
+                            )
+                        )
+                    ),
+                    If((fill_cnt != 3) & sink.last,
+                        source.valid.eq(1),
+                        source.last.eq(1),
+                        If(source.ready,
+                            NextState("ERROR"),
+                            NextValue(fill_cnt, 0)
+                        )
+                    )
+                ),
+            )
+        )
+
+        fsm.act("PASSTHROUGH",
+            source.valid.eq(sink.valid),
+            sink.ready.eq(source.ready),
+            source.data.eq(pipe[:8]),
+            shift_pipe.eq(sink.valid & source.ready),
+            If(sink.valid & source.ready,
+                NextValue(fill_cnt, fill_cnt + 1),
+            ),
+            If(sink.valid & sink.last,
+                If(source.ready & (fill_cnt == 3),
+                    sink.ready.eq(0),
+                    NextValue(dat_cnt, 3 - sink.pad),
+                    NextState("PAD")
+                ),
+                If(fill_cnt != 3,
+                    source.last.eq(1),
+                    If(source.ready,
+                        NextState("ERROR"),
+                        NextValue(fill_cnt, 0)
+                    )
+                )
+            )
+        )
+
+        fsm.act("PAD",
+            source.valid.eq(1),
+            source.data.eq(pipe[:8]),
+            shift_pipe.eq(source.ready),
+            NextValue(dat_cnt, dat_cnt - source.ready),
+            source.last.eq(dat_cnt == 0),
+            If(source.ready & source.last,
+                sink.ready.eq(1),
+                NextState("FILL")
+            )
+        )
+
+        fsm.act("ERROR",
+            error.eq(1),
+            NextState("FILL")
+        )

--- a/liteeth/core/rocev2/qp.py
+++ b/liteeth/core/rocev2/qp.py
@@ -1,0 +1,296 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import SyncFIFO
+
+# Queue pairs --------------------------------------------------------------------------------------
+class _LiteEthIBSendQueue(SyncFIFO):
+    def __init__(self, layout, depth, with_rdma_state=True):
+        super().__init__(layout, depth, buffered=True)
+
+        self.psn   = Signal(24)
+        if with_rdma_state:
+            # only for tracking RDMA Read Responses locations
+            self.rdma_state = Record([
+                ("va_r",  64, DIR_M_TO_S),
+                ("va_l",  64, DIR_M_TO_S),
+                ("l_key", 32, DIR_M_TO_S)
+            ], reset_less=True)
+
+class _LiteEthIBReceiveQueue(SyncFIFO):
+    def __init__(self, layout, depth, with_rdma_state=True):
+        super().__init__(layout, depth, buffered=True)
+
+        self.psn   = Signal(24, reset=STARTING_PSN)
+        if with_rdma_state:
+            # mem_key is r_key on WRITE and l_key on SEND (which cannot be received simultaneously)
+            self.rdma_state = Record([
+                ("va",      64, DIR_M_TO_S),
+                ("mem_key", 32, DIR_M_TO_S)
+            ], reset_less=True)
+
+class _LiteEthIBGenericQP(LiteXModule):
+    def __init__(self, qp_id, conn_type):
+        # The two queues constituting the QP
+        self.send_queue    = _LiteEthIBSendQueue(
+            layout          = eth_rocev2_send_wr_description(),
+            depth           = 16,
+            with_rdma_state = (qp_id not in [0, 1])
+        )
+        self.receive_queue = _LiteEthIBReceiveQueue(
+            layout          = eth_rocev2_recv_wr_description(),
+            depth           = 16,
+            with_rdma_state = (qp_id not in [0, 1])
+        )
+
+        self.id = Constant(qp_id, 24)
+        # Id of the connected qp
+        self.other_id   = Signal(24, reset_less=True)
+        self.ip_address = Signal(32)
+
+        # Signals tracking the state of the QP
+        self.conn_type = Signal(3)
+        self.msn       = Signal(24, reset_less=True)
+
+        self.p_key = Signal(16)
+
+        # # #
+
+        # We treat conn_type as a constant
+        self.comb += self.conn_type.eq(conn_type)
+        # Default partition
+        self.comb += self.p_key.eq(DEFAULT_P_KEY)
+
+class LiteEthIBQP(_LiteEthIBGenericQP):
+    """Infiniband Queue Pair
+
+    A pair of queues (send and receive) used for establishing an RC (Reliable Connection)
+
+    Parameters
+    ----------
+    qp_id : int
+        Unique number associated with the QP.
+
+    Attributes
+    ----------
+    qp_state : in/out
+        Current state of the QP.
+    ip_address : in/out
+        Current IP address of the QP this QP is connected to.
+    nak_sent : in/out
+        Indicates if the qp has an outstanding NAK.
+    retry_cnt_rst: in/out
+        Value to which the retry counter has to be reset.
+    retry_cnt_rnr_rst: in/out
+        Value to which the rnr retry counter has to be reset.
+    """
+    (RESET, INIT, RTR, RTS, ERROR) = range(5)
+    def __init__(self, qp_id):
+        super().__init__(qp_id, QP_CONN_TYPE.RC)
+        assert qp_id not in [0, 1] # 0 and 1 are special QPs
+
+        self.qp_state = qp_state = Signal(bits_for(4), reset=LiteEthIBQP.RESET)
+        self.nak_sent = nak_sent = Signal()
+
+        self.local_error = local_error = Signal()
+
+        self.retry_cnt_rst     = Signal(3)
+        self.retry_cnt_rnr_rst = Signal(3)
+
+        # TODO How many requests can be outstanding?
+        # Requests that are awaiting acknowledgement
+        self.outstanding_read_requests = SyncFIFO(
+            layout   = add_params(eth_rocev2_send_wr_description(), [("psn", 24)]),
+            depth    = INITIATOR_DEPTH,
+            buffered = False
+        )
+        self.outstanding_requests = SyncFIFO(
+            layout   = add_params(eth_rocev2_send_wr_description(), [("psn", 24)]),
+            depth    = 16,
+            buffered = False
+        )
+        self.outstanding_requests_chooser = SyncFIFO(
+            layout   = [("choose", 1)],
+            depth    = INITIATOR_DEPTH + 16,
+            buffered = False
+        )
+
+        # # #
+
+        # We reset the QP depending on state
+        reset = Signal()
+        self.comb += reset.eq(qp_state == LiteEthIBQP.RESET)
+
+        op_seq_check_req  = OpcodeSequenceCheckerRequester()
+        op_seq_check_resp = OpcodeSequenceCheckerResponder()
+        self.submodules.op_seq_check_req  = op_seq_check_req
+        self.submodules.op_seq_check_resp = op_seq_check_resp
+
+        # Reset logic
+        self.comb += op_seq_check_req.reset.eq(reset)
+        self.comb += op_seq_check_resp.reset.eq(reset)
+        self.sync += [
+            If(reset,
+                self.receive_queue.psn.eq(self.receive_queue.psn.reset),
+                self.msn.eq(self.msn.reset),
+                self.receive_queue.rdma_state.va.eq(self.receive_queue.rdma_state.va.reset),
+                self.receive_queue.rdma_state.mem_key.eq(self.receive_queue.rdma_state.mem_key.reset),
+                self.send_queue.rdma_state.va_r.eq(self.send_queue.rdma_state.va_r.reset),
+                self.send_queue.rdma_state.va_l.eq(self.send_queue.rdma_state.va_l.reset),
+                self.send_queue.rdma_state.l_key.eq(self.send_queue.rdma_state.l_key.reset),
+                self.ip_address.eq(self.ip_address.reset),
+                local_error.eq(0),
+                nak_sent.eq(0)
+            )
+        ]
+
+# 0 and 1 are reserved QP ids. 1 is the only special QP in RoCEv2
+class LiteEthIBSpecialQP(_LiteEthIBGenericQP):
+    def __init__(self):
+        super().__init__(1, QP_CONN_TYPE.UD)
+
+        self.other_id = Constant(1, 24)
+
+# Misc ---------------------------------------------------------------------------------------------
+@ResetInserter()
+class OpcodeSequenceCheckerResponder(LiteXModule):
+    """Opcode Sequence checker for the responder
+
+    Checks that the sequence of received opcodes is correct
+
+    Attributes
+    ----------
+    update : in
+        Consume new packet opcode.
+    opcode : in
+        Opcode of incoming packet.
+    invalid_sequence : out
+        Indicates that the current incoming packet
+        has an invalid opcode considering the previous
+        ones.
+    """
+    def __init__(self):
+        self.update = update = Signal()
+        self.opcode = opcode = Signal(5)
+
+        self.invalid_sequence = invalid_sequence = Signal()
+
+        # # #
+        self.fsm = fsm = FSM(reset_state="NONE")
+        fsm.act("NONE",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.SEND_First,
+                BTH_OPCODE_OP.SEND_Only,
+                BTH_OPCODE_OP.SEND_Only_with_Immediate,
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Only,
+                BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate,
+                BTH_OPCODE_OP.RDMA_READ_Request,
+                # BTH_OPCODE_OP.CmpSwap,
+                # BTH_OPCODE_OP.FetchAdd
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.SEND_First:       NextState("SEND"),
+                    BTH_OPCODE_OP.RDMA_WRITE_First: NextState("RDMA_WRITE"),
+                    "default":                      NextState("NONE")
+                })
+            )
+        )
+
+        fsm.act("SEND",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.SEND_Middle,
+                BTH_OPCODE_OP.SEND_Last,
+                BTH_OPCODE_OP.SEND_Last_with_Immediate
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.SEND_Middle: NextState("SEND"),
+                    "default":                 NextState("NONE")
+                })
+            )
+        )
+
+        fsm.act("RDMA_WRITE",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.RDMA_WRITE_Middle,
+                BTH_OPCODE_OP.RDMA_WRITE_Last,
+                BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.RDMA_WRITE_Middle: NextState("RDMA_WRITE"),
+                    "default":                       NextState("NONE")
+                })
+            )
+        )
+
+@ResetInserter()
+class OpcodeSequenceCheckerRequester(LiteXModule):
+    """Opcode Sequence checker for the requester
+
+    Checks that the sequence of received opcodes is correct
+
+    Attributes
+    ----------
+    update : in
+        Consume new packet opcode.
+    opcode : in
+        Opcode of incoming packet.
+    invalid_sequence : out
+        Indicates that the current incoming packet
+        has an invalid opcode considering the previous
+        ones.
+    """
+    def __init__(self):
+        self.update = update = Signal()
+        self.opcode = opcode = Signal(5)
+
+        self.invalid_sequence = invalid_sequence = Signal()
+
+        # # #
+        self.fsm = fsm = FSM(reset_state="NONE")
+        fsm.act("NONE",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.RDMA_READ_response_First,
+                BTH_OPCODE_OP.RDMA_READ_response_Only,
+                BTH_OPCODE_OP.Acknowledge
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.RDMA_READ_response_First: NextState("RDMA_READ"),
+                    "default":                              NextState("NONE")
+                })
+            )
+        )
+
+        fsm.act("RDMA_READ",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.RDMA_READ_response_Middle,
+                BTH_OPCODE_OP.RDMA_READ_response_Last
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.RDMA_READ_response_Middle: NextState("RDMA_READ"),
+                    "default":                               NextState("NONE")
+                })
+            )
+        )
+
+# Completion queue
+class LiteEthCQ(SyncFIFO):
+    def __init__(self, depth, buffered=True):
+        super().__init__(eth_rocev2_cq_description(), depth, buffered)
+

--- a/liteeth/core/rocev2/qp.py
+++ b/liteeth/core/rocev2/qp.py
@@ -1,0 +1,361 @@
+from litex.gen import *
+
+from liteeth.common import *
+
+from collections import OrderedDict
+
+from litex.soc.interconnect.stream import SyncFIFO, Endpoint
+
+from litex.soc.interconnect.packet import Arbiter
+
+# Queue pairs --------------------------------------------------------------------------------------
+class LiteEthIBQPMasterPort:
+    def __init__(self):
+        self.send_source    = Endpoint(eth_rocev2_send_wr_description())
+        self.receive_source = Endpoint(eth_rocev2_recv_wr_description())
+
+class LiteEthIBQPSlavePort:
+    def __init__(self):
+        self.send_sink    = Endpoint(eth_rocev2_send_wr_description())
+        self.receive_sink = Endpoint(eth_rocev2_recv_wr_description())
+
+class LiteEthIBQPUserPort(LiteEthIBQPSlavePort):
+    def __init__(self):
+        LiteEthIBQPSlavePort.__init__(self)
+
+class LiteEthIBQPCrossbar(LiteXModule):
+    def __init__(self):
+        self.users = OrderedDict()
+        self.master = LiteEthIBQPMasterPort()
+
+    def get_port(self, qp_id, cd="sys", depth=None):
+        if qp_id in self.users.keys():
+            raise ValueError(f"QP with id {qp_id:#x} already assigned")
+
+        user_port     = LiteEthIBQPUserPort()
+        internal_port = LiteEthIBQPUserPort()
+
+        self.send_cdc = send_cdc = stream.ClockDomainCrossing(
+            layout  = eth_rocev2_send_wr_description(),
+            cd_from = cd,
+            cd_to   = "sys",
+            depth   = depth,
+        )
+        self.comb += [
+            user_port.send_sink.connect(send_cdc.sink),
+            send_cdc.source.connect(internal_port.send_sink)
+        ]
+
+        self.receive_cdc = receive_cdc = stream.ClockDomainCrossing(
+            layout  = eth_rocev2_recv_wr_description(),
+            cd_from = cd,
+            cd_to   = "sys",
+            depth   = depth,
+        )
+        self.comb += [
+            user_port.receive_sink.connect(receive_cdc.sink),
+            receive_cdc.source.connect(internal_port.receive_sink)
+        ]
+
+        self.users[qp_id] = internal_port
+        return user_port
+
+    def do_finalize(self):
+        send_sinks = [port.send_sink for port in self.users.values()]
+        self.arbiter_send = Arbiter(send_sinks, self.master.send_source)
+
+        receive_sinks = [port.receive_sink for port in self.users.values()]
+        self.arbiter_receive = Arbiter(receive_sinks, self.master.receive_source)
+
+class _LiteEthIBSendQueue(SyncFIFO):
+    def __init__(self, layout, depth, with_rdma_state=True):
+        super().__init__(layout, depth, buffered=True)
+
+        self.psn   = Signal(24, reset_less=True)
+        if with_rdma_state:
+            # only for tracking RDMA Read Responses locations
+            self.rdma_state = Record([
+                ("va_r",  64, DIR_M_TO_S),
+                ("va_l",  64, DIR_M_TO_S),
+                ("l_key", 32, DIR_M_TO_S)
+            ], reset_less=True)
+
+class _LiteEthIBReceiveQueue(SyncFIFO):
+    def __init__(self, layout, depth, with_rdma_state=True):
+        super().__init__(layout, depth, buffered=True)
+
+        self.psn   = Signal(24, reset_less=True, reset=STARTING_PSN)
+        if with_rdma_state:
+            # mem_key is r_key on WRITE and l_key on SEND (which cannot be received simultaneously)
+            self.rdma_state = Record([
+                ("va",      64, DIR_M_TO_S),
+                ("mem_key", 32, DIR_M_TO_S)
+            ], reset_less=True)
+
+class _LiteEthIBGenericQP(LiteXModule):
+    def __init__(self, qp_id, conn_type):
+        # The two queues constituting the QP
+        self.send_queue    = _LiteEthIBSendQueue(
+            layout          = eth_rocev2_send_wr_description(),
+            depth           = 16,
+            with_rdma_state = (qp_id not in [0, 1])
+        )
+        self.receive_queue = _LiteEthIBReceiveQueue(
+            layout          = eth_rocev2_recv_wr_description(),
+            depth           = 16,
+            with_rdma_state = (qp_id not in [0, 1])
+        )
+
+        self.id = Constant(qp_id, 24)
+        # Id of the connected qp
+        self.other_id   = Signal(24, reset_less=True)
+        self.ip_address = Signal(32, reset_less=True)
+
+        # Signals tracking the state of the QP
+        self.conn_type = Signal(3)
+        self.msn       = Signal(24, reset_less=True)
+
+        self.p_key = Signal(16)
+
+        # # #
+
+        # We treat conn_type as a constant
+        self.comb += self.conn_type.eq(conn_type)
+        # Default partition
+        self.comb += self.p_key.eq(DEFAULT_P_KEY)
+
+@ResetInserter(clock_domains=["sys"])
+class LiteEthIBQP(_LiteEthIBGenericQP):
+    """Infiniband Queue Pair
+
+    A pair of queues (send and receive) used for establishing an RC (Reliable Connection)
+
+    Parameters
+    ----------
+    qp_id : int
+        Unique number associated with the QP.
+
+    Attributes
+    ----------
+    qp_state : in/out
+        Current state of the QP.
+    ip_address : in/out
+        Current IP address of the QP this QP is connected to.
+    nak_sent : in/out
+        Indicates if the qp has an outstanding NAK.
+    retry_cnt_rst: in/out
+        Value to which the retry counter has to be reset.
+    retry_cnt_rnr_rst: in/out
+        Value to which the rnr retry counter has to be reset.
+    """
+    (RESET, INIT, RTR, RTS, ERROR) = range(5)
+    def __init__(self, qp_id):
+        super().__init__(qp_id, QP_CONN_TYPE.RC)
+        assert qp_id not in [0, 1] # 0 and 1 are special QPs
+
+        self.crossbar = LiteEthIBQPCrossbar()
+        self.comb += [
+            self.crossbar.master.send_source.connect(self.send_queue.sink),
+            self.crossbar.master.receive_source.connect(self.receive_queue.sink)
+        ]
+
+        self.qp_state = qp_state = Signal(bits_for(4), reset=LiteEthIBQP.RESET)
+        self.nak_sent = nak_sent = Signal(reset_less=True)
+
+        self.local_error = local_error = Signal(reset_less=True)
+
+        self.retry_cnt_rst     = Signal(3, reset=7, reset_less=True)
+        self.retry_cnt_rnr_rst = Signal(3, reset=7, reset_less=True)
+
+        # TODO How many requests can be outstanding?
+        # Requests that are awaiting acknowledgement
+        self.outstanding_read_requests = SyncFIFO(
+            layout   = add_params(eth_rocev2_send_wr_description(), [("psn", 24)]),
+            depth    = INITIATOR_DEPTH,
+            buffered = False
+        )
+        self.outstanding_requests = SyncFIFO(
+            layout   = add_params(eth_rocev2_send_wr_description(), [("psn", 24)]),
+            depth    = MAX_OUTSTANDING - INITIATOR_DEPTH,
+            buffered = False
+        )
+        self.outstanding_requests_chooser = SyncFIFO(
+            layout   = [("choose", 1)],
+            depth    = MAX_OUTSTANDING,
+            buffered = False
+        )
+
+        # # #
+
+        # We reset the QP depending on state
+        local_reset = Signal()
+        self.comb += local_reset.eq(qp_state == LiteEthIBQP.RESET)
+
+        op_seq_check_req  = OpcodeSequenceCheckerRequester()
+        op_seq_check_resp = OpcodeSequenceCheckerResponder()
+        self.submodules.op_seq_check_req  = op_seq_check_req
+        self.submodules.op_seq_check_resp = op_seq_check_resp
+
+        # Reset logic
+        self.comb += op_seq_check_req.reset.eq(local_reset)
+        self.comb += op_seq_check_resp.reset.eq(local_reset)
+        self.sync += [
+            If(local_reset,
+                self.receive_queue.psn.eq(self.receive_queue.psn.reset),
+                self.msn.eq(self.msn.reset),
+                self.receive_queue.rdma_state.va.eq(self.receive_queue.rdma_state.va.reset),
+                self.receive_queue.rdma_state.mem_key.eq(self.receive_queue.rdma_state.mem_key.reset),
+                self.send_queue.rdma_state.va_r.eq(self.send_queue.rdma_state.va_r.reset),
+                self.send_queue.rdma_state.va_l.eq(self.send_queue.rdma_state.va_l.reset),
+                self.send_queue.rdma_state.l_key.eq(self.send_queue.rdma_state.l_key.reset),
+                self.ip_address.eq(self.ip_address.reset),
+                local_error.eq(0),
+                nak_sent.eq(0),
+                self.retry_cnt_rst.eq(self.retry_cnt_rst.reset),
+                self.retry_cnt_rnr_rst.eq(self.retry_cnt_rnr_rst.reset)
+            )
+        ]
+
+# 0 and 1 are reserved QP ids. 1 is the only special QP in RoCEv2
+class LiteEthIBSpecialQP(_LiteEthIBGenericQP):
+    def __init__(self):
+        super().__init__(1, QP_CONN_TYPE.UD)
+
+        self.other_id = Constant(1, 24)
+
+# Misc ---------------------------------------------------------------------------------------------
+@ResetInserter()
+class OpcodeSequenceCheckerResponder(LiteXModule):
+    """Opcode Sequence checker for the responder
+
+    Checks that the sequence of received opcodes is correct
+
+    Attributes
+    ----------
+    update : in
+        Consume new packet opcode.
+    opcode : in
+        Opcode of incoming packet.
+    invalid_sequence : out
+        Indicates that the current incoming packet
+        has an invalid opcode considering the previous
+        ones.
+    """
+    def __init__(self):
+        self.update = update = Signal()
+        self.opcode = opcode = Signal(5)
+
+        self.invalid_sequence = invalid_sequence = Signal()
+
+        # # #
+        self.fsm = fsm = FSM(reset_state="NONE")
+        fsm.act("NONE",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.SEND_First,
+                BTH_OPCODE_OP.SEND_Only,
+                BTH_OPCODE_OP.SEND_Only_with_Immediate,
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Only,
+                BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate,
+                BTH_OPCODE_OP.RDMA_READ_Request,
+                # BTH_OPCODE_OP.CmpSwap,
+                # BTH_OPCODE_OP.FetchAdd
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.SEND_First:       NextState("SEND"),
+                    BTH_OPCODE_OP.RDMA_WRITE_First: NextState("RDMA_WRITE"),
+                    "default":                      NextState("NONE")
+                })
+            )
+        )
+
+        fsm.act("SEND",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.SEND_Middle,
+                BTH_OPCODE_OP.SEND_Last,
+                BTH_OPCODE_OP.SEND_Last_with_Immediate
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.SEND_Middle: NextState("SEND"),
+                    "default":                 NextState("NONE")
+                })
+            )
+        )
+
+        fsm.act("RDMA_WRITE",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.RDMA_WRITE_Middle,
+                BTH_OPCODE_OP.RDMA_WRITE_Last,
+                BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.RDMA_WRITE_Middle: NextState("RDMA_WRITE"),
+                    "default":                       NextState("NONE")
+                })
+            )
+        )
+
+@ResetInserter()
+class OpcodeSequenceCheckerRequester(LiteXModule):
+    """Opcode Sequence checker for the requester
+
+    Checks that the sequence of received opcodes is correct
+
+    Attributes
+    ----------
+    update : in
+        Consume new packet opcode.
+    opcode : in
+        Opcode of incoming packet.
+    invalid_sequence : out
+        Indicates that the current incoming packet
+        has an invalid opcode considering the previous
+        ones.
+    """
+    def __init__(self):
+        self.update = update = Signal()
+        self.opcode = opcode = Signal(5)
+
+        self.invalid_sequence = invalid_sequence = Signal()
+
+        # # #
+        self.fsm = fsm = FSM(reset_state="NONE")
+        fsm.act("NONE",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.RDMA_READ_response_First,
+                BTH_OPCODE_OP.RDMA_READ_response_Only,
+                BTH_OPCODE_OP.Acknowledge
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.RDMA_READ_response_First: NextState("RDMA_READ"),
+                    "default":                              NextState("NONE")
+                })
+            )
+        )
+
+        fsm.act("RDMA_READ",
+            # Invalid sequence
+            invalid_sequence.eq(~is_in(opcode, [
+                BTH_OPCODE_OP.RDMA_READ_response_Middle,
+                BTH_OPCODE_OP.RDMA_READ_response_Last
+            ])),
+            # State transitions
+            If(update,
+                Case(opcode, {
+                    BTH_OPCODE_OP.RDMA_READ_response_Middle: NextState("RDMA_READ"),
+                    "default":                               NextState("NONE")
+                })
+            )
+        )

--- a/liteeth/core/rocev2/rdma_key_exchanger.py
+++ b/liteeth/core/rocev2/rdma_key_exchanger.py
@@ -1,0 +1,115 @@
+from migen import *
+
+from litex.gen import *
+
+from litex.soc.interconnect.stream import Endpoint, EndpointDescription
+from liteeth.packet import Depacketizer, Header, HeaderField
+
+from liteeth.common import WC
+
+class KeyDecoder(LiteXModule):
+    def __init__(self, memr_num, dw):
+        self.sink   = sink   = Endpoint([("data", dw)])
+        self.source = source = Endpoint([("r_key", 32), ("va", 64), ("key_cnt", log2_int(memr_num))])
+
+        # # #
+
+        ratio = 96 // dw
+
+        memr_cnt = Signal(max=memr_num)
+        buff = Signal(96)
+        buff_prev = Signal(96)
+        cnt  = Signal(max=ratio)
+
+        self.comb += [
+            buff.eq(Cat(sink.data, buff_prev[:-dw])),
+            source.r_key.eq(buff[64:96]),
+            source.va.eq(buff[0:64]),
+            source.key_cnt.eq(memr_cnt),
+            source.valid.eq(cnt == ratio-1),
+            sink.ready.eq(~source.valid | source.ready),
+            source.last.eq(memr_cnt == memr_num - 1)
+        ]
+
+        self.sync += [
+            If(sink.valid & (~source.valid | source.ready),
+                buff_prev.eq(buff),
+                If(cnt == ratio - 1,
+                    cnt.eq(0)
+                ).Else(
+                    cnt.eq(cnt + 1)
+                )
+            ),
+            memr_cnt.eq(memr_cnt + (source.valid & source.ready))
+        ]
+
+
+class LiteEthRDMAKeyExchanger(LiteXModule):
+    def __init__(self, qp, cq, keymem, memr_num, dw):
+        self.source = Endpoint([("r_key", 32), ("va", 64), ("key_cnt", log2_int(memr_num))])
+        self.request = request = Signal()
+
+        # # #
+
+        key_dec = KeyDecoder(memr_num, dw)
+        self.submodules.key_dec = key_dec
+
+        port = keymem.get_port()
+        self.specials += port
+
+        self.fsm = fsm = FSM()
+        fsm.act("IDLE",
+            If(request,
+                NextState("EXPECT_SEND")
+            )
+        )
+
+        fsm.act("EXPECT_SEND",
+            qp.receive_queue.sink.valid.eq(1),
+            qp.receive_queue.sink.va.eq(0),
+            qp.receive_queue.sink.dma_len.eq(96),
+            qp.receive_queue.sink.l_key.eq(0xdeaded),
+            If(qp.receive_queue.sink.ready,
+                NextState("WAIT")
+            )
+        )
+
+        fsm.act("WAIT",
+            If(cq.source.valid &
+               (cq.source.status == WC.Status.SUCCESS) &
+               (cq.source.opcode == WC.Opcode.RECV),
+                cq.source.ready.eq(1),
+                NextState("DECODE")
+            )
+        )
+
+        r_size = 2**8
+        r_dw = len(port.dat_r)
+        ratio_r_port = r_dw//dw
+
+        r_addr = Signal(log2_int(r_size//(r_dw//8)))
+        r_addr_next = Signal().like(r_addr)
+        r_cnt = Signal(log2_int(ratio_r_port))
+        r_buff = Signal(r_dw)
+
+        fsm.act("DECODE",
+            key_dec.sink.valid.eq(1),
+            Case(r_cnt, {
+                i: key_dec.sink.data.eq(r_buff[i*dw:(i+1)*dw])
+                for i in range(ratio_r_port)
+            }),
+            port.adr[:log2_int(r_size//(r_dw//8))].eq(r_addr_next),
+            r_buff.eq(port.dat_r),
+            r_addr_next.eq(r_addr + (key_dec.sink.ready & (r_cnt == ratio_r_port - 1))),
+            If(key_dec.source.last & key_dec.source.valid & key_dec.source.ready,
+                NextValue(r_addr, 0),
+                NextValue(r_cnt, 0),
+                NextState("IDLE")
+            ).Elif(key_dec.sink.ready,
+                NextValue(r_addr, r_addr_next),
+                NextValue(r_cnt, r_cnt + 1)
+            ),
+            key_dec.source.connect(self.source)
+        )
+
+

--- a/liteeth/core/rocev2/rdma_key_exchanger.py
+++ b/liteeth/core/rocev2/rdma_key_exchanger.py
@@ -1,0 +1,115 @@
+from migen import *
+
+from litex.gen import *
+
+from litex.soc.interconnect.stream import Endpoint, EndpointDescription
+from liteeth.packet import Depacketizer, Header, HeaderField
+
+from liteeth.common import WC
+
+class KeyDecoder(LiteXModule):
+    def __init__(self, mem_num, dw):
+        self.sink   = sink   = Endpoint([("data", dw)])
+        self.source = source = Endpoint([("r_key", 32), ("va", 64), ("key_cnt", log2_int(mem_num))])
+
+        # # #
+
+        ratio = 96 // dw
+
+        memr_cnt = Signal(max=mem_num)
+        buff = Signal(96)
+        buff_prev = Signal(96)
+        cnt  = Signal(max=ratio)
+
+        self.comb += [
+            buff.eq(Cat(sink.data, buff_prev[:-dw])),
+            source.r_key.eq(buff[64:96]),
+            source.va.eq(buff[0:64]),
+            source.key_cnt.eq(memr_cnt),
+            source.valid.eq(cnt == ratio-1),
+            sink.ready.eq(~source.valid | source.ready),
+            source.last.eq(memr_cnt == mem_num - 1)
+        ]
+
+        self.sync += [
+            If(sink.valid & (~source.valid | source.ready),
+                buff_prev.eq(buff),
+                If(cnt == ratio - 1,
+                    cnt.eq(0)
+                ).Else(
+                    cnt.eq(cnt + 1)
+                )
+            ),
+            memr_cnt.eq(memr_cnt + (source.valid & source.ready))
+        ]
+
+@ResetInserter()
+class LiteEthRDMAKeyExchanger(LiteXModule):
+    def __init__(self, qp, cq, keymem, mem_num, dw):
+        self.source = Endpoint([("r_key", 32), ("va", 64), ("key_cnt", log2_int(mem_num))])
+        self.request = request = Signal()
+
+        # # #
+
+        key_dec = KeyDecoder(mem_num, dw)
+        self.submodules.key_dec = key_dec
+
+        port = keymem.get_port()
+        self.specials += port
+
+        self.fsm = fsm = FSM()
+        fsm.act("IDLE",
+            If(request,
+                NextState("EXPECT_SEND")
+            )
+        )
+
+        fsm.act("EXPECT_SEND",
+            qp.receive_sink.valid.eq(1),
+            qp.receive_sink.va.eq(0),
+            qp.receive_sink.dma_len.eq(96),
+            qp.receive_sink.l_key.eq(0xdeaded),
+            If(qp.receive_sink.ready,
+                NextState("WAIT")
+            )
+        )
+
+        fsm.act("WAIT",
+            If(cq.source.valid &
+               (cq.source.status == WC.Status.SUCCESS) &
+               (cq.source.opcode == WC.Opcode.RECV),
+                cq.source.ready.eq(1),
+                NextState("DECODE")
+            )
+        )
+
+        r_size = 2**bits_for(mem_num * 12)
+        r_dw = len(port.dat_r)
+        ratio_r_port = r_dw//dw
+
+        r_addr = Signal(log2_int(r_size//(r_dw//8)))
+        r_addr_next = Signal().like(r_addr)
+        r_cnt = Signal(log2_int(ratio_r_port))
+        r_buff = Signal(r_dw)
+
+        fsm.act("DECODE",
+            key_dec.sink.valid.eq(1),
+            Case(r_cnt, {
+                i: key_dec.sink.data.eq(r_buff[i*dw:(i+1)*dw])
+                for i in range(ratio_r_port)
+            }),
+            port.adr[:log2_int(r_size//(r_dw//8))].eq(r_addr_next),
+            r_buff.eq(port.dat_r),
+            r_addr_next.eq(r_addr + (key_dec.sink.ready & (r_cnt == ratio_r_port - 1))),
+            If(key_dec.source.last & key_dec.source.valid & key_dec.source.ready,
+                NextValue(r_addr, 0),
+                NextValue(r_cnt, 0),
+                NextState("IDLE")
+            ).Elif(key_dec.sink.ready,
+                NextValue(r_addr, r_addr_next),
+                NextValue(r_cnt, r_cnt + 1)
+            ),
+            key_dec.source.connect(self.source)
+        )
+
+

--- a/liteeth/core/rocev2/rdma_streamer.py
+++ b/liteeth/core/rocev2/rdma_streamer.py
@@ -1,0 +1,222 @@
+from migen import *
+
+from litex.gen import *
+
+from litex.soc.interconnect.stream import Endpoint
+
+from liteeth.common import WR_OPCODE, WC
+
+class LiteEthRDMAStreamer(LiteXModule):
+    def __init__(self, qp, cq, wmems, rmems, dw):
+        self.sink   = sink   = Endpoint([("data", dw)])
+        self.source = source = Endpoint([("data", dw)])
+
+        self.r_keys = r_keys = Array([Signal(32, reset_less=True) for _ in range(len(wmems) + len(rmems))])
+        self.vas    = vas    = Array([Signal(64, reset_less=True) for _ in range(len(wmems) + len(rmems))])
+
+        self.enable = enable = Signal()
+
+        # # #
+
+        # Parameters
+        read_l_keys = []
+        read_r_ports = []
+        r_dw = 0
+        r_size = 0
+
+        for i, mr in enumerate(rmems):
+            read_r_port = mr.memory.get_port()
+            self.specials += read_r_port
+
+            if i == 0:
+                r_dw = len(read_r_port.dat_r)
+                r_size = mr.region_size
+            else:
+                assert len(read_r_port.dat_r) == r_dw
+                assert mr.region_size == r_size
+
+            read_l_keys.append(mr.l_key)
+            read_r_ports.append(read_r_port)
+
+        assert r_dw % dw == 0
+        ratio_r_port = r_dw // dw
+
+        write_l_keys = []
+        write_w_ports = []
+        w_dw = 0
+        w_size = 0
+
+        for i, mr in enumerate(wmems):
+            write_w_port = mr.memory.get_port(write_capable=True)
+            self.specials += write_w_port
+
+            if i == 0:
+                w_dw = len(write_w_port.dat_w)
+                w_size = mr.region_size
+            else:
+                assert len(write_w_port.dat_w) == w_dw
+                assert mr.region_size == w_size
+
+            write_l_keys.append(mr.l_key)
+            write_w_ports.append(write_w_port)
+
+        assert w_dw % dw == 0
+        ratio_w_port = w_dw // dw
+
+        # Streamer logic
+
+        # Write buffs (data sent)
+        available_w_buffs = Signal(max=len(wmems) + 1, reset=len(wmems))
+        available_w_buffs_inc = Signal()
+        available_w_buffs_dec = Signal()
+        choose_w_port = Signal(max=len(wmems))
+        choose_w_port_next = Signal().like(choose_w_port)
+        w_addr = Signal(log2_int(w_size//(w_dw//8)))
+        w_addr_next = Signal().like(w_addr)
+        w_cnt = Signal(log2_int(ratio_w_port))
+        w_buff = Signal(w_dw)
+        w_buff_next = Signal().like(w_buff)
+
+        self.comb += [
+            sink.ready.eq(available_w_buffs != 0),
+            Case(choose_w_port, {
+                i: [
+                    write_w_ports[i].adr[:log2_int(w_size//(w_dw//8))].eq(w_addr),
+                    write_w_ports[i].we.eq(sink.valid & (w_cnt == ratio_w_port - 1)),
+                    write_w_ports[i].dat_w.eq(w_buff_next),
+                ]
+                for i in range(len(wmems))
+            }),
+            w_buff_next.eq(Cat(w_buff[dw:], sink.data)),
+            w_addr_next.eq(w_addr),
+            choose_w_port_next.eq(choose_w_port),
+            If(w_cnt == ratio_w_port - 1,
+                w_addr_next.eq(w_addr + 1),
+                If(w_addr == w_size//(w_dw//8) - 1,
+                    If(choose_w_port == len(wmems) - 1,
+                        choose_w_port_next.eq(0)
+                    ).Else(
+                        choose_w_port_next.eq(choose_w_port + 1)
+                    )
+                )
+            )
+        ]
+
+        self.sync += [
+            If(sink.valid & (available_w_buffs != 0),
+                w_addr.eq(w_addr_next),
+                w_buff.eq(w_buff_next),
+                w_cnt.eq(w_cnt + 1),
+            ),
+            available_w_buffs.eq(available_w_buffs + available_w_buffs_inc - available_w_buffs_dec),
+            choose_w_port.eq(choose_w_port_next)
+        ]
+
+        self.comb += [
+            If(sink.valid & (w_addr_next != w_addr) & (choose_w_port_next != choose_w_port),
+                available_w_buffs_dec.eq(1),
+                qp.send_queue.sink.valid.eq(1),
+                qp.send_queue.sink.wr_opcode.eq(WR_OPCODE.RDMA_WRITE),
+                qp.send_queue.sink.ack_req.eq(1),
+                qp.send_queue.sink.w_immdt.eq(0),
+                qp.send_queue.sink.va.eq(vas[choose_w_port]),
+                qp.send_queue.sink.dma_len.eq(w_size),
+                Case(choose_w_port, {
+                    i: [
+                        qp.send_queue.sink.l_key.eq(write_l_keys[i]),
+                    ] for i in range(len(wmems))
+                }),
+                qp.send_queue.sink.r_key.eq(r_keys[choose_w_port])
+            ),
+            If(cq.source.valid &
+               (cq.source.status == WC.Status.SUCCESS) &
+               (cq.source.opcode == WC.Opcode.RDMA_WRITE),
+                cq.source.ready.eq(1),
+                available_w_buffs_inc.eq(1)
+            )
+        ]
+
+        # Read buffs (data received)
+
+        readable_r_buffs = Signal(max=len(rmems) + 1)
+        readable_r_buffs_inc = Signal()
+        readable_r_buffs_dec = Signal()
+        available_r_buffs = Signal(max=len(rmems) + 1, reset=len(rmems))
+        available_r_buffs_inc = Signal()
+        available_r_buffs_dec = Signal()
+        choose_req_port = Signal(max=len(rmems))
+        choose_req_port_next = Signal().like(choose_req_port)
+        choose_r_port = Signal(max=len(rmems))
+        choose_r_port_next = Signal().like(choose_r_port)
+        r_addr = Signal(log2_int(r_size//(r_dw//8)))
+        r_addr_next = Signal().like(r_addr)
+        r_cnt = Signal(log2_int(ratio_r_port))
+        r_buff = Signal(r_dw)
+
+        self.comb += [
+            source.valid.eq(readable_r_buffs != 0),
+            Case(r_cnt, {
+                i: source.data.eq(r_buff[i*dw:(i+1)*dw])
+                for i in range(ratio_r_port)
+            }),
+            Case(choose_r_port, {
+                i: [
+                    read_r_ports[i].adr[:log2_int(r_size//(r_dw//8))].eq(r_addr),
+                    r_buff.eq(read_r_ports[i].dat_r),
+                ]
+                for i in range(len(rmems))
+            }),
+            r_addr_next.eq(r_addr),
+            If(r_cnt == ratio_r_port - 1,
+                r_addr_next.eq(r_addr + 1),
+                If(r_addr == r_size//(r_dw//8) - 1,
+                    readable_r_buffs_dec.eq(1),
+                    If(choose_r_port == len(rmems) - 1,
+                        choose_r_port_next.eq(0)
+                    ).Else(
+                        choose_r_port_next.eq(choose_r_port + 1)
+                    )
+                )
+            )
+        ]
+
+        self.sync += [
+            If(source.ready & (readable_r_buffs != 0),
+                r_addr.eq(r_addr_next),
+                r_cnt.eq(r_cnt + 1),
+            ),
+            available_r_buffs.eq(available_r_buffs + available_r_buffs_inc - available_r_buffs_dec),
+            readable_r_buffs.eq(readable_r_buffs + readable_r_buffs_inc - readable_r_buffs_dec),
+            choose_req_port.eq(choose_req_port_next)
+        ]
+
+        self.comb += [
+            choose_req_port_next.eq(choose_req_port),
+            If((r_addr_next != r_addr) & (choose_r_port_next != choose_r_port),
+                readable_r_buffs_dec.eq(1),
+                available_r_buffs_inc.eq(1)
+            ),
+            If(enable & sink.valid & (available_r_buffs != 0) & ~available_w_buffs_dec, # Wait when Write is committing request to send_queue
+                available_r_buffs_dec.eq(1),
+                qp.send_queue.sink.valid.eq(1),
+                qp.send_queue.sink.wr_opcode.eq(WR_OPCODE.RDMA_READ),
+                qp.send_queue.sink.ack_req.eq(1),
+                qp.send_queue.sink.w_immdt.eq(0),
+                qp.send_queue.sink.va.eq(vas[choose_req_port + len(wmems)]),
+                qp.send_queue.sink.dma_len.eq(r_size),
+                Case(choose_req_port, {
+                    Constant(i): [
+                        qp.send_queue.sink.l_key.eq(read_l_keys[i]),
+                    ] for i in range(len(rmems))
+                }),
+                qp.send_queue.sink.r_key.eq(r_keys[choose_req_port + len(wmems)]),
+                choose_req_port_next.eq(choose_req_port + 1)
+            ),
+            If(cq.source.valid &
+               (cq.source.status == WC.Status.SUCCESS) &
+               (cq.source.opcode == WC.Opcode.RDMA_READ),
+                cq.source.ready.eq(1),
+                readable_r_buffs_inc.eq(1)
+            )
+        ]
+

--- a/liteeth/core/rocev2/rdma_streamer.py
+++ b/liteeth/core/rocev2/rdma_streamer.py
@@ -1,0 +1,325 @@
+from migen import *
+
+from litex.gen import *
+
+from litex.soc.interconnect.stream import Endpoint, SyncFIFO
+
+from liteeth.common import WR_OPCODE, WC, eth_rocev2_send_wr_description, INITIATOR_DEPTH, MAX_OUTSTANDING
+from litex.soc.interconnect.stream import StrideConverter
+
+class LiteEthRDMAStreamerWriter(LiteXModule):
+    def __init__(self, port, l_key, mem_num, size, dw):
+        self.sink  = sink  = Endpoint([("data", dw)])
+        self.acked = acked = Signal()
+        self.qp_sink = qp_sink = Endpoint(eth_rocev2_send_wr_description())
+
+        self.key_sink = key_sink = Endpoint([("r_key", 32), ("va", 64)])
+
+        self.loss_cnt = Signal(24)
+
+        # # #
+
+        word_size = size//(dw//8)
+
+        self.key_fifo = key_fifo = SyncFIFO([("r_key", 32), ("va", 64)], mem_num + 1)
+        self.comb += [
+            If(key_sink.valid,
+                key_sink.connect(key_fifo.sink)
+            )
+        ]
+
+        # Write buffs (data sent)
+        # Buffers on host that do not have an associated pending write
+        available_buffs = Signal(max=mem_num + 1, reset=mem_num)
+        available_buffs_inc = Signal()
+        available_buffs_dec = Signal()
+
+        addr = Signal(log2_int(word_size))
+        addr_next = Signal().like(addr)
+        last_word = Signal()
+
+        self.comb += sink.connect(port.sink)
+
+        # Helper signals
+        self.comb += [
+            addr_next.eq(addr + 1),
+            last_word.eq(addr_next == 0)
+        ]
+
+        self.sync += [
+            If(port.sink.valid & port.sink.ready,
+                addr.eq(addr_next),
+            ).Elif(sink.valid,
+                self.loss_cnt.eq(self.loss_cnt + 1)
+            )
+        ]
+
+        # Buffer availability logic
+        self.comb += [
+            If(last_word & port.sink.valid & port.sink.ready,
+                key_fifo.source.connect(key_fifo.sink),
+                available_buffs_dec.eq(1)
+            ),
+            If(acked,
+                available_buffs_inc.eq(1)
+            )
+        ]
+        self.sync += available_buffs.eq(available_buffs + available_buffs_inc - available_buffs_dec),
+
+        self.load_fsm = load_fsm = FSM()
+        load_fsm.act("SEND",
+            If((available_buffs != 0) & (sink.valid | ~port.sink.ready),
+                qp_sink.valid.eq(1),
+                If(qp_sink.ready,
+                    NextState("WAIT")
+                )
+            )
+        )
+
+        load_fsm.act("WAIT",
+            If(port.sink.valid & port.sink.ready,
+                If(last_word,
+                    NextState("SEND")
+                )
+            )
+        )
+
+        # QP signals (other than valid)
+        self.comb += [
+            qp_sink.wr_opcode.eq(WR_OPCODE.RDMA_WRITE),
+            qp_sink.ack_req.eq(1),
+            qp_sink.w_immdt.eq(0),
+            qp_sink.va.eq(key_fifo.source.va),
+            qp_sink.dma_len.eq(0),
+            qp_sink.l_key.eq(l_key),
+            qp_sink.r_key.eq(key_fifo.source.r_key),
+        ]
+
+@ResetInserter()
+class LiteEthRDMAStreamerReader(LiteXModule):
+    def __init__(self, port, l_key, mem_num, size, i_dw, o_dw):
+        self.acked = acked = Signal()
+        self.source  = source  = Endpoint([("data", o_dw)])
+        self.qp_sink = qp_sink = Endpoint(eth_rocev2_send_wr_description())
+
+        self.key_sink = key_sink = Endpoint([("r_key", 32), ("va", 64)])
+
+        self.enable = enable = Signal()
+
+        # # #
+
+        self.conv      = conv      = StrideConverter([("data", i_dw)], [("data", o_dw)], reverse=True)
+        self.conv_fifo = conv_fifo = SyncFIFO([("data", o_dw)], 64)
+
+        word_size = size//(i_dw//8)
+
+        self.key_fifo = key_fifo = SyncFIFO([("r_key", 32), ("va", 64)], mem_num + 1)
+        self.comb += [
+            If(key_sink.valid,
+                key_sink.connect(key_fifo.sink)
+            )
+        ]
+
+        # Read buffs (data received)
+        # Buffers on host that do not have an associated pending read
+        available_buffs = Signal(max=mem_num + 1, reset=mem_num)
+        available_buffs_inc = Signal()
+        available_buffs_dec = Signal()
+
+        readable_buffs = Signal(max=mem_num + 1)
+        readable_buffs_inc = Signal()
+        readable_buffs_dec = Signal()
+
+        addr = Signal(log2_int(word_size))
+        addr_next = Signal().like(addr)
+        last_word = Signal()
+
+        self.comb += [
+            port.source.connect(conv.sink, omit={"valid", "ready"}),
+            conv.sink.valid.eq(enable & port.source.valid),
+            port.source.ready.eq(enable & conv.sink.ready),
+
+            conv.source.connect(conv_fifo.sink),
+            conv_fifo.source.connect(source)
+        ]
+
+        # Helper signals
+        self.comb += [
+            addr_next.eq(addr + 1),
+            last_word.eq(addr_next == 0)
+        ]
+
+        # Transition logic
+        self.sync += [
+            If(port.source.valid & port.source.ready,
+                addr.eq(addr_next)
+            )
+        ]
+
+        from litex.gen.genlib.misc import WaitTimer
+        self.timer = timer = WaitTimer(size)
+
+        notify = Signal()
+        self.fsm = fsm = FSM()
+        fsm.act("SEND_READ",
+            If(enable,
+                qp_sink.valid.eq(1),
+                If(qp_sink.ready,
+                    key_fifo.source.connect(key_fifo.sink),
+                    NextState("SEND_WRITE")
+                )
+            ),
+        )
+
+        fsm.act("SEND_WRITE",
+            notify.eq(1),
+            qp_sink.valid.eq(1),
+            If(qp_sink.ready,
+                available_buffs_dec.eq(1),
+                NextState("WAIT")
+            )
+        )
+
+        fsm.act("WAIT",
+            timer.wait.eq(1),
+            If(timer.done & (available_buffs != 0),
+                NextState("SEND_READ")
+            )
+        )
+
+        # Buffer availability logic
+        self.comb += [
+            readable_buffs_inc.eq(acked),
+            If(last_word & port.source.valid & port.source.ready,
+                readable_buffs_dec.eq(1),
+                available_buffs_inc.eq(1)
+            )
+        ]
+        self.sync += [
+            readable_buffs.eq(readable_buffs + readable_buffs_inc - readable_buffs_dec),
+            available_buffs.eq(available_buffs + available_buffs_inc - available_buffs_dec)
+        ]
+
+        # Send queue signals (except valid)
+        self.comb += [
+            If(notify,
+                qp_sink.wr_opcode.eq(WR_OPCODE.RDMA_WRITE),
+                qp_sink.dma_len.eq(0),
+                qp_sink.w_immdt.eq(1),
+                qp_sink.immdt.eq(0),
+            ).Else(
+                qp_sink.wr_opcode.eq(WR_OPCODE.RDMA_READ),
+                qp_sink.dma_len.eq(size),
+                qp_sink.w_immdt.eq(0)
+            ),
+            qp_sink.ack_req.eq(1),
+            qp_sink.va.eq(key_fifo.source.va),
+            qp_sink.l_key.eq(l_key),
+            qp_sink.r_key.eq(key_fifo.source.r_key)
+        ]
+
+@ResetInserter()
+class LiteEthRDMAStreamer(LiteXModule):
+    def __init__(self, qp, cq, wmem, rmem, wmem_l_key, rmem_l_key, mem_num, dw):
+        self.sink   = sink   = Endpoint([("data", dw)])
+        self.source = source = Endpoint([("data", dw)])
+
+        self.key_sink = key_sink = Endpoint([("r_key", 32), ("va", 64)])
+
+        self.enable = enable = Signal()
+
+        # # #
+
+        # Check if we can send enough reads and writes
+        assert mem_num // 2 <= INITIATOR_DEPTH
+        assert mem_num // 2 <= MAX_OUTSTANDING - INITIATOR_DEPTH
+
+        size = 2048
+
+        # Parameters (extraction and validation)
+        read_r_port = rmem.read_port
+        r_dw = read_r_port.data_width
+
+        # assert r_dw == o_dw
+
+        write_w_port = wmem.write_port
+        w_dw = write_w_port.data_width
+
+        # assert w_dw == o_dw
+
+        # Streamer logic
+
+        # Warning : I have not changed writer width to be correct
+        self.writer = writer = LiteEthRDMAStreamerWriter(
+            port     = write_w_port,
+            l_key    = wmem_l_key,
+            mem_num = mem_num // 2,
+            size     = size,
+            dw       = w_dw
+        )
+        self.reader = reader = LiteEthRDMAStreamerReader(
+            port     = read_r_port,
+            l_key    = rmem_l_key,
+            mem_num = mem_num // 2,
+            size     = size,
+            i_dw     = r_dw,
+            o_dw     = dw
+        )
+
+        self.comb += [
+            sink.connect(writer.sink),
+            reader.source.connect(source)
+        ]
+
+        # CQ logic
+        self.comb += [
+            If(cq.source.valid & (cq.source.status == WC.Status.SUCCESS),
+                writer.acked.eq(cq.source.opcode == WC.Opcode.RDMA_WRITE),
+                reader.acked.eq(cq.source.opcode == WC.Opcode.RDMA_READ),
+                cq.source.ready.eq(writer.acked | reader.acked)
+            ).Else(
+                cq.source.ready.eq(1)
+            )
+        ]
+
+        # Send queue arbitration
+        self.comb += [
+            If(enable,
+                If(reader.qp_sink.valid,
+                    reader.qp_sink.connect(qp.send_sink)
+                ).Elif(writer.qp_sink.valid,
+                    writer.qp_sink.connect(qp.send_sink)
+                )
+            )
+        ]
+
+
+        self.comb += [
+            # writer.enable.eq(enable),
+            reader.enable.eq(enable)
+        ]
+
+        # Pass r_keys and vas
+        cnt = Signal(max=mem_num)
+        self.fsm = fsm = FSM()
+        fsm.act("RECEIVE_WRITE_KEYS",
+            key_sink.connect(writer.key_sink),
+            If(key_sink.valid & key_sink.ready,
+                NextValue(cnt, cnt + 1),
+                If(cnt == mem_num // 2 - 1,
+                    NextState("RECEIVE_READ_KEYS")
+                )
+            )
+        )
+
+        fsm.act("RECEIVE_READ_KEYS",
+            key_sink.connect(reader.key_sink),
+            If(key_sink.valid & key_sink.ready,
+                NextValue(cnt, cnt + 1),
+                If(cnt == mem_num - 1,
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        fsm.act("IDLE") # Do nothing

--- a/liteeth/core/rocev2/requester.py
+++ b/liteeth/core/rocev2/requester.py
@@ -1,0 +1,1034 @@
+from liteeth.common import *
+
+from liteeth.core.rocev2.mr import PERM as MR_PERM
+from liteeth.core.rocev2.common import WaitPipe, VarWaitTimer
+from liteeth.core.rocev2.ack import NAK
+from liteeth.core.rocev2.qp import LiteEthIBQP
+
+from litex.soc.interconnect.stream import Endpoint, Buffer, SyncFIFO
+
+
+class LiteEthRDMARequesterTX(LiteXModule):
+    def __init__(self, qp, mrs, dw=8):
+        self.sink  = sink  = Endpoint(add_params(eth_rocev2_send_wr_description(), [("psn", 24)]))
+        self.source = source = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1)]))
+
+        self.timer_start = timer_start = Signal()
+
+        # # #
+
+        # Indicates if we are resending an old unacknowledged packet
+        resending       = Signal()
+        resending_set   = Signal()
+        resending_unset = Signal()
+        resending_mem   = Signal()
+
+        self.comb += [
+            If(resending_set,
+                resending.eq(1)
+            ).Elif(resending_unset,
+                resending.eq(0)
+            ).Else(
+                resending.eq(resending_mem)
+            )
+        ]
+        self.sync += [
+            If(resending_set,
+                resending_mem.eq(1)
+            ).Elif(resending_unset,
+                resending_mem.eq(0)
+            )
+        ]
+
+        # Picks requests from send_queue or resend_handler
+        request_source = Endpoint(eth_rocev2_send_wr_description())
+
+        self.comb += [
+            If(resending,
+                sink.connect(request_source, omit={"psn"})
+            ).Else(
+                qp.send_queue.source.connect(request_source)
+            )
+        ]
+
+        mem_reader_sink   = Endpoint([("va", 64), ("len", bits_for(PMTU))])
+        mem_reader_source = Endpoint([("data", dw)])
+
+        self.comb += [
+            If(mem_reader_sink.valid | mem_reader_source.ready,
+                Case(request_source.l_key, {
+                    Constant(mr.l_key, 32): [
+                        mem_reader_sink.connect(mr.reader.sink),
+                        mr.reader.source.connect(mem_reader_source)]
+                    for mr in mrs if not MR_PERM.NO_LOCAL_READ in mr.permissions
+                })
+            )
+        ]
+
+        # WaitPipe to fetch entire packet from RAM before send
+        # (MAC cannot be stopped after packet start and RAM reads in bursts)
+        send_wait_pipe = WaitPipe(eth_rocev2_description(dw), 8, PMTU, discarding=False, dw=dw)
+        self.submodules.send_wait_pipe = send_wait_pipe
+
+        p_key    = Signal(16, reset_less=True)
+        other_id = Signal(24, reset_less=True)
+
+        psn     = Signal(24, reset_less=True)
+        va_src  = Signal(64, reset_less=True)
+
+        # For First/Middle/Last/Only packet variations
+        first_packet = Signal()
+        # If there are more packets left to send after the current one
+        more_left = Signal()
+
+        # Number of PMTU-sized blocks that need to be sent
+        whole_blocks      = Signal(24)
+        whole_blocks_left = Signal(24)
+        remainder_bytes   = Signal(PMTU_BITS)
+        payload_length    = Signal(PMTU_BITS + 1)
+        header_length     = Signal(32)
+
+
+        self.comb += [
+            If(request_source.wr_opcode != WR_OPCODE.RDMA_READ,
+                remainder_bytes.eq(request_source.dma_len[:PMTU_BITS]),
+                whole_blocks.eq(request_source.dma_len[PMTU_BITS:])
+            )
+        ]
+        self.comb += more_left.eq(
+            ~((whole_blocks_left == 0) |
+              ((whole_blocks_left == 1) & (remainder_bytes == 0)))
+        )
+
+        invalid_request = Signal()
+        # Requests in error state are invalid
+        # Ignore a read request for which the local write location does not allow writing
+        invalid_request.eq(
+            (qp.qp_state == LiteEthIBQP.ERROR) |
+            (qp.send_queue.source.dma_len != 0) &
+            (qp.send_queue.source.wr_opcode == WR_OPCODE.RDMA_READ) &
+            ~is_in(qp.send_queue.source.l_key, [
+                Constant(mr.l_key, 32) for mr in mrs
+                if MR_PERM.LOCAL_WRITE in mr.permissions
+            ]))
+
+        # Main transmission combinatory logic
+        self.comb += [
+            send_wait_pipe.sink.tver.eq(0),
+            send_wait_pipe.sink.m.eq(0),
+            send_wait_pipe.sink.se.eq(0),
+            send_wait_pipe.sink.a.eq(request_source.ack_req),
+
+            If(request_source.wr_opcode == WR_OPCODE.RDMA_READ,
+                send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_Request)
+            ).Else(
+                If(more_left,
+                    If(first_packet,
+                        Case(request_source.wr_opcode, {
+                            WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_First),
+                            WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_First),
+                        })
+                    ).Else(
+                        Case(request_source.wr_opcode, {
+                            WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Middle),
+                            WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Middle),
+                        })
+                    )
+                ).Else(
+                    If(~request_source.w_immdt,
+                        If(first_packet,
+                            Case(request_source.wr_opcode, {
+                                WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Only),
+                                WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Only),
+                            })
+                        ).Else(
+                            Case(request_source.wr_opcode, {
+                                WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Last),
+                                WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Last),
+                            })
+                        )
+                    ).Else(
+                        If(first_packet,
+                            Case(request_source.wr_opcode, {
+                                WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Only_with_Immediate),
+                                WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Only_with_Immediate),
+                            })
+                        ).Else(
+                            Case(request_source.wr_opcode, {
+                                WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Last_with_Immediate),
+                                WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Last_with_Immediate),
+                            })
+                        )
+                    )
+                )
+            ),
+            If(whole_blocks_left != 0,
+                send_wait_pipe.sink.pad.eq(0),
+                payload_length.eq(PMTU)
+            ).Else(
+                send_wait_pipe.sink.pad.eq((0b100 - (remainder_bytes & 0b11))[:2]),
+                payload_length.eq(remainder_bytes)
+            ),
+            mem_reader_sink.len.eq(payload_length),
+
+            IBT_header_length(send_wait_pipe.sink.opcode, header_length),
+            send_wait_pipe.sink.length.eq(header_length + payload_length),
+
+            send_wait_pipe.sink.psn.eq(psn),
+
+            send_wait_pipe.sink.dma_len.eq(request_source.dma_len),
+
+            send_wait_pipe.sink.p_key.eq(p_key),
+            send_wait_pipe.sink.dest_qp.eq(other_id),
+
+            send_wait_pipe.sink.r_key.eq(request_source.r_key),
+            send_wait_pipe.sink.va.eq(request_source.va),
+
+            send_wait_pipe.sink.immdt.eq(request_source.immdt),
+
+            send_wait_pipe.source.connect(source),
+
+            mem_reader_sink.va.eq(va_src),
+        ]
+
+        send_resend = Signal()
+        send_new_req = Signal()
+
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            NextValue(p_key, qp.p_key),
+            NextValue(other_id, qp.other_id),
+
+            NextValue(va_src, 0),
+            NextValue(whole_blocks_left, whole_blocks),
+            NextValue(first_packet, 1),
+
+            If(qp.qp_state == LiteEthIBQP.ERROR,
+                qp.send_queue.source.ready.eq(1),
+                sink.ready.eq(1)
+            ).Else(
+                # Ignore invalid requests from our send queue
+                qp.send_queue.source.ready.eq(invalid_request),
+                If(~send_wait_pipe.full,
+                    If(sink.valid,
+                        send_resend.eq(1)
+                    ).Elif(qp.send_queue.source.valid & ~invalid_request &
+                        qp.outstanding_requests_chooser.sink.ready,
+                        send_new_req.eq(1)
+                    )
+                ),
+                If(send_resend,
+                    If((sink.dma_len != 0) & (sink.wr_opcode != WR_OPCODE.RDMA_READ),
+                        NextValue(mem_reader_sink.valid, 1),
+                        NextState("READ_RAM")
+                    ).Else(
+                        NextState("EMPTY")
+                    ),
+                    resending_set.eq(1),
+
+                    NextValue(psn, sink.psn)
+                ),
+                If(send_new_req,
+                    If((qp.send_queue.source.dma_len != 0) & (qp.send_queue.source.wr_opcode != WR_OPCODE.RDMA_READ),
+                        NextValue(mem_reader_sink.valid, 1),
+                        NextState("READ_RAM")
+                    ).Else(
+                        NextState("EMPTY")
+                    ),
+                    resending_unset.eq(1),
+
+                    NextValue(psn, qp.send_queue.psn),
+
+                    # Transfer wr from send_queue to outstanding
+                    qp.outstanding_requests_chooser.sink.valid.eq(1),
+                    If(qp.send_queue.source.wr_opcode != WR_OPCODE.RDMA_READ,
+                        qp.outstanding_requests_chooser.sink.choose.eq(1),
+                        qp.send_queue.source.connect(qp.outstanding_requests.sink, omit={"ready", "psn"}),
+                        qp.outstanding_requests.sink.psn.eq(qp.send_queue.psn)
+                    ).Else(
+                        qp.outstanding_requests_chooser.sink.choose.eq(0),
+                        qp.send_queue.source.connect(qp.outstanding_read_requests.sink, omit={"ready", "psn"}),
+                        qp.outstanding_read_requests.sink.psn.eq(qp.send_queue.psn)
+                    ),
+
+                    If(qp.send_queue.source.ack_req | (qp.send_queue.source.wr_opcode == WR_OPCODE.RDMA_READ),
+                        timer_start.eq(1)
+                    )
+                )
+            )
+        )
+
+        fsm.act("READ_RAM",
+            If(qp.qp_state == LiteEthIBQP.ERROR,
+                send_wait_pipe.validate_sink.invalidate.eq(1),
+                NextValue(mem_reader_sink.valid, 0),
+                NextState("ERROR_DUMP")
+            ).Else(
+                If(mem_reader_sink.ready == 1, # Once the reader has consumed the request, we end it
+                    NextValue(mem_reader_sink.valid, 0)
+                ),
+                mem_reader_source.connect(send_wait_pipe.sink, keep={"valid", "ready", "data", "last"}),
+
+                If(mem_reader_source.valid & mem_reader_source.last & send_wait_pipe.sink.ready,
+                    send_wait_pipe.validate_sink.validate.eq(1),
+                    NextValue(first_packet, 0),
+                    If(~resending,
+                        NextValue(qp.send_queue.psn, psn + 1)
+                    ),
+                    If(more_left,
+                        NextValue(mem_reader_sink.valid, 1),
+                        NextValue(whole_blocks_left, whole_blocks_left - 1),
+                        NextValue(va_src, va_src + PMTU),
+                        NextValue(psn, psn + 1),
+                    ).Else(
+                        NextValue(mem_reader_sink.valid, 0),
+                        # Consume request
+                        If(~resending,
+                            qp.send_queue.source.ready.eq(1)
+                        ).Else(
+                            sink.ready.eq(1)
+                        ),
+                        NextState("IDLE")
+                    )
+                )
+            )
+        )
+
+        fsm.act("EMPTY",
+            If(qp.qp_state == LiteEthIBQP.ERROR,
+                NextState("IDLE")
+            ).Else(
+                send_wait_pipe.sink.valid.eq(1),
+                send_wait_pipe.sink.last.eq(1),
+                send_wait_pipe.sink.header_only.eq(1),
+                If(send_wait_pipe.sink.ready,
+                    send_wait_pipe.validate_sink.validate.eq(1),
+                    If(~resending,
+                        If(request_source.wr_opcode == WR_OPCODE.RDMA_READ,
+                            NextValue(qp.send_queue.psn, psn + request_source.dma_len[PMTU_BITS:] + (request_source.dma_len[:PMTU_BITS] != 0))
+                        ).Else(
+                            NextValue(qp.send_queue.psn, psn + 1)
+                        ),
+                        qp.send_queue.source.ready.eq(1)
+                    ).Else(
+                        sink.ready.eq(1)
+                    ),
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        fsm.act("ERROR_DUMP",
+            mem_reader_source.ready.eq(1),
+            If(~mem_reader_source.valid | mem_reader_source.last,
+                NextState("IDLE")
+            )
+        )
+
+# PSN helper functions
+def psn_ge(psn_a, psn_b):
+    return (psn_a - psn_b)[-1:] == 0
+
+def psn_gt(psn_a, psn_b):
+    return psn_ge(psn_a, psn_b) & (psn_a != psn_b)
+
+class LiteEthRDMARequesterValidation(LiteXModule):
+    def __init__(self, read_wait_pipe, qps, mrs, dw=8):
+        self.sink = sink = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1), ("payload_length", PMTU_BITS + 1), ("validate", 1)]))
+        self.oldest_unacked_psn = oldest_unacked_psn = Signal(24)
+
+        self.source = source = Endpoint([("opcode_op", 5), ("psn", 24), ("syndrome", 8), ("dest_qp", 24)])
+
+        # # #
+
+        ## Params to save sink parameters
+        params = Endpoint(add_params(eth_rocev2_description(dw=dw), [("header_only", 1)]))
+        self.sync += sink.connect(params, omit={"valid", "ready", "last", "data", "payload_length", "validate"})
+
+        ### Opcode splitting
+        # Connection type and operation extracted from opcode
+        opcode_conn_type = Signal(3)
+        opcode_op        = Signal(5)
+        # Opcode decomposition (must be always correct, not only for validation)
+        self.comb += Cat(opcode_op, opcode_conn_type).eq(params.opcode)
+
+        ## Reception logic
+        current_mem_loc = Record([
+            ("va_r",  64, DIR_M_TO_S),
+            ("va_l",  64, DIR_M_TO_S),
+            ("l_key", 32, DIR_M_TO_S)
+        ], reset_less=True)
+
+        # Extract qp parameters
+        init_dict = {
+            qp.id : [
+                qp.send_queue.rdma_state.connect(current_mem_loc)
+            ] for qp in qps if qp.id.value != 1
+        }
+        init_dict["default"] = [
+            current_mem_loc.va_r.eq(0),
+            current_mem_loc.va_l.eq(0),
+            current_mem_loc.l_key.eq(0)
+        ]
+        self.sync += [
+            If(sink.valid,
+                Case(sink.dest_qp, init_dict)
+            )
+        ]
+
+        ## Validation logic
+        valid_opcode_seq = Signal()
+        check_syndrome   = Signal()
+        valid_syndrome   = Signal()
+
+        self.comb += [
+            qps[1].op_seq_check_req.opcode.eq(opcode_op),
+            valid_opcode_seq.eq(~qps[1].op_seq_check_req.invalid_sequence),
+            check_syndrome.eq(opcode_op == BTH_OPCODE_OP.Acknowledge),
+            valid_syndrome.eq(~check_syndrome |
+                (
+                    params.syndrome[7] == 0 &
+                    (
+                        ((params.syndrome[6:7] == 0b00) & (params.syndrome[0:6] != 0b11111)) | # ACK credits
+                        (params.syndrome[6:7] == 0b01)                                      | # RNR NAKs
+                        ((params.syndrome[6:7] == 0b11) & (params.syndrome[0:6] <= 0b100))     # NAK codes
+                    )
+                )
+            )
+        ]
+
+        # MR boundary checks
+        check_memory = Signal()
+        valid_memory = Signal()
+        read_response = Signal()
+
+        memory_under = Signal()
+        memory_over  = Signal()
+
+        self.comb += [
+            check_memory.eq(sink.payload_length != 0),
+            valid_memory.eq(~check_memory | (~memory_under & ~memory_over)),
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.RDMA_READ_response_First,
+                BTH_OPCODE_OP.RDMA_READ_response_Middle,
+                BTH_OPCODE_OP.RDMA_READ_response_Last,
+                BTH_OPCODE_OP.RDMA_READ_response_Only,
+            ], read_response)
+        ]
+        self.sync += [
+            If(read_response,
+                Case(current_mem_loc.l_key, {
+                    Constant(mr.l_key, 32): [
+                        memory_under.eq(current_mem_loc.va_l < mr.region_start),
+                        # We set greater or equal, because this is done synchronously on RECEIVE
+                        # And so the payload_length is the number of bytes written so far
+                        # Thus, one cycle before validate, payload_length will be one less than the actual size
+                        memory_over.eq(current_mem_loc.va_l + sink.payload_length >= mr.region_start + mr.region_size)
+                    ]
+                    for mr in mrs if MR_PERM.LOCAL_WRITE in mr.permissions
+                })
+            )
+        ]
+
+        # Duplicate and readiness
+        duplicate = Signal()
+        rnr = Signal()
+        self.comb += [
+            duplicate.eq(~((oldest_unacked_psn - params.psn) >> 23) & (oldest_unacked_psn != params.psn)),
+            rnr.eq(
+                ~duplicate &
+                read_wait_pipe.full &
+                (opcode_op != BTH_OPCODE_OP.Acknowledge)
+            )
+        ]
+
+        # Reception FSM
+        self.fsm = fsm = FSM()
+        fsm.act("RECEIVE",
+            # We only buffer non-empty read responses through wait_pipe, to later commit them to memory
+            If(~sink.header_only,
+                sink.connect(read_wait_pipe.sink, keep={"valid", "ready", "last", "data"})
+            ).Else(
+                sink.ready.eq(1)
+            ),
+            If(sink.valid & sink.ready & sink.last,
+                NextState("VALIDATE")
+            )
+        )
+
+        # QP context checks
+        fsm.act("VALIDATE",
+            NextState("RECEIVE"),
+            If(sink.valid,
+                read_wait_pipe.sink.l_key.eq(current_mem_loc.l_key),
+                read_wait_pipe.sink.va.eq(current_mem_loc.va_l),
+                read_wait_pipe.sink.signal_cq.eq(
+                    (opcode_op == BTH_OPCODE_OP.RDMA_READ_response_Last) |
+                    (opcode_op == BTH_OPCODE_OP.RDMA_READ_response_Only)
+                ),
+                # We validate the packet even if the psn is incorrect (we will send another read request for that location if that is the case)
+                # In fact, we cannot stall the sink for too long as if packets are send one after another, depacketizer only waits while it
+                # receives the packet header
+                If(sink.validate & valid_opcode_seq & valid_syndrome & valid_memory &
+                ~psn_gt(oldest_unacked_psn, params.psn) | ~rnr, # Not duplicate and receiver ready
+                    # If we accept packet, we send it to the fsm
+                    source.psn.eq(params.psn),
+                    source.syndrome.eq(params.syndrome),
+                    source.opcode_op.eq(opcode_op),
+                    source.dest_qp.eq(params.dest_qp),
+                    source.valid.eq(1),
+                    read_wait_pipe.validate_sink.validate.eq(~params.header_only),
+                ).Else(
+                    read_wait_pipe.validate_sink.invalidate.eq(~params.header_only)
+                )
+            )
+            # Else should never happen
+        )
+
+class LiteEthRDMARequesterContextChecker(LiteXModule):
+    class ToggleTimer(VarWaitTimer):
+        def __init__(self, clk_freq):
+            super().__init__(clk_freq)
+
+            self.start   = start   = Signal()
+            self.stop    = stop    = Signal()
+            self.reset   = reset   = Signal()
+
+            # # #
+
+            running = Signal()
+
+            self.comb += self.pow.eq(0x11)
+            self.comb += self.wait.eq(running & ~reset & ~self.done)
+
+            self.sync += [
+                If(start,
+                    running.eq(1)
+                ).Elif(stop,
+                    running.eq(0)
+                )
+            ]
+
+    def __init__(self, qps, pre_cq, clk_freq):
+        self.responses_sink = responses_sink = Endpoint([("opcode_op", 5), ("psn", 24), ("syndrome", 8), ("dest_qp", 24)])
+        self.timer_start = Signal()
+
+        self.resend_source = resend_source = Endpoint(add_params(eth_rocev2_send_wr_description(), [("psn", 24)]))
+        self.oldest_unacked_psn = oldest_unacked_psn = Signal(24)
+
+        # # #
+
+        # Params
+        outstanding_requests = qps[1].outstanding_requests
+        outstanding_read_requests = qps[1].outstanding_read_requests
+        outstanding_requests_chooser = qps[1].outstanding_requests_chooser
+
+        ## Datapath
+        # responses_sink -> SyncFIFO
+        # Responses to be treated from the receiver
+        responses_fifo = SyncFIFO([("opcode_op", 5), ("psn", 24), ("syndrome", 8), ("dest_qp", 24)], 16, buffered=True)
+        self.submodules.responses_fifo = responses_fifo
+        self.comb += responses_sink.connect(responses_fifo.sink)
+
+        # Buffer -> resend_source
+        # Pending resend
+        pending_resend = Buffer(add_params(eth_rocev2_send_wr_description(), [("psn", 24)]))
+        self.submodules.pending_resend = pending_resend
+
+        ## Logic
+        # Timer logic
+        outstanding_timer = self.ToggleTimer(clk_freq)
+        self.submodules.outstanding_timer = outstanding_timer
+
+        self.comb += [
+            outstanding_timer.start.eq(self.timer_start),
+            outstanding_timer.stop.eq(~outstanding_requests_chooser.source.valid),
+            outstanding_timer.reset.eq(responses_fifo.source.valid & responses_fifo.source.ready & outstanding_requests_chooser.source.valid)
+        ]
+
+        # Syndrome decode
+        ack_type  = Signal(2)
+        ack_value = Signal(5)
+
+        self.comb += [
+            ack_value.eq(responses_fifo.source.syndrome[:5]),
+            ack_type.eq(responses_fifo.source.syndrome[5:7])
+        ]
+
+        # Resend logic
+        # Retry counters, when equal to 7, indicate infinite retries
+        retry_cnt     = Signal(3)
+        retry_cnt_rnr = Signal(3)
+
+        resend_ask = Signal()
+
+        # Response logic
+
+        # Number of expected packets for top outstanding request
+        wr_packets = Signal(16, reset_less=True)
+        self.comb += [
+            If(outstanding_requests_chooser.source.choose,
+                wr_packets.eq(outstanding_requests.source.dma_len[PMTU_BITS:] + (outstanding_requests.source.dma_len[:PMTU_BITS] != 0))
+            ).Else(
+                wr_packets.eq(outstanding_read_requests.source.dma_len[PMTU_BITS:] + (outstanding_read_requests.source.dma_len[:PMTU_BITS] != 0))
+            )
+        ]
+
+        ## Resend logic
+        last_expected_psn  = Signal(24, reset_less=True) # From the oldest unacknowledged request
+
+        resend_starting_pos     = Signal(64, reset_less=True)
+        resend_remaining_length = Signal(32, reset_less=True)
+
+        # FSM
+        self.fsm = fsm = FSM()
+        # Fetch next outstanding work request
+        fsm.act("NEXT_WR",
+            If(qps[1].qp_state == LiteEthIBQP.ERROR,
+                NextState("ERROR")
+            ).Elif(outstanding_requests_chooser.source.valid,
+                If(outstanding_requests_chooser.source.choose,
+                    NextValue(oldest_unacked_psn, outstanding_requests.source.psn),
+                    NextValue(last_expected_psn, outstanding_requests.source.psn + wr_packets - 1),
+
+                    NextValue(resend_starting_pos, outstanding_requests.source.va),
+                    NextValue(resend_remaining_length, outstanding_requests.source.dma_len)
+                ).Else(
+                    NextValue(oldest_unacked_psn, outstanding_read_requests.source.psn),
+                    NextValue(last_expected_psn, outstanding_read_requests.source.psn + wr_packets - 1),
+
+                    NextValue(resend_starting_pos, outstanding_read_requests.source.va),
+                    NextValue(resend_remaining_length, outstanding_read_requests.source.dma_len)
+                ),
+
+                # Reload retry counters
+                NextValue(retry_cnt, qps[1].retry_cnt_rst),
+                NextValue(retry_cnt_rnr, qps[1].retry_cnt_rnr_rst),
+
+                # QP state - For reception location
+                NextValue(qps[1].send_queue.rdma_state.va_r, outstanding_read_requests.source.va),
+                NextValue(qps[1].send_queue.rdma_state.va_l, 0),
+                NextValue(qps[1].send_queue.rdma_state.l_key, outstanding_read_requests.source.l_key),
+
+                # We receiving a read response is different from receiving an ack to send or write
+                If(outstanding_requests_chooser.source.choose,
+                    NextState("WAIT_ACK")
+                ).Else(
+                    NextState("WAIT_READ")
+                )
+            ).Else(
+                responses_fifo.source.ready.eq(1)
+            )
+        )
+
+        # Set pre_cq parameters
+        self.comb += [
+            If(fsm.ongoing("ERROR"),
+                pre_cq.sink.opcode.eq(WC.Opcode.FLUSH)
+            ).Else(
+                If(outstanding_requests_chooser.source.choose,
+                    Case(outstanding_requests.source.wr_opcode, {
+                        WR_OPCODE.SEND:
+                            pre_cq.sink.opcode.eq(WC.Opcode.SEND),
+                        WR_OPCODE.RDMA_WRITE:
+                            pre_cq.sink.opcode.eq(WC.Opcode.RDMA_WRITE)
+                    })
+                ).Else(
+                    # It has to be a read
+                    pre_cq.sink.opcode.eq(WC.Opcode.RDMA_READ)
+                )
+
+            ),
+            If(outstanding_requests_chooser.source.choose,
+                outstanding_requests.source.connect(pre_cq.sink, keep={"w_immdt", "immdt", "dma_len"})
+            ).Else(
+                outstanding_read_requests.source.connect(pre_cq.sink, keep={"w_immdt", "immdt", "dma_len"}),
+            ),
+            pre_cq.sink.qp_num.eq(responses_fifo.source.dest_qp),
+            Case(responses_fifo.source.dest_qp, {qp.id : [
+                pre_cq.sink.src_qp.eq(qp.other_id)
+            ] for qp in qps[1:]})
+        ]
+
+        # Shorthand for decrementing retry_cnt or rnr_retry_cnt and reporting an error
+        def decrease_retry_cnt(rnr=False, resend=True, check_diff_pack=False, error_status=WC.Status.GENERAL_ERR):
+            rst = qps[1].retry_cnt_rnr_rst if rnr else qps[1].retry_cnt_rst
+            cnt = retry_cnt_rnr if rnr else retry_cnt
+
+            # Ask the tx module to resend the last outstanding packet
+            resend = resend_ask.eq(1) if resend else []
+
+            decrement_cnt = (
+                # Check if NAK concerns same packet
+                If(oldest_unacked_psn == responses_fifo.source.psn,
+                    NextValue(cnt, cnt - 1)
+                ).Else(
+                    NextValue(cnt, rst - 1)
+                )
+            ) if check_diff_pack else (
+                NextValue(cnt, cnt - 1)
+            )
+
+            return If(rst != 7, # Infinite retries
+                If(cnt != 0,
+                    resend,
+                    # CLASS A ERROR
+                    decrement_cnt
+                ).Else(
+                    # CLASS B ERROR
+                    NextState("ERROR"),
+
+                    pre_cq.sink.status.eq(error_status),
+                    pre_cq.sink.valid.eq(1)
+                )
+            ).Else(
+                resend
+            )
+
+        # Wait for a response to a SEND or RDMA_WRITE
+        fsm.act("WAIT_ACK",
+            If(qps[1].qp_state == LiteEthIBQP.ERROR,
+                NextState("ERROR")
+            ).Else(
+                If(outstanding_timer.done & (retry_cnt != 0),
+                    # Local Ack Timeout error.
+                    decrease_retry_cnt(resend=False, error_status=WC.Status.RESP_TIMEOUT_ERR),
+                ),
+                responses_fifo.source.ready.eq(1),
+                # We receive a response with a psn in the expected range
+                If(responses_fifo.source.valid & psn_ge(responses_fifo.source.psn, oldest_unacked_psn),
+                    # We receive a response with a psn relating to a later request
+                    If(psn_gt(responses_fifo.source.psn, last_expected_psn),
+                        # We receive a response with a psn that is less than the last possible psn
+                        If(psn_ge(responses_fifo.source.psn, qps[1].send_queue.psn),
+                            responses_fifo.source.ready.eq(0),
+                            outstanding_requests.source.ready.eq(1),
+                            outstanding_requests_chooser.source.ready.eq(1),
+
+                            # Push to pre_cq at end of response
+                            pre_cq.sink.valid.eq(1),
+                            pre_cq.sink.status.eq(WC.Status.SUCCESS),
+
+                            NextState("NEXT_WR")
+                        )
+                        # Ignore packet if it has an invalid psn
+                    ).Else(
+                        # We cannot receive a READ Response on a request where we are expecting an ACK
+                        # (responses to subsequent packets are treated in above condition)
+                        If(responses_fifo.source.opcode_op == BTH_OPCODE_OP.Acknowledge,
+                            qps[1].op_seq_check_req.update.eq(1),
+                            If(ack_type == 0b00, # ACK
+                                If(responses_fifo.source.psn == last_expected_psn,
+                                    outstanding_requests.source.ready.eq(1),
+                                    outstanding_requests_chooser.source.ready.eq(1),
+                                    # CQ completion
+                                    # Push to pre_cq at end of response
+                                    pre_cq.sink.valid.eq(1),
+                                    pre_cq.sink.status.eq(WC.Status.SUCCESS),
+
+                                    NextState("NEXT_WR")
+                                ).Else(
+                                    NextValue(resend_starting_pos, resend_starting_pos + (oldest_unacked_psn - responses_fifo.source.psn) << PMTU_BITS),
+                                    NextValue(resend_remaining_length, resend_remaining_length - (oldest_unacked_psn - responses_fifo.source.psn) << PMTU_BITS),
+                                ),
+                                NextValue(oldest_unacked_psn, responses_fifo.source.psn + 1),
+                                NextValue(retry_cnt, qps[1].retry_cnt_rst),
+                                NextValue(retry_cnt_rnr, qps[1].retry_cnt_rnr_rst)
+                            ).Else(
+                                NextValue(resend_starting_pos, resend_starting_pos + (oldest_unacked_psn - responses_fifo.source.psn - 1) << PMTU_BITS),
+                                NextValue(resend_remaining_length, resend_remaining_length - (oldest_unacked_psn - responses_fifo.source.psn - 1) << PMTU_BITS),
+
+                                NextValue(oldest_unacked_psn, responses_fifo.source.psn),
+                            ),
+                            If(ack_type == 0b01, # RNR NAK
+                                # RNR NAK Retry error.
+                                decrease_retry_cnt(rnr=True, check_diff_pack=True, error_status=WC.Status.RNR_RETRY_EXC_ERR),
+                            ).Elif(ack_type == 0b11, # NAK
+                                If(ack_value == NAK.Code.PSN_Sequence_Error,
+                                    # Packet sequence error.
+                                    decrease_retry_cnt(check_diff_pack=True, error_status=WC.Status.RETRY_EXC_ERR),
+                                ).Else(
+                                    # Unrecoverable NAK error.
+                                    # CLASS B ERROR
+                                    pre_cq.sink.valid.eq(1),
+                                    Case(ack_value, {
+                                        NAK.Code.Invalid_Request:
+                                            pre_cq.sink.status.eq(WC.Status.REM_INV_REQ_ERR),
+                                        NAK.Code.Remote_Access_Error:
+                                            pre_cq.sink.status.eq(WC.Status.REM_ACCESS_ERR),
+                                        NAK.Code.Remote_Operational_Error:
+                                            pre_cq.sink.status.eq(WC.Status.REM_OP_ERR),
+                                    }),
+                                    NextState("ERROR")
+                                )
+                            )
+                        ).Else(
+                            # Bad response.
+                            # CLASS B ERROR
+                            pre_cq.sink.valid.eq(1),
+                            pre_cq.sink.status.eq(WC.Status.BAD_RESP_ERR),
+                            NextState("ERROR")
+                        )
+                    )
+                # Ignore duplicate
+                ),
+                If(pre_cq.sink.valid & ~pre_cq.sink.ready,
+                    NextState("ERROR")
+                )
+            )
+        )
+
+        fsm.act("WAIT_READ",
+            If(qps[1].qp_state == LiteEthIBQP.ERROR,
+                NextState("ERROR")
+            ).Else(
+                If(outstanding_timer.done & (retry_cnt != 0),
+                    # Local Ack Timeout error.
+                    decrease_retry_cnt(resend=False, error_status=WC.Status.RESP_TIMEOUT_ERR),
+                ),
+                responses_fifo.source.ready.eq(1),
+                # We receive a response with a psn in the expected range
+                If(responses_fifo.source.valid & psn_ge(responses_fifo.source.psn, oldest_unacked_psn),
+                    # We receive a response with a psn larger than expected
+                    If(responses_fifo.source.psn != oldest_unacked_psn,
+                        # Implied NAK sequence error.
+                        decrease_retry_cnt(error_status=WC.Status.RETRY_EXC_ERR),
+                    ).Else(
+                        # We receive an acknowledge
+                        If(responses_fifo.source.opcode_op == BTH_OPCODE_OP.Acknowledge,
+                            If(ack_type == 0b01, # RNR NAK
+                                # RNR NAK Retry error.
+                                decrease_retry_cnt(rnr=True, error_status=WC.Status.RNR_RETRY_EXC_ERR),
+                            ).Elif(ack_type == 0b11, # NAK
+                                If(ack_value == NAK.Code.PSN_Sequence_Error,
+                                    # Packet sequence error.
+                                    decrease_retry_cnt(error_status=WC.Status.RETRY_EXC_ERR),
+                                ).Else(
+                                    # Unrecoverable NAK error.
+                                    # CLASS B ERROR
+                                    pre_cq.sink.valid.eq(1),
+                                    Case(ack_value, {
+                                        NAK.Code.Invalid_Request:
+                                            pre_cq.sink.status.eq(WC.Status.REM_INV_REQ_ERR),
+                                        NAK.Code.Remote_Access_Error:
+                                            pre_cq.sink.status.eq(WC.Status.REM_ACCESS_ERR),
+                                        NAK.Code.Remote_Operational_Error:
+                                            pre_cq.sink.status.eq(WC.Status.REM_OP_ERR),
+                                    }),
+                                    NextState("ERROR")
+                                )
+                            ).Else(
+                                # Bad response
+                                # CLASS B ERROR
+                                pre_cq.sink.valid.eq(1),
+                                pre_cq.sink.status.eq(WC.Status.BAD_RESP_ERR),
+                                NextState("ERROR")
+                            )
+                        # We receive a read response
+                        ).Else(
+                            qps[1].op_seq_check_req.update.eq(1),
+                            If(responses_fifo.source.psn == last_expected_psn,
+                                outstanding_read_requests.source.ready.eq(1),
+                                outstanding_requests_chooser.source.ready.eq(1),
+
+                                # Push to pre_cq at end of read response
+                                pre_cq.sink.valid.eq(1),
+                                If((responses_fifo.source.opcode_op == BTH_OPCODE_OP.RDMA_READ_response_Last) |
+                                (responses_fifo.source.opcode_op == BTH_OPCODE_OP.RDMA_READ_response_Only),
+                                    pre_cq.sink.status.eq(WC.Status.SUCCESS),
+                                    NextState("NEXT_WR")
+                                ).Else(
+                                    # Bad response
+                                    pre_cq.sink.status.eq(WC.Status.BAD_RESP_ERR),
+                                    NextState("ERROR")
+                                )
+                            ),
+
+                            # For receiving RDMA READ responses
+                            NextValue(qps[1].send_queue.rdma_state.va_r, resend_starting_pos + PMTU),
+                            NextValue(qps[1].send_queue.rdma_state.va_l, qps[1].send_queue.rdma_state.va_l + PMTU),
+
+                            NextValue(resend_starting_pos, resend_starting_pos + PMTU),
+                            NextValue(resend_remaining_length, resend_remaining_length - PMTU),
+
+                            NextValue(oldest_unacked_psn, oldest_unacked_psn + 1),
+                            NextValue(retry_cnt, qps[1].retry_cnt_rst),
+                            NextValue(retry_cnt_rnr, qps[1].retry_cnt_rnr_rst)
+                        )
+                    )
+                ),
+                If(pre_cq.sink.valid & ~pre_cq.sink.ready,
+                    NextState("ERROR")
+                )
+            )
+        )
+
+        # Dump all outstanding requests and received responses
+        fsm.act("ERROR",
+            If(qps[1].qp_state != LiteEthIBQP.ERROR,
+                NextValue(qps[1].local_error, 1)
+            ),
+            outstanding_requests.source.ready.eq(pre_cq.sink.ready),
+            outstanding_read_requests.source.ready.eq(pre_cq.sink.ready),
+            outstanding_requests_chooser.source.ready.eq(pre_cq.sink.ready),
+            pre_cq.sink.valid.eq(outstanding_requests_chooser.source.valid),
+            pre_cq.sink.status.eq(WC.Status.WR_FLUSH_ERR),
+            responses_fifo.source.ready.eq(1),
+            If(~outstanding_requests_chooser.source.valid &
+                ~responses_fifo.source.valid,
+                NextState("NEXT_WR")
+            )
+        )
+
+        # Resend
+        self.comb += [
+            If(outstanding_requests_chooser.source.choose,
+                outstanding_requests.source.connect(pending_resend.sink, omit={"valid", "ready", "psn", "va", "dma_len"}),
+            ).Else(
+                outstanding_read_requests.source.connect(pending_resend.sink, omit={"valid", "ready", "psn", "va", "dma_len"}),
+            ),
+            pending_resend.sink.va.eq(resend_starting_pos),
+            pending_resend.sink.dma_len.eq(resend_remaining_length),
+            pending_resend.sink.psn.eq(oldest_unacked_psn),
+            pending_resend.sink.valid.eq(resend_ask | (outstanding_timer.done & (retry_cnt != 0)))
+        ]
+
+        # Dump resend buffer on ERROR
+        self.comb += [
+            If(fsm.ongoing("ERROR"),
+                pending_resend.source.ready.eq(1)
+            ).Else(
+                pending_resend.source.connect(resend_source)
+            )
+        ]
+
+class LiteEthRDMARequesterRX(LiteXModule):
+    """
+                           ┌───────────┐
+                           │   sink    │
+    ┌──────────────────────┴─────┬─────┴─────────────────────────┐
+    │                            │                               │
+    │                            │                               │
+    │                            │                               │
+    │    ┌───────────────────────▼────────────────────────┐      │
+    │    │                                                │      │
+    │    │                                                │      │
+    │    │                RDMARequester                   │      │
+    │    │                 Validation                     │      │
+    │    │                                                │      │
+    │    │                                                │      │
+    │    └───▲─────┬────────────────────────────────┬─────┘      │
+    │        │     │                                │            │
+    │        │     │                                │            │
+    │  oldest│     │                                │            │
+    │ unacked│     │responses                       │            │
+    │     psn│     │                                │            │
+    │        │     │                                │data+params │
+    │        │     │                                │            │
+    │    ┌───┴─────▼─────┐                          │            │
+    │    │               │                     ┌────▼─────┐      │
+    │    │  RDMAContext  │                     │          │      │
+    │    │    Checker    │                     │ WaitPipe │      │
+    │    │               │                     │          │      │
+    │    └──────┬────────┘                     └──┬────┬──┘      │
+    │           │                    +1 on read   │    │         │
+    │           │completion       ┌───────────────┘    │data     │
+    │           │                 │  last or only      │         │
+    │      ┌────▼─────┐     ┌─────▼──────┐     ┌───────▼──┐      │
+    │      │          │     │    read    │     │          │      │
+    │      │  pre_cq  │     │ completion │     │  Memory  │      │
+    │      │          │     │    cnt     │     │          │      │
+    │      └────┬─────┘     └─────┬──────┘     └──────────┘      │
+    └───────────┼─────────────────┼──────────────────────────────┘
+                │                 │
+                └────────┬────────┘
+                      ┌──▼──┐
+                      │     │
+                      │ cq  │
+                      │     │
+                      └─────┘
+    """
+
+    def __init__(self, requester_tx, qps, cq, mrs, clk_freq, dw=8):
+        self.sink = sink = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1), ("payload_length", PMTU_BITS + 1), ("validate", 1)]))
+
+        # # #
+
+        # Read (response) wait pipe
+        read_wait_pipe = WaitPipe(EndpointDescription([("data", dw)], [("va", 64), ("l_key", 32), ("signal_cq", 1)]), 16, PMTU, dw=dw)
+        self.submodules.read_wait_pipe = read_wait_pipe
+
+        # A completion queue that waits for read responses to be committed to memory,
+        # before actually moving CQEs to the CQ
+        pre_cq = SyncFIFO(eth_rocev2_cq_description(), INITIATOR_DEPTH*2 + 0x10, buffered=True)
+        self.submodules.pre_cq = pre_cq
+
+        # Counting completed (committed to memory) read requests
+        # There is no defined limit on read response packets, only on number of requests
+        read_completion_cnt = Signal(max=INITIATOR_DEPTH*2)
+        read_completion_inc = Signal()
+        read_completion_dec = Signal()
+
+        requester_validator = LiteEthRDMARequesterValidation(
+            read_wait_pipe = read_wait_pipe,
+            qps            = qps,
+            mrs            = mrs,
+            dw             = dw
+        )
+        self.submodules.requester_validator = requester_validator
+
+        context_checker = LiteEthRDMARequesterContextChecker(
+            qps      = qps,
+            pre_cq   = pre_cq,
+            clk_freq = clk_freq
+        )
+        self.submodules.context_checker = context_checker
+
+        ## Datapath
+        # Connect modules
+        self.comb += [
+            sink.connect(requester_validator.sink),
+
+            requester_validator.source.connect(context_checker.responses_sink),
+            requester_validator.oldest_unacked_psn.eq(context_checker.oldest_unacked_psn),
+            context_checker.timer_start.eq(requester_tx.timer_start),
+
+            context_checker.resend_source.connect(requester_tx.sink)
+        ]
+
+        # read_wait pipe -> memory
+        self.comb += [
+            If(read_wait_pipe.source.valid,
+                Case(read_wait_pipe.source.l_key, {
+                    Constant(mr.l_key, 32): [
+                        read_wait_pipe.source.connect(mr.writer.sink, keep={"valid", "ready", "last", "data"}),
+                        mr.writer.sink.va.eq(read_wait_pipe.source.va)
+                    ] for mr in mrs if MR_PERM.LOCAL_WRITE in mr.permissions
+                }),
+            ),
+            read_completion_inc.eq(
+                read_wait_pipe.source.valid &
+                read_wait_pipe.source.ready &
+                read_wait_pipe.source.last &
+                read_wait_pipe.source.signal_cq
+            )
+        ]
+
+        # Completion queue logic
+        self.comb += [
+            If(pre_cq.source.valid,
+                pre_cq.source.connect(cq.sink, omit={"valid", "ready"}),
+                If(pre_cq.source.opcode == WC.Opcode.RDMA_READ,
+                    If(read_completion_inc | (read_completion_cnt != 0),
+                        read_completion_dec.eq(1),
+                        pre_cq.source.connect(cq.sink, keep={"valid", "ready"})
+                    )
+                ).Else(
+                    pre_cq.source.connect(cq.sink, keep={"valid", "ready"})
+                )
+            )
+        ]
+
+        self.sync += [
+            read_completion_cnt.eq(read_completion_cnt + read_completion_inc - read_completion_dec)
+        ]

--- a/liteeth/core/rocev2/requester.py
+++ b/liteeth/core/rocev2/requester.py
@@ -1,0 +1,1070 @@
+from liteeth.common import *
+
+from liteeth.core.rocev2.mr import PERM as MR_PERM
+from liteeth.core.rocev2.common import WaitPipe, VarWaitTimer
+from liteeth.core.rocev2.ack import NAK
+from liteeth.core.rocev2.qp import LiteEthIBQP
+
+from litex.soc.interconnect.stream import Endpoint, Buffer, SyncFIFO
+
+
+class LiteEthRDMARequesterTX(LiteXModule):
+    def __init__(self, qp, mrs, dw=8):
+        self.sink  = sink  = Endpoint(add_params(eth_rocev2_send_wr_description(), [("psn", 24)]))
+        self.source = source = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1)]))
+
+        self.timer_start = timer_start = Signal()
+
+        # # #
+
+        # Indicates if we are resending an old unacknowledged packet
+        resending       = Signal()
+        resending_set   = Signal()
+        resending_unset = Signal()
+        resending_mem   = Signal()
+
+        self.comb += [
+            If(resending_set,
+                resending.eq(1)
+            ).Elif(resending_unset,
+                resending.eq(0)
+            ).Else(
+                resending.eq(resending_mem)
+            )
+        ]
+        self.sync += [
+            If(resending_set,
+                resending_mem.eq(1)
+            ).Elif(resending_unset,
+                resending_mem.eq(0)
+            )
+        ]
+
+        # Picks requests from send_queue or resend_handler
+        request_source = Endpoint(eth_rocev2_send_wr_description())
+
+        self.comb += [
+            If(resending,
+                sink.connect(request_source, omit={"psn"})
+            ).Else(
+                qp.send_queue.source.connect(request_source)
+            )
+        ]
+
+        mem_reader_sink   = Endpoint([("va", 64), ("len", bits_for(PMTU))])
+        mem_reader_source = Endpoint([("data", dw)])
+
+        self.comb += [
+            If(mem_reader_sink.valid | mem_reader_source.ready,
+                Case(request_source.l_key, {
+                    Constant(mr.l_key, 32): [
+                        mem_reader_sink.connect(mr.reader.sink),
+                        mr.reader.source.connect(mem_reader_source)]
+                    for mr in mrs if not MR_PERM.NO_LOCAL_READ in mr.permissions
+                })
+            )
+        ]
+
+        # WaitPipe to fetch entire packet from RAM before send
+        # (MAC cannot be stopped after packet start and RAM reads in bursts)
+        send_wait_pipe = WaitPipe(
+            layout      = eth_rocev2_description(dw),
+            depth       = 8,
+            block_size  = PMTU,
+            discarding  = False,
+            buffered_in = False,
+            dw          = dw
+        )
+        self.submodules.send_wait_pipe = send_wait_pipe
+
+        p_key    = Signal(16, reset_less=True)
+        other_id = Signal(24, reset_less=True)
+
+        psn     = Signal(24, reset_less=True)
+        va_src  = Signal(64, reset_less=True)
+
+        # For First/Middle/Last/Only packet variations
+        first_packet = Signal()
+        # If there are more packets left to send after the current one
+        more_left = Signal()
+
+        # Number of PMTU-sized blocks that need to be sent
+        whole_blocks      = Signal(32 - PMTU_BITS)
+        whole_blocks_left = Signal().like(whole_blocks)
+        remainder_bytes   = Signal(PMTU_BITS)
+        payload_length    = Signal(PMTU_BITS + 1)
+        header_length     = Signal(32)
+
+
+        self.comb += [
+            If(request_source.wr_opcode != WR_OPCODE.RDMA_READ,
+                remainder_bytes.eq(request_source.dma_len[:PMTU_BITS]),
+                whole_blocks.eq(request_source.dma_len[PMTU_BITS:])
+            )
+        ]
+        self.comb += more_left.eq(
+            ~((whole_blocks_left == 0) |
+              ((whole_blocks_left == 1) & (remainder_bytes == 0)))
+        )
+
+        invalid_request = Signal()
+        # Requests in error state are invalid
+        # Ignore a read request for which the local write location does not allow writing
+        self.comb += invalid_request.eq(
+            (qp.qp_state == LiteEthIBQP.ERROR) |
+            (qp.send_queue.source.dma_len != 0) &
+            (qp.send_queue.source.wr_opcode == WR_OPCODE.RDMA_READ) &
+            ~is_in(qp.send_queue.source.l_key, [
+                Constant(mr.l_key, 32) for mr in mrs
+                if MR_PERM.LOCAL_WRITE in mr.permissions
+            ]))
+
+        # Main transmission combinatory logic
+        self.comb += [
+            send_wait_pipe.sink.tver.eq(0),
+            send_wait_pipe.sink.m.eq(0),
+            send_wait_pipe.sink.se.eq(0),
+            send_wait_pipe.sink.a.eq(request_source.ack_req),
+
+            If(request_source.wr_opcode == WR_OPCODE.RDMA_READ,
+                send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_Request)
+            ).Else(
+                If(more_left,
+                    If(first_packet,
+                        Case(request_source.wr_opcode, {
+                            WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_First),
+                            WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_First),
+                        })
+                    ).Else(
+                        Case(request_source.wr_opcode, {
+                            WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Middle),
+                            WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Middle),
+                        })
+                    )
+                ).Else(
+                    If(~request_source.w_immdt,
+                        If(first_packet,
+                            Case(request_source.wr_opcode, {
+                                WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Only),
+                                WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Only),
+                            })
+                        ).Else(
+                            Case(request_source.wr_opcode, {
+                                WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Last),
+                                WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Last),
+                            })
+                        )
+                    ).Else(
+                        If(first_packet,
+                            Case(request_source.wr_opcode, {
+                                WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Only_with_Immediate),
+                                WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Only_with_Immediate),
+                            })
+                        ).Else(
+                            Case(request_source.wr_opcode, {
+                                WR_OPCODE.RDMA_WRITE: send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_WRITE_Last_with_Immediate),
+                                WR_OPCODE.SEND:       send_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.SEND_Last_with_Immediate),
+                            })
+                        )
+                    )
+                )
+            ),
+            If(whole_blocks_left != 0,
+                send_wait_pipe.sink.pad.eq(0),
+                payload_length.eq(PMTU)
+            ).Else(
+                send_wait_pipe.sink.pad.eq((0b100 - (remainder_bytes & 0b11))[:2]),
+                payload_length.eq(remainder_bytes)
+            ),
+            mem_reader_sink.len.eq(payload_length),
+
+            IBT_header_length(send_wait_pipe.sink.opcode, header_length),
+            send_wait_pipe.sink.length.eq(header_length + payload_length),
+
+            send_wait_pipe.sink.psn.eq(psn),
+
+            send_wait_pipe.sink.dma_len.eq(request_source.dma_len),
+
+            send_wait_pipe.sink.p_key.eq(p_key),
+            send_wait_pipe.sink.dest_qp.eq(other_id),
+
+            send_wait_pipe.sink.r_key.eq(request_source.r_key),
+            send_wait_pipe.sink.va.eq(request_source.va),
+
+            send_wait_pipe.sink.immdt.eq(request_source.immdt),
+
+            send_wait_pipe.source.connect(source),
+
+            mem_reader_sink.va.eq(va_src),
+        ]
+
+        send_resend = Signal()
+        send_new_req = Signal()
+
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            NextValue(p_key, qp.p_key),
+            NextValue(other_id, qp.other_id),
+
+            NextValue(va_src, 0),
+            NextValue(whole_blocks_left, whole_blocks),
+            NextValue(first_packet, 1),
+
+            If(qp.qp_state == LiteEthIBQP.ERROR,
+                qp.send_queue.source.ready.eq(1),
+                sink.ready.eq(1)
+            ).Else(
+                # Ignore invalid requests from our send queue
+                qp.send_queue.source.ready.eq(invalid_request),
+                If(~send_wait_pipe.full,
+                    If(sink.valid,
+                        send_resend.eq(1)
+                    ).Elif(qp.send_queue.source.valid & ~invalid_request &
+                        qp.outstanding_requests_chooser.sink.ready & (
+                            (
+                                (qp.send_queue.source.wr_opcode != WR_OPCODE.RDMA_READ) &
+                                qp.outstanding_requests.sink.ready
+                            ) | (
+                                (qp.send_queue.source.wr_opcode == WR_OPCODE.RDMA_READ) &
+                                qp.outstanding_read_requests.sink.ready
+                            )
+                        ),
+                        send_new_req.eq(1)
+                    )
+                ),
+                If(send_resend,
+                    If((sink.dma_len != 0) & (sink.wr_opcode != WR_OPCODE.RDMA_READ),
+                        NextValue(mem_reader_sink.valid, 1),
+                        NextState("READ_RAM")
+                    ).Else(
+                        NextState("EMPTY")
+                    ),
+                    resending_set.eq(1),
+
+                    NextValue(psn, sink.psn)
+                ),
+                If(send_new_req,
+                    If((qp.send_queue.source.dma_len != 0) & (qp.send_queue.source.wr_opcode != WR_OPCODE.RDMA_READ),
+                        NextValue(mem_reader_sink.valid, 1),
+                        NextState("READ_RAM")
+                    ).Else(
+                        NextState("EMPTY")
+                    ),
+                    resending_unset.eq(1),
+
+                    NextValue(psn, qp.send_queue.psn),
+
+                    # Transfer wr from send_queue to outstanding
+                    qp.outstanding_requests_chooser.sink.valid.eq(1),
+                    If(qp.send_queue.source.wr_opcode != WR_OPCODE.RDMA_READ,
+                        qp.outstanding_requests_chooser.sink.choose.eq(1),
+                        qp.send_queue.source.connect(qp.outstanding_requests.sink, omit={"ready", "psn"}),
+                        qp.outstanding_requests.sink.psn.eq(qp.send_queue.psn)
+                    ).Else(
+                        qp.outstanding_requests_chooser.sink.choose.eq(0),
+                        qp.send_queue.source.connect(qp.outstanding_read_requests.sink, omit={"ready", "psn"}),
+                        qp.outstanding_read_requests.sink.psn.eq(qp.send_queue.psn)
+                    ),
+
+                    If(qp.send_queue.source.ack_req | (qp.send_queue.source.wr_opcode == WR_OPCODE.RDMA_READ),
+                        timer_start.eq(1)
+                    )
+                )
+            )
+        )
+
+        fsm.act("READ_RAM",
+            If(qp.qp_state == LiteEthIBQP.ERROR,
+                send_wait_pipe.validate_sink.invalidate.eq(1),
+                NextValue(mem_reader_sink.valid, 0),
+                NextState("ERROR_DUMP")
+            ).Else(
+                If(mem_reader_sink.ready == 1, # Once the reader has consumed the request, we end it
+                    NextValue(mem_reader_sink.valid, 0)
+                ),
+                mem_reader_source.connect(send_wait_pipe.sink, keep={"valid", "ready", "data", "last"}),
+
+                If(mem_reader_source.valid & mem_reader_source.last & send_wait_pipe.sink.ready,
+                    send_wait_pipe.validate_sink.validate.eq(1),
+                    NextValue(first_packet, 0),
+                    If(~resending,
+                        NextValue(qp.send_queue.psn, psn + 1)
+                    ),
+                    If(more_left,
+                        NextValue(mem_reader_sink.valid, 1),
+                        NextValue(whole_blocks_left, whole_blocks_left - 1),
+                        NextValue(va_src, va_src + PMTU),
+                        NextValue(psn, psn + 1),
+                    ).Else(
+                        NextValue(mem_reader_sink.valid, 0),
+                        # Consume request
+                        If(~resending,
+                            qp.send_queue.source.ready.eq(1)
+                        ).Else(
+                            sink.ready.eq(1)
+                        ),
+                        NextState("IDLE")
+                    )
+                )
+            )
+        )
+
+        fsm.act("EMPTY",
+            If(qp.qp_state == LiteEthIBQP.ERROR,
+                NextState("IDLE")
+            ).Else(
+                send_wait_pipe.sink.valid.eq(1),
+                send_wait_pipe.sink.last.eq(1),
+                send_wait_pipe.sink.header_only.eq(1),
+                If(send_wait_pipe.sink.ready,
+                    send_wait_pipe.validate_sink.validate.eq(1),
+                    If(~resending,
+                        If(request_source.wr_opcode == WR_OPCODE.RDMA_READ,
+                            NextValue(qp.send_queue.psn, psn + request_source.dma_len[PMTU_BITS:] + (request_source.dma_len[:PMTU_BITS] != 0))
+                        ).Else(
+                            NextValue(qp.send_queue.psn, psn + 1)
+                        ),
+                        qp.send_queue.source.ready.eq(1)
+                    ).Else(
+                        sink.ready.eq(1)
+                    ),
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        fsm.act("ERROR_DUMP",
+            mem_reader_source.ready.eq(1),
+            If(~mem_reader_source.valid | mem_reader_source.last,
+                NextState("IDLE")
+            )
+        )
+
+# PSN helper functions
+def psn_ge(psn_a, psn_b):
+    return (psn_a - psn_b)[-1:] == 0
+
+def psn_gt(psn_a, psn_b):
+    return psn_ge(psn_a, psn_b) & (psn_a != psn_b)
+
+class LiteEthRDMARequesterValidation(LiteXModule):
+    def __init__(self, read_wait_pipe, qps, mrs, dw=8):
+        self.sink = sink = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1), ("payload_length", PMTU_BITS + 1), ("validate", 1)]))
+        self.oldest_unacked_psn = oldest_unacked_psn = Signal(24)
+
+        self.source = source = Endpoint([("opcode_op", 5), ("psn", 24), ("syndrome", 8), ("dest_qp", 24)])
+
+        # # #
+
+        ## Params to save sink parameters
+        params = Endpoint(add_params(eth_rocev2_description(dw=dw), [("header_only", 1)]))
+        self.sync += sink.connect(params, omit={"valid", "ready", "last", "data", "payload_length", "validate"})
+
+        ### Opcode splitting
+        # Connection type and operation extracted from opcode
+        opcode_conn_type = Signal(3)
+        opcode_op        = Signal(5)
+        # Opcode decomposition (must be always correct, not only for validation)
+        self.comb += Cat(opcode_op, opcode_conn_type).eq(params.opcode)
+
+        ## Reception logic
+        current_mem_loc = Record([
+            ("va_r",  64, DIR_M_TO_S),
+            ("va_l",  64, DIR_M_TO_S),
+            ("l_key", 32, DIR_M_TO_S)
+        ], reset_less=True)
+
+        # Extract qp parameters
+        init_dict = {
+            qp.id : [
+                qp.send_queue.rdma_state.connect(current_mem_loc)
+            ] for qp in qps if qp.id.value != 1
+        }
+        init_dict["default"] = [
+            current_mem_loc.va_r.eq(0),
+            current_mem_loc.va_l.eq(0),
+            current_mem_loc.l_key.eq(0)
+        ]
+        self.sync += [
+            If(sink.valid,
+                Case(sink.dest_qp, init_dict)
+            )
+        ]
+
+        ## Validation logic
+        valid_opcode_seq = Signal()
+        check_syndrome   = Signal()
+        valid_syndrome   = Signal()
+
+        self.comb += [
+            qps[1].op_seq_check_req.opcode.eq(opcode_op),
+            valid_opcode_seq.eq(~qps[1].op_seq_check_req.invalid_sequence),
+            check_syndrome.eq(opcode_op == BTH_OPCODE_OP.Acknowledge),
+            valid_syndrome.eq(~check_syndrome |
+                (
+                    params.syndrome[7] == 0 &
+                    (
+                        ((params.syndrome[6:7] == 0b00) & (params.syndrome[0:6] != 0b11111)) | # ACK credits
+                        (params.syndrome[6:7] == 0b01)                                      | # RNR NAKs
+                        ((params.syndrome[6:7] == 0b11) & (params.syndrome[0:6] <= 0b100))     # NAK codes
+                    )
+                )
+            )
+        ]
+
+        # MR boundary checks
+        check_memory = Signal()
+        valid_memory = Signal()
+        read_response = Signal()
+
+        memory_under = Signal(reset_less=True)
+        memory_over  = Signal(reset_less=True)
+
+        self.comb += [
+            check_memory.eq(sink.payload_length != 0),
+            valid_memory.eq(~check_memory | (~memory_under & ~memory_over)),
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.RDMA_READ_response_First,
+                BTH_OPCODE_OP.RDMA_READ_response_Middle,
+                BTH_OPCODE_OP.RDMA_READ_response_Last,
+                BTH_OPCODE_OP.RDMA_READ_response_Only,
+            ], read_response)
+        ]
+        self.sync += [
+            If(read_response,
+                Case(current_mem_loc.l_key, {
+                    Constant(mr.l_key, 32): [
+                        memory_under.eq(current_mem_loc.va_l < mr.region_start),
+                        # We set greater or equal, because this is done synchronously on RECEIVE
+                        # And so the payload_length is the number of bytes written so far
+                        # Thus, one cycle before validate, payload_length will be one less than the actual size
+                        memory_over.eq(current_mem_loc.va_l + sink.payload_length >= mr.region_start + mr.region_size)
+                    ]
+                    for mr in mrs if MR_PERM.LOCAL_WRITE in mr.permissions
+                })
+            )
+        ]
+
+        # Duplicate and readiness
+        duplicate = Signal()
+        rnr = Signal()
+        self.comb += [
+            duplicate.eq(~((oldest_unacked_psn - params.psn) >> 23) & (oldest_unacked_psn != params.psn)),
+            rnr.eq(
+                ~duplicate &
+                read_wait_pipe.full &
+                (opcode_op != BTH_OPCODE_OP.Acknowledge)
+            )
+        ]
+
+        # Reception FSM
+        self.fsm = fsm = FSM()
+        fsm.act("RECEIVE",
+            # We only buffer non-empty read responses through wait_pipe, to later commit them to memory
+            If(~sink.header_only,
+                sink.connect(read_wait_pipe.sink, keep={"valid", "ready", "last", "data"})
+            ).Else(
+                sink.ready.eq(1)
+            ),
+            If(sink.valid & sink.ready & sink.last,
+                NextState("VALIDATE")
+            )
+        )
+
+        # QP context checks
+        fsm.act("VALIDATE",
+            NextState("RECEIVE"),
+            If(sink.valid,
+                read_wait_pipe.sink.l_key.eq(current_mem_loc.l_key),
+                read_wait_pipe.sink.va.eq(current_mem_loc.va_l),
+                read_wait_pipe.sink.signal_cq.eq(
+                    (opcode_op == BTH_OPCODE_OP.RDMA_READ_response_Last) |
+                    (opcode_op == BTH_OPCODE_OP.RDMA_READ_response_Only)
+                ),
+                # We validate the packet even if the psn is incorrect (we will send another read request for that location if that is the case)
+                # In fact, we cannot stall the sink for too long as if packets are send one after another, depacketizer only waits while it
+                # receives the packet header
+                If(sink.validate & valid_opcode_seq & valid_syndrome & valid_memory &
+                ~psn_gt(oldest_unacked_psn, params.psn) | ~rnr, # Not duplicate and receiver ready
+                    # If we accept packet, we send it to the fsm
+                    source.psn.eq(params.psn),
+                    source.syndrome.eq(params.syndrome),
+                    source.opcode_op.eq(opcode_op),
+                    source.dest_qp.eq(params.dest_qp),
+                    source.valid.eq(1),
+                    read_wait_pipe.validate_sink.validate.eq(~params.header_only),
+                ).Else(
+                    read_wait_pipe.validate_sink.invalidate.eq(~params.header_only)
+                )
+            )
+            # Else should never happen
+        )
+
+class LiteEthRDMARequesterContextChecker(LiteXModule):
+    class ToggleTimer(VarWaitTimer):
+        def __init__(self, clk_freq):
+            super().__init__(clk_freq)
+
+            self.start   = start   = Signal()
+            self.stop    = stop    = Signal()
+            self.reset   = reset   = Signal()
+
+            # # #
+
+            running = Signal()
+
+            self.comb += self.pow.eq(0x11)
+            self.comb += self.wait.eq(running & ~reset & ~self.done)
+
+            self.sync += [
+                If(start,
+                    running.eq(1)
+                ).Elif(stop,
+                    running.eq(0)
+                )
+            ]
+
+    def __init__(self, qps, pre_cq, clk_freq):
+        self.responses_sink = responses_sink = Endpoint([("opcode_op", 5), ("psn", 24), ("syndrome", 8), ("dest_qp", 24)])
+        self.timer_start = Signal()
+
+        self.resend_source = resend_source = Endpoint(add_params(eth_rocev2_send_wr_description(), [("psn", 24)]))
+        self.oldest_unacked_psn = oldest_unacked_psn = Signal(24, reset_less=True)
+
+        # # #
+
+        # Params
+        outstanding_requests = qps[1].outstanding_requests
+        outstanding_read_requests = qps[1].outstanding_read_requests
+        outstanding_requests_chooser = qps[1].outstanding_requests_chooser
+
+        ## Datapath
+        # responses_sink -> SyncFIFO
+        # Responses to be treated from the receiver
+        responses_fifo = SyncFIFO([("opcode_op", 5), ("psn", 24), ("syndrome", 8), ("dest_qp", 24)], 16, buffered=True)
+        self.submodules.responses_fifo = responses_fifo
+        self.comb += responses_sink.connect(responses_fifo.sink)
+
+        # Buffer -> resend_source
+        # Pending resend
+        pending_resend = Buffer(add_params(eth_rocev2_send_wr_description(), [("psn", 24)]))
+        self.submodules.pending_resend = pending_resend
+
+        ## Logic
+        # Timer logic
+        outstanding_timer = self.ToggleTimer(clk_freq)
+        self.submodules.outstanding_timer = outstanding_timer
+
+        resend_ask = Signal()
+
+        self.comb += [
+            outstanding_timer.start.eq(self.timer_start),
+            outstanding_timer.stop.eq(~outstanding_requests_chooser.source.valid),
+            outstanding_timer.reset.eq((responses_fifo.source.valid & responses_fifo.source.ready & outstanding_requests_chooser.source.valid) | resend_ask)
+        ]
+
+        # Syndrome decode
+        ack_type  = Signal(2)
+        ack_value = Signal(5)
+
+        self.comb += [
+            ack_value.eq(responses_fifo.source.syndrome[:5]),
+            ack_type.eq(responses_fifo.source.syndrome[5:7])
+        ]
+
+        # Resend logic
+        # Retry counters, when equal to 7, indicate infinite retries
+        retry_cnt     = Signal(3, reset_less=True)
+        retry_cnt_rnr = Signal(3, reset_less=True)
+
+
+        # Response logic
+
+        # Number of expected packets for top outstanding request
+        wr_packets = Signal(16, reset_less=True)
+        self.comb += [
+            If(outstanding_requests_chooser.source.choose,
+                If(outstanding_requests.source.dma_len != 0,
+                    wr_packets.eq(outstanding_requests.source.dma_len[PMTU_BITS:] + (outstanding_requests.source.dma_len[:PMTU_BITS] != 0))
+                ).Else(
+                    wr_packets.eq(1)
+                )
+            ).Else(
+                If(outstanding_read_requests.source.dma_len != 0,
+                    wr_packets.eq(outstanding_read_requests.source.dma_len[PMTU_BITS:] + (outstanding_read_requests.source.dma_len[:PMTU_BITS] != 0))
+                ).Else(
+                    wr_packets.eq(1)
+                )
+            )
+        ]
+
+        ## Resend logic
+        last_expected_psn  = Signal(24, reset_less=True) # From the oldest unacknowledged request
+
+        resend_starting_pos     = Signal(64, reset_less=True)
+        resend_remaining_length = Signal(32, reset_less=True)
+
+        # FSM
+        self.fsm = fsm = FSM()
+        # Fetch next outstanding work request
+        fsm.act("NEXT_WR",
+            If(qps[1].qp_state == LiteEthIBQP.ERROR,
+                NextState("ERROR")
+            ).Elif(outstanding_requests_chooser.source.valid,
+                If(outstanding_requests_chooser.source.choose,
+                    NextValue(oldest_unacked_psn, outstanding_requests.source.psn),
+                    NextValue(last_expected_psn, outstanding_requests.source.psn + wr_packets - 1),
+
+                    NextValue(resend_starting_pos, outstanding_requests.source.va),
+                    NextValue(resend_remaining_length, outstanding_requests.source.dma_len)
+                ).Else(
+                    NextValue(oldest_unacked_psn, outstanding_read_requests.source.psn),
+                    NextValue(last_expected_psn, outstanding_read_requests.source.psn + wr_packets - 1),
+
+                    NextValue(resend_starting_pos, outstanding_read_requests.source.va),
+                    NextValue(resend_remaining_length, outstanding_read_requests.source.dma_len)
+                ),
+
+                # Reload retry counters
+                NextValue(retry_cnt, qps[1].retry_cnt_rst),
+                NextValue(retry_cnt_rnr, qps[1].retry_cnt_rnr_rst),
+
+                # QP state - For reception location
+                NextValue(qps[1].send_queue.rdma_state.va_r, outstanding_read_requests.source.va),
+                NextValue(qps[1].send_queue.rdma_state.va_l, 0),
+                NextValue(qps[1].send_queue.rdma_state.l_key, outstanding_read_requests.source.l_key),
+
+                # We receiving a read response is different from receiving an ack to send or write
+                If(outstanding_requests_chooser.source.choose,
+                    NextState("WAIT_ACK")
+                ).Else(
+                    NextState("WAIT_READ")
+                )
+            ).Else(
+                responses_fifo.source.ready.eq(1)
+            )
+        )
+
+        # Set pre_cq parameters
+        self.comb += [
+            If(fsm.ongoing("ERROR"),
+                pre_cq.sink.opcode.eq(WC.Opcode.FLUSH)
+            ).Else(
+                If(outstanding_requests_chooser.source.choose,
+                    Case(outstanding_requests.source.wr_opcode, {
+                        WR_OPCODE.SEND:
+                            pre_cq.sink.opcode.eq(WC.Opcode.SEND),
+                        WR_OPCODE.RDMA_WRITE:
+                            pre_cq.sink.opcode.eq(WC.Opcode.RDMA_WRITE)
+                    })
+                ).Else(
+                    # It has to be a read
+                    pre_cq.sink.opcode.eq(WC.Opcode.RDMA_READ)
+                )
+
+            ),
+            If(outstanding_requests_chooser.source.choose,
+                outstanding_requests.source.connect(pre_cq.sink, keep={"w_immdt", "immdt", "dma_len"})
+            ).Else(
+                outstanding_read_requests.source.connect(pre_cq.sink, keep={"w_immdt", "immdt", "dma_len"}),
+            ),
+            pre_cq.sink.qp_num.eq(responses_fifo.source.dest_qp),
+            Case(responses_fifo.source.dest_qp, {qp.id : [
+                pre_cq.sink.src_qp.eq(qp.other_id)
+            ] for qp in qps[1:]})
+        ]
+
+        # Shorthand for decrementing retry_cnt or rnr_retry_cnt and reporting an error
+        def decrease_retry_cnt(rnr=False, resend=True, check_diff_pack=False, error_status=WC.Status.GENERAL_ERR):
+            rst = qps[1].retry_cnt_rnr_rst if rnr else qps[1].retry_cnt_rst
+            cnt = retry_cnt_rnr if rnr else retry_cnt
+
+            # Ask the tx module to resend the last outstanding packet
+            resend = resend_ask.eq(1) if resend else []
+
+            decrement_cnt = (
+                # Check if NAK concerns same packet
+                If(oldest_unacked_psn == responses_fifo.source.psn,
+                    NextValue(cnt, cnt - 1)
+                ).Else(
+                    NextValue(cnt, rst - 1)
+                )
+            ) if check_diff_pack else (
+                NextValue(cnt, cnt - 1)
+            )
+
+            return If(rst != 7, # Infinite retries
+                If(cnt != 0,
+                    resend,
+                    # CLASS A ERROR
+                    decrement_cnt
+                ).Else(
+                    # CLASS B ERROR
+                    NextState("ERROR"),
+
+                    pre_cq.sink.status.eq(error_status),
+                    pre_cq.sink.valid.eq(1)
+                )
+            ).Else(
+                resend
+            )
+
+        # Wait for a response to a SEND or RDMA_WRITE
+        fsm.act("WAIT_ACK",
+            If(qps[1].qp_state == LiteEthIBQP.ERROR,
+                NextState("ERROR")
+            ).Else(
+                If(outstanding_timer.done & (retry_cnt != 0),
+                    # Local Ack Timeout error.
+                    decrease_retry_cnt(resend=False, error_status=WC.Status.RESP_TIMEOUT_ERR),
+                ),
+                responses_fifo.source.ready.eq(1),
+                # We receive a response with a psn in the expected range
+                If(responses_fifo.source.valid & psn_ge(responses_fifo.source.psn, oldest_unacked_psn),
+                    # We receive a response with a psn relating to a later request
+                    If(psn_gt(responses_fifo.source.psn, last_expected_psn),
+                        # We receive a response with a psn that is less than the last possible psn
+                        If(psn_gt(qps[1].send_queue.psn, responses_fifo.source.psn),
+                            responses_fifo.source.ready.eq(0),
+                            outstanding_requests.source.ready.eq(1),
+                            outstanding_requests_chooser.source.ready.eq(1),
+
+                            # Push to pre_cq at end of response
+                            pre_cq.sink.valid.eq(1),
+                            pre_cq.sink.status.eq(WC.Status.SUCCESS),
+
+                            NextState("NEXT_WR")
+                        )
+                        # Ignore packet if it has an invalid psn
+                    ).Else(
+                        # We cannot receive a READ Response on a request where we are expecting an ACK
+                        # (responses to subsequent packets are treated in above condition)
+                        If(responses_fifo.source.opcode_op == BTH_OPCODE_OP.Acknowledge,
+                            qps[1].op_seq_check_req.update.eq(1),
+                            If(ack_type == 0b00, # ACK
+                                If(responses_fifo.source.psn == last_expected_psn,
+                                    outstanding_requests.source.ready.eq(1),
+                                    outstanding_requests_chooser.source.ready.eq(1),
+                                    # CQ completion
+                                    # Push to pre_cq at end of response
+                                    pre_cq.sink.valid.eq(1),
+                                    pre_cq.sink.status.eq(WC.Status.SUCCESS),
+
+                                    NextState("NEXT_WR")
+                                ).Else(
+                                    NextValue(resend_starting_pos, resend_starting_pos + ((responses_fifo.source.psn - oldest_unacked_psn + 1) << PMTU_BITS)),
+                                    NextValue(resend_remaining_length, resend_remaining_length - ((responses_fifo.source.psn - oldest_unacked_psn + 1) << PMTU_BITS)),
+                                    # When we get a partial ack, we immediately resend
+                                    resend_ask.eq(1)
+                                ),
+                                NextValue(oldest_unacked_psn, responses_fifo.source.psn + 1),
+                                NextValue(retry_cnt, qps[1].retry_cnt_rst),
+                                NextValue(retry_cnt_rnr, qps[1].retry_cnt_rnr_rst)
+                            ).Else(
+                                NextValue(resend_starting_pos, resend_starting_pos + ((responses_fifo.source.psn - oldest_unacked_psn) << PMTU_BITS)),
+                                NextValue(resend_remaining_length, resend_remaining_length - ((responses_fifo.source.psn - oldest_unacked_psn) << PMTU_BITS)),
+
+                                NextValue(oldest_unacked_psn, responses_fifo.source.psn),
+                            ),
+                            If(ack_type == 0b01, # RNR NAK
+                                # RNR NAK Retry error.
+                                decrease_retry_cnt(rnr=True, check_diff_pack=True, error_status=WC.Status.RNR_RETRY_EXC_ERR),
+                            ).Elif(ack_type == 0b11, # NAK
+                                If(ack_value == NAK.Code.PSN_Sequence_Error,
+                                    # Packet sequence error.
+                                    decrease_retry_cnt(check_diff_pack=True, error_status=WC.Status.RETRY_EXC_ERR),
+                                ).Else(
+                                    # Unrecoverable NAK error.
+                                    # CLASS B ERROR
+                                    pre_cq.sink.valid.eq(1),
+                                    Case(ack_value, {
+                                        NAK.Code.Invalid_Request:
+                                            pre_cq.sink.status.eq(WC.Status.REM_INV_REQ_ERR),
+                                        NAK.Code.Remote_Access_Error:
+                                            pre_cq.sink.status.eq(WC.Status.REM_ACCESS_ERR),
+                                        NAK.Code.Remote_Operational_Error:
+                                            pre_cq.sink.status.eq(WC.Status.REM_OP_ERR),
+                                    }),
+                                    NextState("ERROR")
+                                )
+                            )
+                        ).Else(
+                            # Bad response.
+                            # CLASS B ERROR
+                            pre_cq.sink.valid.eq(1),
+                            pre_cq.sink.status.eq(WC.Status.BAD_RESP_ERR),
+                            NextState("ERROR")
+                        )
+                    )
+                # Ignore duplicate
+                ),
+                # If(pre_cq.sink.valid & ~pre_cq.sink.ready,
+                #     NextState("ERROR")
+                # )
+            )
+        )
+
+        fsm.act("WAIT_READ",
+            If(qps[1].qp_state == LiteEthIBQP.ERROR,
+                NextState("ERROR")
+            ).Else(
+                If(outstanding_timer.done & (retry_cnt != 0),
+                    # Local Ack Timeout error.
+                    decrease_retry_cnt(resend=False, error_status=WC.Status.RESP_TIMEOUT_ERR),
+                ),
+                responses_fifo.source.ready.eq(1),
+                # We receive a response with a psn in the expected range
+                If(responses_fifo.source.valid & psn_ge(responses_fifo.source.psn, oldest_unacked_psn),
+                    # We receive a response with a psn larger than expected
+                    If(responses_fifo.source.psn != oldest_unacked_psn,
+                        # Implied NAK sequence error.
+                        decrease_retry_cnt(error_status=WC.Status.RETRY_EXC_ERR),
+                    ).Else(
+                        # We receive an acknowledge
+                        If(responses_fifo.source.opcode_op == BTH_OPCODE_OP.Acknowledge,
+                            If(ack_type == 0b01, # RNR NAK
+                                # RNR NAK Retry error.
+                                decrease_retry_cnt(rnr=True, error_status=WC.Status.RNR_RETRY_EXC_ERR),
+                            ).Elif(ack_type == 0b11, # NAK
+                                If(ack_value == NAK.Code.PSN_Sequence_Error,
+                                    # Packet sequence error.
+                                    decrease_retry_cnt(error_status=WC.Status.RETRY_EXC_ERR),
+                                ).Else(
+                                    # Unrecoverable NAK error.
+                                    # CLASS B ERROR
+                                    pre_cq.sink.valid.eq(1),
+                                    Case(ack_value, {
+                                        NAK.Code.Invalid_Request:
+                                            pre_cq.sink.status.eq(WC.Status.REM_INV_REQ_ERR),
+                                        NAK.Code.Remote_Access_Error:
+                                            pre_cq.sink.status.eq(WC.Status.REM_ACCESS_ERR),
+                                        NAK.Code.Remote_Operational_Error:
+                                            pre_cq.sink.status.eq(WC.Status.REM_OP_ERR),
+                                    }),
+                                    NextState("ERROR")
+                                )
+                            ).Else(
+                                # Bad response
+                                # CLASS B ERROR
+                                pre_cq.sink.valid.eq(1),
+                                pre_cq.sink.status.eq(WC.Status.BAD_RESP_ERR),
+                                NextState("ERROR")
+                            )
+                        # We receive a read response
+                        ).Else(
+                            qps[1].op_seq_check_req.update.eq(1),
+                            If(responses_fifo.source.psn == last_expected_psn,
+                                outstanding_read_requests.source.ready.eq(1),
+                                outstanding_requests_chooser.source.ready.eq(1),
+
+                                # Push to pre_cq at end of read response
+                                pre_cq.sink.valid.eq(1),
+                                If((responses_fifo.source.opcode_op == BTH_OPCODE_OP.RDMA_READ_response_Last) |
+                                (responses_fifo.source.opcode_op == BTH_OPCODE_OP.RDMA_READ_response_Only),
+                                    pre_cq.sink.status.eq(WC.Status.SUCCESS),
+                                    NextState("NEXT_WR")
+                                ).Else(
+                                    # Bad response
+                                    pre_cq.sink.status.eq(WC.Status.BAD_RESP_ERR),
+                                    NextState("ERROR")
+                                )
+                            ),
+
+                            # For receiving RDMA READ responses
+                            NextValue(qps[1].send_queue.rdma_state.va_r, resend_starting_pos + PMTU),
+                            NextValue(qps[1].send_queue.rdma_state.va_l, qps[1].send_queue.rdma_state.va_l + PMTU),
+
+                            NextValue(resend_starting_pos, resend_starting_pos + PMTU),
+                            NextValue(resend_remaining_length, resend_remaining_length - PMTU),
+
+                            NextValue(oldest_unacked_psn, oldest_unacked_psn + 1),
+                            NextValue(retry_cnt, qps[1].retry_cnt_rst),
+                            NextValue(retry_cnt_rnr, qps[1].retry_cnt_rnr_rst)
+                        )
+                    )
+                ),
+                # If(pre_cq.sink.valid & ~pre_cq.sink.ready,
+                #     NextState("ERROR")
+                # )
+            )
+        )
+
+        # Dump all outstanding requests and received responses
+        fsm.act("ERROR",
+            If((qps[1].qp_state != LiteEthIBQP.ERROR) & (qps[1].qp_state != LiteEthIBQP.RESET),
+                NextValue(qps[1].local_error, 1)
+            ),
+            outstanding_requests.source.ready.eq(pre_cq.sink.ready),
+            outstanding_read_requests.source.ready.eq(pre_cq.sink.ready),
+            outstanding_requests_chooser.source.ready.eq(pre_cq.sink.ready),
+            pre_cq.sink.valid.eq(outstanding_requests_chooser.source.valid),
+            pre_cq.sink.status.eq(WC.Status.WR_FLUSH_ERR),
+            responses_fifo.source.ready.eq(1),
+            If(~outstanding_requests_chooser.source.valid &
+                ~responses_fifo.source.valid,
+                NextState("NEXT_WR")
+            )
+        )
+
+        # Resend
+        self.comb += [
+            If(outstanding_requests_chooser.source.choose,
+                outstanding_requests.source.connect(pending_resend.sink, omit={"valid", "ready", "psn", "va", "dma_len"}),
+            ).Else(
+                outstanding_read_requests.source.connect(pending_resend.sink, omit={"valid", "ready", "psn", "va", "dma_len"}),
+            ),
+            pending_resend.sink.va.eq(resend_starting_pos),
+            pending_resend.sink.dma_len.eq(resend_remaining_length),
+            pending_resend.sink.psn.eq(oldest_unacked_psn),
+            pending_resend.sink.valid.eq(resend_ask | (outstanding_timer.done & (retry_cnt != 0)))
+        ]
+
+        # Dump resend buffer on ERROR
+        self.comb += [
+            If(fsm.ongoing("ERROR"),
+                pending_resend.source.ready.eq(1)
+            ).Else(
+                pending_resend.source.connect(resend_source)
+            )
+        ]
+
+class LiteEthRDMARequesterRX(LiteXModule):
+    """
+                           ┌───────────┐
+                           │   sink    │
+    ┌──────────────────────┴─────┬─────┴─────────────────────────┐
+    │                            │                               │
+    │                            │                               │
+    │                            │                               │
+    │    ┌───────────────────────▼────────────────────────┐      │
+    │    │                                                │      │
+    │    │                                                │      │
+    │    │                RDMARequester                   │      │
+    │    │                 Validation                     │      │
+    │    │                                                │      │
+    │    │                                                │      │
+    │    └───▲─────┬────────────────────────────────┬─────┘      │
+    │        │     │                                │            │
+    │        │     │                                │            │
+    │  oldest│     │                                │            │
+    │ unacked│     │responses                       │            │
+    │     psn│     │                                │            │
+    │        │     │                                │data+params │
+    │        │     │                                │            │
+    │    ┌───┴─────▼─────┐                          │            │
+    │    │               │                     ┌────▼─────┐      │
+    │    │  RDMAContext  │                     │          │      │
+    │    │    Checker    │                     │ WaitPipe │      │
+    │    │               │                     │          │      │
+    │    └──────┬────────┘                     └──┬────┬──┘      │
+    │           │                    +1 on read   │    │         │
+    │           │completion       ┌───────────────┘    │data     │
+    │           │                 │  last or only      │         │
+    │      ┌────▼─────┐     ┌─────▼──────┐     ┌───────▼──┐      │
+    │      │          │     │    read    │     │          │      │
+    │      │  pre_cq  │     │ completion │     │  Memory  │      │
+    │      │          │     │    cnt     │     │          │      │
+    │      └────┬─────┘     └─────┬──────┘     └──────────┘      │
+    └───────────┼─────────────────┼──────────────────────────────┘
+                │                 │
+                └────────┬────────┘
+                      ┌──▼──┐
+                      │     │
+                      │ cq  │
+                      │     │
+                      └─────┘
+    """
+
+    def __init__(self, requester_tx, qps, cq, mrs, clk_freq, dw=8):
+        self.sink = sink = Endpoint(add_params(eth_rocev2_description(dw), [("header_only", 1), ("payload_length", PMTU_BITS + 1), ("validate", 1)]))
+
+        # # #
+
+        # Read (response) wait pipe
+        read_wait_pipe = WaitPipe(
+            layout = EndpointDescription(
+                payload_layout = [("data", dw)],
+                param_layout   = [("va", 64), ("l_key", 32), ("signal_cq", 1)]
+            ),
+            depth      = 16,
+            block_size = PMTU,
+            dw         = dw
+        )
+        self.submodules.read_wait_pipe = read_wait_pipe
+
+        # A completion queue that waits for read responses to be committed to memory,
+        # before actually moving CQEs to the CQ
+        # Theoretically, we could be waiting for a read request to complete and receive all the possible
+        # acknowledgements for the following packets (both acks and short reads)
+        pre_cq = SyncFIFO(eth_rocev2_cq_description(), MAX_OUTSTANDING, buffered=True)
+        self.submodules.pre_cq = pre_cq
+
+        # Counting completed (committed to memory) read requests
+        # There is no defined limit on read response packets, only on number of requests
+        read_completion_cnt = Signal(max=INITIATOR_DEPTH+1)
+        read_completion_inc = Signal()
+        read_completion_dec = Signal()
+
+        requester_validator = LiteEthRDMARequesterValidation(
+            read_wait_pipe = read_wait_pipe,
+            qps            = qps,
+            mrs            = mrs,
+            dw             = dw
+        )
+        self.submodules.requester_validator = requester_validator
+
+        context_checker = LiteEthRDMARequesterContextChecker(
+            qps      = qps,
+            pre_cq   = pre_cq,
+            clk_freq = clk_freq
+        )
+        self.submodules.context_checker = context_checker
+
+        ## Datapath
+        # Connect modules
+        self.comb += [
+            sink.connect(requester_validator.sink),
+
+            requester_validator.source.connect(context_checker.responses_sink),
+            requester_validator.oldest_unacked_psn.eq(context_checker.oldest_unacked_psn),
+            context_checker.timer_start.eq(requester_tx.timer_start),
+
+            context_checker.resend_source.connect(requester_tx.sink)
+        ]
+
+        # read_wait pipe -> memory
+        self.comb += [
+            If(read_wait_pipe.source.valid,
+                Case(read_wait_pipe.source.l_key, {
+                    Constant(mr.l_key, 32): [
+                        read_wait_pipe.source.connect(mr.writer.sink, keep={"valid", "ready", "last", "data"}),
+                        mr.writer.sink.va.eq(read_wait_pipe.source.va)
+                    ] for mr in mrs if MR_PERM.LOCAL_WRITE in mr.permissions
+                }),
+            ),
+            read_completion_inc.eq(
+                read_wait_pipe.source.valid &
+                read_wait_pipe.source.ready &
+                read_wait_pipe.source.last &
+                read_wait_pipe.source.signal_cq
+            )
+        ]
+
+        # Completion queue logic
+        self.comb += [
+            If(pre_cq.source.valid,
+                pre_cq.source.connect(cq.sink, omit={"valid", "ready"}),
+                If(pre_cq.source.opcode == WC.Opcode.RDMA_READ,
+                    If(read_completion_inc | (read_completion_cnt != 0),
+                        read_completion_dec.eq(1),
+                        pre_cq.source.connect(cq.sink, keep={"valid", "ready"})
+                    )
+                ).Else(
+                    pre_cq.source.connect(cq.sink, keep={"valid", "ready"})
+                )
+            )
+        ]
+
+        self.sync += [
+            read_completion_cnt.eq(read_completion_cnt + read_completion_inc - read_completion_dec)
+        ]

--- a/liteeth/core/rocev2/responder.py
+++ b/liteeth/core/rocev2/responder.py
@@ -1,0 +1,769 @@
+from liteeth.common import *
+
+from liteeth.core.rocev2.mr import PERM as MR_PERM
+from liteeth.core.rocev2.common import WaitPipe
+from liteeth.core.rocev2.qp import LiteEthIBQP
+from liteeth.core.rocev2.ack import ACK, NAK, RNR_NAK
+
+from litex.soc.interconnect.stream import Endpoint, Buffer, SyncFIFO
+
+# Consumes a read request and generates valid read responses by reading qp's memory region
+class LiteEthRDMAReadResponder(LiteXModule):
+    def __init__(self, qp, mrs, dw=8):
+        self.sink   = sink   = Endpoint(eth_rocev2_description(dw))
+        self.source = source = Endpoint(
+            add_params(
+                eth_rocev2_description(dw),
+                [("rq_last", 1), ("header_only", 1)]
+            )
+        )
+
+        # # #
+
+        mem_reader_sink   = Endpoint([("va", 64), ("len", bits_for(PMTU))])
+        mem_reader_source = Endpoint([("data", dw)])
+
+        msn      = Signal(24, reset_less=True)
+        p_key    = Signal(16, reset_less=True)
+        other_id = Signal(24, reset_less=True)
+
+        psn      = Signal(24, reset_less=True)
+        va       = Signal(64, reset_less=True)
+
+        # For First/Middle/Last/Only packet variations
+        first_packet = Signal()
+        # If there are more packets left to send after the current one
+        more_left = Signal()
+
+        # Number of PMTU-sized blocks that need to be sent
+        whole_blocks      = Signal(24)
+        whole_blocks_left = Signal(24)
+        remainder_bytes   = Signal(PMTU_BITS)
+        payload_length    = Signal(PMTU_BITS + 1)
+        header_length     = Signal(32)
+
+        # WaitPipe to fetch entire packet from RAM before send
+        # (MAC cannot be stopped after packet start and RAM reads in bursts)
+        read_wait_pipe = WaitPipe(
+            add_params(
+                eth_rocev2_description(dw),
+                [("rq_last", 1)]
+            ), 8, PMTU, discarding=False, dw=dw
+        )
+        self.submodules.read_wait_pipe = read_wait_pipe
+
+        self.comb += If(mem_reader_sink.valid | mem_reader_source.ready,
+            Case(sink.r_key, {
+                Constant(mr.r_key, 32): [
+                    mem_reader_sink.connect(mr.reader.sink),
+                    mr.reader.source.connect(mem_reader_source)]
+                for mr in mrs if MR_PERM.REMOTE_READ in mr.permissions
+            })
+        )
+
+        self.comb += [
+            remainder_bytes.eq(sink.dma_len[:PMTU_BITS]),
+            whole_blocks.eq(sink.dma_len[PMTU_BITS:])
+        ]
+        self.comb += more_left.eq(
+            ~((whole_blocks_left == 0) |
+              ((whole_blocks_left == 1) & (remainder_bytes == 0)))
+        )
+
+        self.comb += [
+            Case(Cat(more_left, first_packet), {
+                0b00: read_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_response_Last),
+                0b01: read_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_response_Middle),
+                0b10: read_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_response_Only),
+                0b11: read_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_response_First)
+            }),
+            If(whole_blocks_left != 0,
+                read_wait_pipe.sink.pad.eq(0),
+                payload_length.eq(PMTU)
+            ).Else(
+                read_wait_pipe.sink.pad.eq((0b100 - (remainder_bytes & 0b11))[:2]),
+                payload_length.eq(remainder_bytes)
+            ),
+            mem_reader_sink.len.eq(payload_length),
+
+            IBT_header_length(read_wait_pipe.sink.opcode, header_length),
+            read_wait_pipe.sink.length.eq(header_length + payload_length),
+
+            read_wait_pipe.sink.psn.eq(psn),
+            read_wait_pipe.sink.msn.eq(msn),
+
+            read_wait_pipe.sink.p_key.eq(p_key),
+            read_wait_pipe.sink.dest_qp.eq(other_id),
+
+            read_wait_pipe.source.connect(source),
+
+            mem_reader_sink.va.eq(va),
+        ]
+
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(sink.valid & ~read_wait_pipe.full,
+                NextValue(msn, qp.msn),
+                NextValue(p_key, qp.p_key),
+                NextValue(other_id, qp.other_id),
+
+                NextValue(psn, sink.psn),
+                NextValue(va, sink.va),
+                NextValue(whole_blocks_left, whole_blocks),
+                NextValue(first_packet, 1),
+                If(sink.dma_len != 0,
+                    NextValue(mem_reader_sink.valid, 1),
+                    NextState("READ")
+                ).Else(
+                    NextState("EMPTY")
+                )
+            )
+        )
+
+        fsm.act("READ",
+            If(mem_reader_sink.ready == 1, # Once the reader has consumed the request, we end it
+                NextValue(mem_reader_sink.valid, 0)
+            ),
+            mem_reader_source.connect(read_wait_pipe.sink, keep={"valid", "ready", "data", "last"}),
+
+            If(~more_left,
+                read_wait_pipe.sink.rq_last.eq(1)
+            ),
+
+            If(mem_reader_source.valid & mem_reader_source.last & read_wait_pipe.sink.ready,
+                read_wait_pipe.validate_sink.validate.eq(1),
+                NextValue(first_packet, 0),
+                If(more_left,
+                    NextValue(mem_reader_sink.valid, 1),
+                    NextValue(whole_blocks_left, whole_blocks_left - 1),
+                    NextValue(va, va + PMTU),
+                    NextValue(psn, psn + 1)
+                ).Else(
+                    NextValue(mem_reader_sink.valid, 0),
+                    # Consume read request
+                    sink.ready.eq(1),
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        fsm.act("EMPTY",
+            read_wait_pipe.sink.rq_last.eq(1),
+
+            read_wait_pipe.sink.valid.eq(1),
+            read_wait_pipe.sink.last.eq(1),
+            read_wait_pipe.sink.header_only.eq(1),
+            If(read_wait_pipe.sink.ready,
+                read_wait_pipe.validate_sink.validate.eq(1),
+                sink.ready.eq(1),
+                NextState("IDLE")
+            )
+        )
+
+class LiteEthRDMAResponderTX(LiteXModule):
+    def __init__(self, mad_tx, qps, mrs, dw=8):
+        self.ack_sink         = ack_sink         = Endpoint(eth_rocev2_description(dw))
+        self.read_sink        = read_sink        = Endpoint(eth_rocev2_description(dw))
+        self.resp_choose_sink = resp_choose_sink = Endpoint([("ack", 1)])
+
+        self.source = source = Endpoint(
+            add_params(
+                eth_rocev2_description(dw),
+                [("header_only", 1)]
+            )
+        )
+
+        # # #
+
+        ## Buffering sinks
+        # Buffer used to receive queued acks/naks
+        ack_buf         = Buffer(eth_rocev2_description(dw))
+        # Buffer used to receive queued RDMA read requests
+        read_buf        = Buffer(eth_rocev2_description(dw))
+        # Buffer used by responder to indicate order of acks/naks and RDMA read requests
+        resp_choose_buf = Buffer([("ack", 1)])
+
+        self.submodules.ack_buf         = ack_buf
+        self.submodules.read_buf        = read_buf
+        self.submodules.resp_choose_buf = resp_choose_buf
+
+        self.comb += [
+            ack_sink.connect(ack_buf.sink),
+            read_sink.connect(read_buf.sink),
+            resp_choose_sink.connect(resp_choose_buf.sink)
+        ]
+
+        ack_sink         = ack_buf.source
+        read_sink        = read_buf.source
+        resp_choose_sink = resp_choose_buf.source
+
+        ## Read responder
+        # Add module that will construct packet responses to read requests
+        read_responder = LiteEthRDMAReadResponder(qps[1], mrs, dw=dw)
+        self.submodules.read_responder = read_responder
+
+        # Read responder is always treating new requests
+        self.comb += read_sink.connect(read_responder.sink)
+
+        # Packet send logic
+        self.comb += [
+            source.tver.eq(0),
+            source.m.eq(0),
+            source.se.eq(0),
+            source.a.eq(0),
+
+            If(~resp_choose_sink.valid,
+                mad_tx.source.connect(source, keep={"valid", "ready", "data", "last"}),
+                source.opcode.eq(BTH_OPCODE.UD.SEND_Only),
+                source.p_key.eq(qps[0].p_key),
+                source.dest_qp.eq(1),
+                source.pad.eq(0b00),
+                source.psn.eq(qps[0].send_queue.psn),
+                source.q_key.eq(DEFAULT_CM_Q_Key),
+                source.src_qp.eq(1),
+                source.length.eq(
+                    IBT_get_header_length(BTH_OPCODE.UD.SEND_Only) +
+                    256
+                )
+            ).Else(
+                # Acks in the ack_fifo are ready to be sent
+                # Read requests need to be treated by the read_responder
+                # (read from memory, generate packets, etc.)
+                If(resp_choose_sink.ack,
+                    ack_sink.connect(source, keep={"valid", "ready", "opcode", "syndrome", "msn"}),
+                    # Acks have no payload
+                    source.header_only.eq(1),
+                    source.last.eq(1),
+
+                    source.pad.eq(0b00), # Acks have padding of 0
+                    Case(ack_sink.dest_qp, {qp.id : [
+                        source.p_key.eq(qp.p_key),
+                        source.dest_qp.eq(qp.other_id)
+                    ] for qp in qps}),
+                    source.psn.eq(ack_sink.psn),
+                    source.length.eq(
+                        IBT_get_header_length(BTH_OPCODE.RC.Acknowledge)
+                    )
+                ).Else(
+                    read_responder.source.connect(source, keep={
+                        "valid",
+                        "ready",
+                        "last",
+                        "data",
+                        "opcode",
+                        "pad",
+                        "psn",
+                        "va",
+                        "r_key",
+                        "dma_len",
+                        "msn",
+                        "p_key",
+                        "dest_qp",
+                        "header_only"
+                    }),
+                    source.length.eq(read_responder.source.length)
+                )
+            ),
+
+            If(source.valid & source.ready & source.last,
+                resp_choose_sink.ready.eq(resp_choose_sink.ack | read_responder.source.rq_last)
+            )
+        ]
+
+class LiteEthRDMAResponderRX(LiteXModule):
+    def __init__(self, responder_tx, mad_rx, qps, cq, mrs, dw=8):
+        self.sink = sink = Endpoint(
+            add_params(
+                eth_rocev2_description(dw),
+                [
+                    ("header_only", 1),
+                    ("payload_length", PMTU_BITS + 1),
+                    ("invalid_packet", 1),
+                    ("validate", 1),
+                    ("ip_address", 32)
+                ]
+            )
+        )
+
+        # # #
+
+        ## Piping messages for Responder_TX
+        # Pipe used to queue acks
+        ack_pipe         = SyncFIFO(eth_rocev2_description(dw), RESPONDER_RESOURCES, buffered=True)
+        # Pipe used by responder to enqueue pending RDMA read requests
+        read_pipe        = SyncFIFO(eth_rocev2_description(dw), RESPONDER_RESOURCES, buffered=True)
+        # Pipe used by responder to indicate order of acks/naks and read requests
+        resp_choose_pipe = SyncFIFO([("ack", 1)], RESPONDER_RESOURCES * 2, buffered=True)
+
+        self.submodules.ack_pipe         = ack_pipe
+        self.submodules.read_pipe        = read_pipe
+        self.submodules.resp_choose_pipe = resp_choose_pipe
+
+        self.comb += [
+            If(qps[1].qp_state != LiteEthIBQP.ERROR,
+                ack_pipe.source.connect(responder_tx.ack_sink),
+                read_pipe.source.connect(responder_tx.read_sink),
+                resp_choose_pipe.source.connect(responder_tx.resp_choose_sink)
+            ).Else(
+                ack_pipe.source.ready.eq(1),
+                read_pipe.source.ready.eq(1),
+                resp_choose_pipe.source.ready.eq(1)
+            )
+        ]
+
+        ack_source         = ack_pipe.sink
+        read_source        = read_pipe.sink
+        resp_choose_source = resp_choose_pipe.sink
+
+        self.comb += [
+            # Both the ack and read sinks should never be valid at the same time
+            resp_choose_source.valid.eq(ack_source.valid | read_source.valid),
+            resp_choose_source.ack.eq(ack_source.valid)
+        ]
+
+        ## Params to save sink parameters
+        params = Endpoint(
+            add_params(eth_rocev2_description(dw=dw), [
+                ("header_only", 1),
+                ("ip_address", 32)
+            ])
+        )
+        self.sync += sink.connect(params, omit={
+            "valid",
+            "ready",
+            "last",
+            "data",
+            "payload_length",
+            "invalid_packet",
+            "validate"
+        })
+
+        # Pre-completion queue
+        pre_cq = SyncFIFO(eth_rocev2_cq_description(), INITIATOR_DEPTH*2 + 0x10, buffered=True)
+        self.submodules.pre_cq = pre_cq
+
+        # Wait pipe
+        wait_pipe = WaitPipe(
+            layout = EndpointDescription(
+                payload_layout = [("data", dw)],
+                param_layout   = [
+                    ("conn_type", 2),
+                    ("dest_qp",   24),
+                    ("va",        64),
+                    ("mem_key",   32),
+                    ("send",      1),
+                    ("signal_cq", 1)
+                ]
+            ),
+            depth      = 16,
+            block_size = PMTU,
+            dw         = dw
+        )
+        self.submodules.wait_pipe = wait_pipe
+
+        qp_rcv_wire_next = Signal()
+        # Notify CM a message was received
+        self.sync += mad_rx.qp_rcv_wire.eq(qp_rcv_wire_next)
+
+        ## Memory location
+        self.current_mem_loc = current_mem_loc = Record([
+            ("va",       64, DIR_M_TO_S),
+            ("mem_key",  32, DIR_M_TO_S)
+        ], reset_less=True)
+
+        ## Reception logic
+        # Connection type and operation extracted from opcode
+        opcode_conn_type = Signal(3)
+        opcode_op        = Signal(5)
+
+        # Opcode decomposition
+        self.comb += Cat(opcode_op, opcode_conn_type).eq(params.opcode)
+
+        conn_type         = Signal(3,  reset_less=True)
+        msn               = Signal(24, reset_less=True)
+        msn_next          = Signal(24)
+        va_next           = Signal(64)
+        expected_psn      = Signal(24, reset_less=True)
+        expected_psn_next = Signal(24)
+        psn_jump          = Signal(24)
+
+        saved_mem_loc      = Record([
+            ("va",       64, DIR_M_TO_S),
+            ("mem_key",  32, DIR_M_TO_S)
+        ], reset_less=True)
+
+        # Extract qp parameters
+        init_dict = {
+            qp.id : [
+                msn.eq(qp.msn),
+                expected_psn.eq(qp.receive_queue.psn),
+                conn_type.eq(qp.conn_type),
+                qp.receive_queue.rdma_state.connect(saved_mem_loc, keep={"va", "mem_key"})
+            ] for qp in qps if qp.id.value != 1
+        }
+        init_dict[1] = {
+            msn.eq(qps[0].msn),
+            expected_psn.eq(qps[0].receive_queue.psn),
+            conn_type.eq(qps[0].conn_type),
+        }
+        init_dict["default"] = [
+            msn.eq(0),
+            expected_psn.eq(0),
+            conn_type.eq(0),
+            saved_mem_loc.va.eq(0),
+            saved_mem_loc.mem_key.eq(0)
+        ]
+        self.sync += [
+            If(sink.valid,
+                Case(sink.dest_qp, init_dict)
+            )
+        ]
+
+        # psn_jump (only useful for RDMA Read)
+        self.comb += [
+            If(params.dma_len == 0,
+                psn_jump.eq(1),
+            ).Else(
+                psn_jump.eq(params.dma_len[PMTU_BITS:] + (params.dma_len[:PMTU_BITS] != 0))
+            )
+        ]
+
+        self.comb += is_in_do(opcode_op, [
+            ([
+                BTH_OPCODE_OP.RDMA_READ_Request,
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Only,
+                BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+            ], [
+                current_mem_loc.va.eq(params.va),
+                current_mem_loc.mem_key.eq(params.r_key)
+            ]),
+            ([
+                BTH_OPCODE_OP.SEND_First,
+                BTH_OPCODE_OP.SEND_Only,
+                BTH_OPCODE_OP.SEND_Only_with_Immediate
+            ],
+            [
+                current_mem_loc.va.eq(qps[1].receive_queue.source.va),
+                current_mem_loc.mem_key.eq(qps[1].receive_queue.source.l_key)
+            ])
+        ], default=saved_mem_loc.connect(current_mem_loc, keep={"va", "mem_key"}))
+
+        ## Validation logic
+        # NAK validations
+        check_psn         = Signal()
+        valid_psn         = Signal()
+        duplicate         = Signal()
+        check_opcode_seq  = Signal()
+        valid_opcode_seq  = Signal()
+        valid_opcode      = Signal()
+        check_r_key_write = Signal()
+        check_r_key_read  = Signal()
+        valid_r_key       = Signal()
+
+        # NAK validations
+        self.comb += [
+            check_psn.eq(conn_type == QP_CONN_TYPE.RC),
+            valid_psn.eq(~check_psn | (params.psn == expected_psn)),
+            duplicate.eq(~((expected_psn - params.psn) >> 23) & (expected_psn != params.psn)),
+            check_opcode_seq.eq(conn_type == QP_CONN_TYPE.RC),
+            qps[1].op_seq_check_resp.opcode.eq(opcode_op),
+            valid_opcode_seq.eq(~check_opcode_seq | ~qps[1].op_seq_check_resp.invalid_sequence),
+            Case(conn_type, {
+                QP_CONN_TYPE.RC: is_in_flag(opcode_op, IBT_RC_OPS, valid_opcode),
+                QP_CONN_TYPE.UD:
+                    If(params.dest_qp != 1,
+                        is_in_flag(opcode_op, IBT_UD_OPS, valid_opcode)
+                    ).Else(
+                        valid_opcode.eq(opcode_op == BTH_OPCODE_OP.SEND_Only)
+                    ),
+                "default": valid_opcode.eq(0)
+            }),
+            If(params.dma_len != 0,
+                is_in_do(opcode_op, [
+                    ([
+                        BTH_OPCODE_OP.RDMA_WRITE_First,
+                        BTH_OPCODE_OP.RDMA_WRITE_Only,
+                        BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+                    ], check_r_key_write.eq(1))
+                ])
+            ), # o9-55
+            check_r_key_read.eq((opcode_op == BTH_OPCODE_OP.RDMA_READ_Request)
+            & (params.dma_len != 0)), # o9-55
+            valid_r_key.eq(
+                (~check_r_key_write |
+                    is_in(params.r_key, [
+                        Constant(mr.r_key, 32) for mr in mrs
+                        if MR_PERM.REMOTE_WRITE in mr.permissions
+                    ])
+                ) &
+                (~check_r_key_read  |
+                    is_in(params.r_key, [
+                        Constant(mr.r_key, 32) for mr in mrs
+                        if MR_PERM.REMOTE_READ in mr.permissions
+                    ])
+                )
+            )
+        ]
+
+        # MR boundary checks
+        check_memory = Signal()
+        valid_memory = Signal()
+
+        memory_under = Signal()
+        memory_over  = Signal()
+
+        check_r_key_write_bounds = Signal()
+        check_r_key_read_bounds  = Signal()
+        check_l_key_bounds       = Signal()
+        self.comb += [
+            check_memory.eq(sink.payload_length != 0),
+            valid_memory.eq(~check_memory | (~memory_under & ~memory_over)),
+            is_in_do(opcode_op, [
+                ([
+                    BTH_OPCODE_OP.RDMA_WRITE_First,
+                    BTH_OPCODE_OP.RDMA_WRITE_Middle,
+                    BTH_OPCODE_OP.RDMA_WRITE_Last,
+                    BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate,
+                    BTH_OPCODE_OP.RDMA_WRITE_Only,
+                    BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate,
+                ], check_r_key_write_bounds.eq(1)),
+                ([
+                    BTH_OPCODE_OP.RDMA_READ_Request
+                ], check_r_key_read_bounds.eq(1)),
+                ([
+                    BTH_OPCODE_OP.SEND_First,
+                    BTH_OPCODE_OP.SEND_Middle,
+                    BTH_OPCODE_OP.SEND_Last,
+                    BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                    BTH_OPCODE_OP.SEND_Only,
+                    BTH_OPCODE_OP.SEND_Only_with_Immediate
+                ], check_l_key_bounds.eq(1))
+            ])
+        ]
+
+        self.sync += [
+            If(check_r_key_write_bounds,
+                Case(current_mem_loc.mem_key, {
+                    mr.r_key: [
+                        memory_under.eq(current_mem_loc.va < mr.region_start),
+                        # We set greater or equal, because this is done synchronously on RECEIVE
+                        # And so the payload_length is the number of bytes written so far
+                        # Thus, one cycle before validate, payload_length will be one less than the actual size
+                        memory_over.eq(current_mem_loc.va + sink.payload_length >= mr.region_start + mr.region_size)
+                    ]
+                    for mr in mrs if MR_PERM.REMOTE_WRITE in mr.permissions
+                })
+            ).Elif(check_r_key_read_bounds,
+                Case(current_mem_loc.mem_key, {
+                    mr.r_key: [
+                        memory_under.eq(current_mem_loc.va < mr.region_start),
+                        memory_over.eq(sink.va + sink.dma_len > mr.region_start + mr.region_size)
+                    ]
+                    for mr in mrs if MR_PERM.REMOTE_READ in mr.permissions
+                })
+            ).Elif(check_l_key_bounds,
+                Case(current_mem_loc.mem_key, {
+                    mr.l_key: [
+                        memory_under.eq(current_mem_loc.va < mr.region_start),
+                        # We set greater or equal, because this is done synchronously on RECEIVE
+                        # And so the payload_length is the number of bytes written so far
+                        # Thus, one cycle before validate, payload_length will be one less than the actual size
+                        memory_over.eq(current_mem_loc.va + sink.payload_length >= mr.region_start + mr.region_size)
+                    ]
+                    for mr in mrs if MR_PERM.LOCAL_WRITE in mr.permissions
+                })
+            )
+        ]
+
+        rnr = Signal()
+        self.comb += rnr.eq(
+            ((
+                (~read_pipe.sink.ready) &
+                (opcode_op == BTH_OPCODE_OP.RDMA_READ_Request)
+            ) |
+            (
+                wait_pipe.full & ~params.header_only & ~duplicate
+            ))
+        )
+
+        self.fsm = fsm = FSM()
+        fsm.act("RECEIVE",
+            If(~sink.header_only,
+                sink.connect(wait_pipe.sink, keep={"valid", "ready", "last", "data"})
+            ).Else(
+                sink.ready.eq(1)
+            ),
+            If(sink.valid & sink.ready & sink.last,
+                NextState("VALIDATE")
+            )
+        )
+
+        valid_fields = Signal()
+        fsm.act("VALIDATE",
+            NextState("RECEIVE"),
+            wait_pipe.validate_sink.invalidate.eq(~params.header_only & ~wait_pipe.validate_sink.validate),
+            If(sink.valid,
+                If(sink.validate,
+                    current_mem_loc.connect(wait_pipe.sink, keep={"va", "mem_key"}),
+                    wait_pipe.sink.conn_type.eq(conn_type),
+                    wait_pipe.sink.dest_qp.eq(params.dest_qp),
+                    is_in_flag(opcode_op, [
+                        BTH_OPCODE_OP.SEND_First,
+                        BTH_OPCODE_OP.SEND_Middle,
+                        BTH_OPCODE_OP.SEND_Last,
+                        BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                        BTH_OPCODE_OP.SEND_Only,
+                        BTH_OPCODE_OP.SEND_Only_with_Immediate
+                    ], wait_pipe.sink.send),
+                    # Validation
+                    # Invalid or duplicate psn
+                    If(~valid_psn,
+                        If(~duplicate,
+                            NAK.emit(NAK.Code.PSN_Sequence_Error, params.dest_qp, msn, params.psn, ack_source, duplicate, qps)
+                        ).Else(
+                            valid_fields.eq(1)
+                        )
+                    ).Elif(~valid_opcode_seq | ~valid_opcode,
+                        NAK.emit(NAK.Code.Invalid_Request, params.dest_qp, msn, params.psn, ack_source, duplicate, qps)
+                    ).Elif(~valid_r_key | ((check_r_key_read | check_r_key_write) & ~valid_memory),
+                        NAK.emit(NAK.Code.Remote_Access_Error, params.dest_qp, msn, params.psn, ack_source, duplicate, qps)
+                    ).Elif(sink.invalid_packet,
+                        NAK.emit(NAK.Code.Invalid_Request, params.dest_qp, msn, params.psn, ack_source, duplicate, qps)
+                    ).Else(
+                        # Valid
+                        valid_fields.eq(1),
+                    )
+                )
+            # Else should never happen
+            ),
+            If(valid_fields,
+                If(opcode_op == BTH_OPCODE_OP.RDMA_READ_Request,
+                    params.connect(read_source, omit={"valid", "ready", "data", "header_only", "ip_address"}),
+                    read_source.valid.eq(read_pipe.sink.ready),
+                    expected_psn_next.eq(expected_psn + psn_jump)
+                ).Else(
+                    expected_psn_next.eq(expected_psn + 1),
+                ),
+                is_in_do(opcode_op, ([
+                    BTH_OPCODE_OP.SEND_First,
+                    BTH_OPCODE_OP.SEND_Middle,
+                    BTH_OPCODE_OP.RDMA_WRITE_First,
+                    BTH_OPCODE_OP.RDMA_WRITE_Middle
+                ], [
+                    msn_next.eq(msn),
+                    va_next.eq(current_mem_loc.va + PMTU),
+                ]), default=[
+                    msn_next.eq(msn + 1)
+                ]),
+
+                # QP update
+                Case(params.dest_qp, {qp.id : [
+                    NextValue(qp.nak_sent, 0),
+                ] for qp in qps[1:]}),
+                If((conn_type == QP_CONN_TYPE.RC) & (opcode_op != BTH_OPCODE_OP.RDMA_READ_Request) & (~rnr), # Read requests are ACKed with a read response
+                    ACK.emit(params.dest_qp, msn_next, params.psn, ack_source)
+                ),
+                If(~duplicate,
+                    If(~rnr,
+                        qp_rcv_wire_next.eq(1),
+                        wait_pipe.validate_sink.validate.eq(~params.header_only),
+
+                        # Completion queue
+                        If(opcode_conn_type == QP_CONN_TYPE.RC,
+                            is_in_flag(opcode_op, [
+                                BTH_OPCODE_OP.SEND_Last,
+                                BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                                BTH_OPCODE_OP.SEND_Only,
+                                BTH_OPCODE_OP.SEND_Only_with_Immediate
+                            ], pre_cq.sink.valid),
+                            # Consume work request
+                            qps[1].receive_queue.source.ready.eq(1)
+                        ),
+                        pre_cq.sink.status.eq(WC.Status.SUCCESS),
+                        is_in_do(opcode_op, [
+                        ([
+                            BTH_OPCODE_OP.SEND_Last,
+                            BTH_OPCODE_OP.SEND_Only
+                        ], [
+                            pre_cq.sink.opcode.eq(WC.Opcode.RECV),
+                            pre_cq.sink.w_immdt.eq(0)
+                        ]), ([
+                            BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                            BTH_OPCODE_OP.SEND_Only_with_Immediate
+                        ], [
+                            pre_cq.sink.opcode.eq(WC.Opcode.RECV_RDMA_WITH_IMM),
+                            pre_cq.sink.w_immdt.eq(1)
+                        ])]),
+                        pre_cq.sink.immdt.eq(params.immdt),
+                        pre_cq.sink.dma_len.eq(sink.payload_length),
+                        pre_cq.sink.qp_num.eq(sink.dest_qp),
+                        Case(params.dest_qp, {
+                            qp.id: pre_cq.sink.src_qp.eq(qp.other_id)
+                        for qp in qps}),
+                        wait_pipe.sink.signal_cq.eq(pre_cq.sink.valid),
+                        Case(params.dest_qp, {
+                            qp.id : [
+                                NextValue(qp.receive_queue.psn, expected_psn_next),
+                                NextValue(qp.msn, msn_next),
+                            ] + ([
+                                qp.op_seq_check_resp.update.eq(1),
+                                NextValue(qp.receive_queue.rdma_state.va, va_next),
+                                If(is_in(opcode_op, [BTH_OPCODE_OP.RDMA_WRITE_First, BTH_OPCODE_OP.SEND_First]),
+                                    NextValue(qp.receive_queue.rdma_state.mem_key, current_mem_loc.mem_key),
+                                )
+                            ] if qp.id.value != 1 else [
+                                # NOTE: Requests from different ip addresses must not come in quick succession
+                                # FIXME: Potential improvement: pass ip through pipeline to mad_tx
+                                NextValue(qp.ip_address, params.ip_address)
+                            ])
+                        for qp in qps}),
+                    ).Elif(conn_type == QP_CONN_TYPE.RC,
+                        RNR_NAK.emit(0b00001, sink.dest_qp, msn, sink.psn, ack_source, qps)
+                    )
+                )
+            )
+        )
+
+        ## Memory write
+        self.comb += [
+            Case(wait_pipe.source.conn_type, {
+            QP_CONN_TYPE.RC:
+                # Only connect when actually needed
+                If(wait_pipe.source.valid,
+                    If(wait_pipe.source.send,
+                        Case(wait_pipe.source.mem_key, {
+                            Constant(mr.l_key, 32): [
+                                wait_pipe.source.connect(mr.writer.sink, keep={"valid", "ready", "last", "data"}),
+                                mr.writer.sink.va.eq(wait_pipe.source.va)
+                            ]
+                            for mr in mrs if MR_PERM.LOCAL_WRITE in mr.permissions
+                        })
+                    ).Else(
+                        Case(wait_pipe.source.mem_key, {
+                            Constant(mr.r_key, 32): [
+                                wait_pipe.source.connect(mr.writer.sink, keep={"valid", "ready", "last", "data"}),
+                                mr.writer.sink.va.eq(wait_pipe.source.va)]
+                            for mr in mrs if MR_PERM.REMOTE_WRITE in mr.permissions
+                        })
+                    )
+                ),
+            QP_CONN_TYPE.UD:
+                If(wait_pipe.source.dest_qp == 1,
+                    wait_pipe.source.connect(mad_rx.sink, keep={"valid", "ready", "last", "data"})
+                ).Else(
+                    wait_pipe.source.ready.eq(1)
+                )
+            })
+        ]
+
+        self.comb += [
+            If(pre_cq.source.valid &
+                (
+                   (pre_cq.source.dma_len == 0) |
+                   (wait_pipe.source.valid & wait_pipe.source.last &
+                    wait_pipe.source.signal_cq)
+                ),
+                pre_cq.source.connect(cq.sink)
+            )
+        ]

--- a/liteeth/core/rocev2/responder.py
+++ b/liteeth/core/rocev2/responder.py
@@ -1,0 +1,794 @@
+from liteeth.common import *
+
+from liteeth.core.rocev2.mr import PERM as MR_PERM
+from liteeth.core.rocev2.common import WaitPipe
+from liteeth.core.rocev2.qp import LiteEthIBQP
+from liteeth.core.rocev2.ack import ACK, NAK, RNR_NAK
+
+from litex.soc.interconnect.stream import Endpoint, Buffer, SyncFIFO
+
+# Consumes a read request and generates valid read responses by reading qp's memory region
+class LiteEthRDMAReadResponder(LiteXModule):
+    def __init__(self, qp, mrs, dw=8):
+        self.sink   = sink   = Endpoint(eth_rocev2_description(dw))
+        self.source = source = Endpoint(
+            add_params(
+                eth_rocev2_description(dw),
+                [("rq_last", 1), ("header_only", 1)]
+            )
+        )
+
+        # # #
+
+        mem_reader_sink   = Endpoint([("va", 64), ("len", bits_for(PMTU))])
+        mem_reader_source = Endpoint([("data", dw)])
+
+        msn      = Signal(24, reset_less=True)
+        p_key    = Signal(16, reset_less=True)
+        other_id = Signal(24, reset_less=True)
+
+        psn      = Signal(24, reset_less=True)
+        va       = Signal(64, reset_less=True)
+
+        # For First/Middle/Last/Only packet variations
+        first_packet = Signal()
+        # If there are more packets left to send after the current one
+        more_left = Signal()
+
+        # Number of PMTU-sized blocks that need to be sent
+        whole_blocks      = Signal(32 - PMTU_BITS)
+        whole_blocks_left = Signal().like(whole_blocks)
+        remainder_bytes   = Signal(PMTU_BITS)
+        payload_length    = Signal(PMTU_BITS + 1)
+        header_length     = Signal(32)
+
+        # WaitPipe to fetch entire packet from RAM before send
+        # (MAC cannot be stopped after packet start and RAM reads in bursts)
+        read_wait_pipe = WaitPipe(
+            layout = add_params(
+                description = eth_rocev2_description(dw),
+                params      = [("rq_last", 1)]
+            ),
+            depth      = 4,
+            block_size = PMTU,
+            discarding = False,
+            dw         = dw
+        )
+        self.submodules.read_wait_pipe = read_wait_pipe
+
+        self.comb += If(mem_reader_sink.valid | mem_reader_source.ready,
+            Case(sink.r_key, {
+                Constant(mr.r_key, 32): [
+                    mem_reader_sink.connect(mr.reader.sink),
+                    mr.reader.source.connect(mem_reader_source)]
+                for mr in mrs if MR_PERM.REMOTE_READ in mr.permissions
+            })
+        )
+
+        self.comb += [
+            remainder_bytes.eq(sink.dma_len[:PMTU_BITS]),
+            whole_blocks.eq(sink.dma_len[PMTU_BITS:])
+        ]
+        self.comb += more_left.eq(
+            ~((whole_blocks_left == 0) |
+              ((whole_blocks_left == 1) & (remainder_bytes == 0)))
+        )
+
+        self.comb += [
+            Case(Cat(more_left, first_packet), {
+                0b00: read_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_response_Last),
+                0b01: read_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_response_Middle),
+                0b10: read_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_response_Only),
+                0b11: read_wait_pipe.sink.opcode.eq(BTH_OPCODE.RC.RDMA_READ_response_First)
+            }),
+            If(whole_blocks_left != 0,
+                read_wait_pipe.sink.pad.eq(0),
+                payload_length.eq(PMTU)
+            ).Else(
+                read_wait_pipe.sink.pad.eq((0b100 - (remainder_bytes & 0b11))[:2]),
+                payload_length.eq(remainder_bytes)
+            ),
+            mem_reader_sink.len.eq(payload_length),
+
+            IBT_header_length(read_wait_pipe.sink.opcode, header_length),
+            read_wait_pipe.sink.length.eq(header_length + payload_length),
+
+            read_wait_pipe.sink.psn.eq(psn),
+            read_wait_pipe.sink.msn.eq(msn),
+
+            read_wait_pipe.sink.p_key.eq(p_key),
+            read_wait_pipe.sink.dest_qp.eq(other_id),
+
+            read_wait_pipe.source.connect(source),
+
+            mem_reader_sink.va.eq(va),
+        ]
+
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(sink.valid & ~read_wait_pipe.full,
+                NextValue(msn, qp.msn),
+                NextValue(p_key, qp.p_key),
+                NextValue(other_id, qp.other_id),
+
+                NextValue(psn, sink.psn),
+                NextValue(va, sink.va),
+                NextValue(whole_blocks_left, whole_blocks),
+                NextValue(first_packet, 1),
+                If(sink.dma_len != 0,
+                    NextValue(mem_reader_sink.valid, 1),
+                    NextState("READ")
+                ).Else(
+                    NextState("EMPTY")
+                )
+            )
+        )
+
+        fsm.act("READ",
+            If(mem_reader_sink.ready == 1, # Once the reader has consumed the request, we end it
+                NextValue(mem_reader_sink.valid, 0)
+            ),
+            mem_reader_source.connect(read_wait_pipe.sink, keep={"valid", "ready", "data", "last"}),
+
+            If(~more_left,
+                read_wait_pipe.sink.rq_last.eq(1)
+            ),
+
+            If(mem_reader_source.valid & mem_reader_source.last & read_wait_pipe.sink.ready,
+                read_wait_pipe.validate_sink.validate.eq(1),
+                NextValue(first_packet, 0),
+                If(more_left,
+                    NextValue(mem_reader_sink.valid, 1),
+                    NextValue(whole_blocks_left, whole_blocks_left - 1),
+                    NextValue(va, va + PMTU),
+                    NextValue(psn, psn + 1)
+                ).Else(
+                    NextValue(mem_reader_sink.valid, 0),
+                    # Consume read request
+                    sink.ready.eq(1),
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        fsm.act("EMPTY",
+            read_wait_pipe.sink.rq_last.eq(1),
+
+            read_wait_pipe.sink.valid.eq(1),
+            read_wait_pipe.sink.last.eq(1),
+            read_wait_pipe.sink.header_only.eq(1),
+            If(read_wait_pipe.sink.ready,
+                read_wait_pipe.validate_sink.validate.eq(1),
+                sink.ready.eq(1),
+                NextState("IDLE")
+            )
+        )
+
+class LiteEthRDMAResponderTX(LiteXModule):
+    def __init__(self, mad_tx, qps, mrs, dw=8):
+        self.ack_sink         = ack_sink         = Endpoint(eth_rocev2_description(dw))
+        self.read_sink        = read_sink        = Endpoint(eth_rocev2_description(dw))
+        self.resp_choose_sink = resp_choose_sink = Endpoint([("ack", 1)])
+
+        self.source = source = Endpoint(
+            add_params(
+                eth_rocev2_description(dw),
+                [("header_only", 1)]
+            )
+        )
+
+        # # #
+
+        ## Buffering sinks
+        # Buffer used to receive queued acks/naks
+        ack_buf         = Buffer(eth_rocev2_description(dw))
+        # Buffer used to receive queued RDMA read requests
+        read_buf        = Buffer(eth_rocev2_description(dw))
+        # Buffer used by responder to indicate order of acks/naks and RDMA read requests
+        resp_choose_buf = Buffer([("ack", 1)])
+
+        self.submodules.ack_buf         = ack_buf
+        self.submodules.read_buf        = read_buf
+        self.submodules.resp_choose_buf = resp_choose_buf
+
+        self.comb += [
+            ack_sink.connect(ack_buf.sink),
+            read_sink.connect(read_buf.sink),
+            resp_choose_sink.connect(resp_choose_buf.sink)
+        ]
+
+        ack_sink         = ack_buf.source
+        read_sink        = read_buf.source
+        resp_choose_sink = resp_choose_buf.source
+
+        ## Read responder
+        # Add module that will construct packet responses to read requests
+        read_responder = LiteEthRDMAReadResponder(qps[1], mrs, dw=dw)
+        self.submodules.read_responder = read_responder
+
+        # Read responder is always treating new requests
+        self.comb += read_sink.connect(read_responder.sink)
+
+        # Packet send logic
+        self.comb += [
+            source.tver.eq(0),
+            source.m.eq(0),
+            source.se.eq(0),
+            source.a.eq(0),
+
+            If(~resp_choose_sink.valid,
+                mad_tx.source.connect(source, keep={"valid", "ready", "data", "last"}),
+                source.opcode.eq(BTH_OPCODE.UD.SEND_Only),
+                source.p_key.eq(qps[0].p_key),
+                source.dest_qp.eq(1),
+                source.pad.eq(0b00),
+                source.psn.eq(qps[0].send_queue.psn),
+                source.q_key.eq(DEFAULT_CM_Q_Key),
+                source.src_qp.eq(1),
+                source.length.eq(
+                    IBT_get_header_length(BTH_OPCODE.UD.SEND_Only) +
+                    256
+                )
+            ).Else(
+                # Acks in the ack_fifo are ready to be sent
+                # Read requests need to be treated by the read_responder
+                # (read from memory, generate packets, etc.)
+                If(resp_choose_sink.ack,
+                    ack_sink.connect(source, keep={"valid", "ready", "opcode", "syndrome", "msn"}),
+                    # Acks have no payload
+                    source.header_only.eq(1),
+                    source.last.eq(1),
+
+                    source.pad.eq(0b00), # Acks have padding of 0
+                    Case(ack_sink.dest_qp, {qp.id : [
+                        source.p_key.eq(qp.p_key),
+                        source.dest_qp.eq(qp.other_id)
+                    ] for qp in qps}),
+                    source.psn.eq(ack_sink.psn),
+                    source.length.eq(
+                        IBT_get_header_length(BTH_OPCODE.RC.Acknowledge)
+                    )
+                ).Else(
+                    read_responder.source.connect(source, keep={
+                        "valid",
+                        "ready",
+                        "last",
+                        "data",
+                        "opcode",
+                        "pad",
+                        "psn",
+                        "va",
+                        "r_key",
+                        "dma_len",
+                        "msn",
+                        "p_key",
+                        "dest_qp",
+                        "header_only"
+                    }),
+                    source.length.eq(read_responder.source.length)
+                )
+            ),
+
+            If(source.valid & source.ready & source.last,
+                resp_choose_sink.ready.eq(resp_choose_sink.ack | read_responder.source.rq_last)
+            )
+        ]
+
+class LiteEthRDMAResponderRX(LiteXModule):
+    def __init__(self, responder_tx, mad_rx, qps, cq, mrs, dw=8):
+        self.sink = sink = Endpoint(
+            add_params(
+                eth_rocev2_description(dw),
+                [
+                    ("header_only", 1),
+                    ("payload_length", PMTU_BITS + 1),
+                    ("invalid_packet", 1),
+                    ("validate", 1),
+                    ("ip_address", 32)
+                ]
+            )
+        )
+
+        # # #
+
+        ## Piping messages for Responder_TX
+        # Pipe used to queue acks
+        ack_pipe         = SyncFIFO(eth_rocev2_description(dw), RESPONDER_RESOURCES, buffered=True)
+        # Pipe used by responder to enqueue pending RDMA read requests
+        read_pipe        = SyncFIFO(eth_rocev2_description(dw), RESPONDER_RESOURCES, buffered=True)
+        # Pipe used by responder to indicate order of acks/naks and read requests
+        resp_choose_pipe = SyncFIFO([("ack", 1)], RESPONDER_RESOURCES * 2, buffered=True)
+
+        self.submodules.ack_pipe         = ack_pipe
+        self.submodules.read_pipe        = read_pipe
+        self.submodules.resp_choose_pipe = resp_choose_pipe
+
+        self.comb += [
+            If(qps[1].qp_state != LiteEthIBQP.ERROR,
+                ack_pipe.source.connect(responder_tx.ack_sink),
+                read_pipe.source.connect(responder_tx.read_sink),
+                resp_choose_pipe.source.connect(responder_tx.resp_choose_sink)
+            ).Else(
+                ack_pipe.source.ready.eq(1),
+                read_pipe.source.ready.eq(1),
+                resp_choose_pipe.source.ready.eq(1)
+            )
+        ]
+
+        ack_source         = ack_pipe.sink
+        read_source        = read_pipe.sink
+        resp_choose_source = resp_choose_pipe.sink
+
+        self.comb += [
+            # Both the ack and read sinks should never be valid at the same time
+            resp_choose_source.valid.eq(ack_source.valid | read_source.valid),
+            resp_choose_source.ack.eq(ack_source.valid)
+        ]
+
+        ## Params to save sink parameters
+        params = Endpoint(
+            add_params(eth_rocev2_description(dw=dw), [
+                ("header_only", 1),
+                ("ip_address", 32)
+            ])
+        )
+        self.sync += sink.connect(params, omit={
+            "valid",
+            "ready",
+            "last",
+            "data",
+            "payload_length",
+            "invalid_packet",
+            "validate"
+        })
+
+        # Pre-completion queue
+        pre_cq = SyncFIFO(eth_rocev2_cq_description(), RESPONDER_RESOURCES * 2 + 0x10, buffered=True)
+        self.submodules.pre_cq = pre_cq
+
+        # Wait pipe to receive requests before the icrc check
+        request_wait_pipe = WaitPipe(
+            layout = EndpointDescription(
+                payload_layout = [("data", dw)],
+                param_layout   = [
+                    ("conn_type", 2),
+                    ("dest_qp",   24),
+                    ("va",        64),
+                    ("mem_key",   32),
+                    ("send",      1),
+                    ("signal_cq", 1)
+                ]
+            ),
+            depth      = 16,
+            block_size = PMTU,
+            dw         = dw
+        )
+        self.submodules.wait_pipe = request_wait_pipe
+
+        qp_rcv_wire_next = Signal()
+        # Notify CM a message was received
+        self.sync += mad_rx.qp_rcv_wire.eq(qp_rcv_wire_next)
+
+        ## Memory location
+        self.current_mem_loc = current_mem_loc = Record([
+            ("va",       64, DIR_M_TO_S),
+            ("mem_key",  32, DIR_M_TO_S)
+        ], reset_less=True)
+
+        ## Reception logic
+        # Connection type and operation extracted from opcode
+        opcode_conn_type = Signal(3)
+        opcode_op        = Signal(5)
+
+        # Opcode decomposition
+        self.comb += Cat(opcode_op, opcode_conn_type).eq(params.opcode)
+
+        conn_type         = Signal(3,  reset_less=True)
+        msn               = Signal(24, reset_less=True)
+        msn_next          = Signal(24)
+        va_next           = Signal(64)
+        expected_psn      = Signal(24, reset_less=True)
+        expected_psn_next = Signal(24)
+        psn_jump          = Signal(24)
+
+        saved_mem_loc      = Record([
+            ("va",       64, DIR_M_TO_S),
+            ("mem_key",  32, DIR_M_TO_S)
+        ], reset_less=True)
+
+        # Extract qp parameters
+        init_dict = {
+            qp.id : [
+                msn.eq(qp.msn),
+                expected_psn.eq(qp.receive_queue.psn),
+                conn_type.eq(qp.conn_type),
+                qp.receive_queue.rdma_state.connect(saved_mem_loc, keep={"va", "mem_key"})
+            ] for qp in qps if qp.id.value != 1
+        }
+        init_dict[1] = {
+            msn.eq(qps[0].msn),
+            expected_psn.eq(qps[0].receive_queue.psn),
+            conn_type.eq(qps[0].conn_type),
+        }
+        init_dict["default"] = [
+            msn.eq(0),
+            expected_psn.eq(0),
+            conn_type.eq(0),
+            saved_mem_loc.va.eq(0),
+            saved_mem_loc.mem_key.eq(0)
+        ]
+        self.sync += [
+            If(sink.valid,
+                Case(sink.dest_qp, init_dict)
+            )
+        ]
+
+        # psn_jump (only useful for RDMA Read)
+        self.comb += [
+            If(params.dma_len == 0,
+                psn_jump.eq(1),
+            ).Else(
+                psn_jump.eq(params.dma_len[PMTU_BITS:] + (params.dma_len[:PMTU_BITS] != 0))
+            )
+        ]
+
+        self.comb += is_in_do(opcode_op, [
+            ([
+                BTH_OPCODE_OP.RDMA_READ_Request,
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Only,
+                BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+            ], [
+                current_mem_loc.va.eq(params.va),
+                current_mem_loc.mem_key.eq(params.r_key)
+            ]),
+            ([
+                BTH_OPCODE_OP.SEND_First,
+                BTH_OPCODE_OP.SEND_Only,
+                BTH_OPCODE_OP.SEND_Only_with_Immediate
+            ],
+            [
+                current_mem_loc.va.eq(qps[1].receive_queue.source.va),
+                current_mem_loc.mem_key.eq(qps[1].receive_queue.source.l_key)
+            ])
+        ], default=saved_mem_loc.connect(current_mem_loc, keep={"va", "mem_key"}))
+
+        ## Validation logic
+        # NAK validations
+        check_psn         = Signal()
+        valid_psn         = Signal()
+        duplicate         = Signal()
+        check_opcode_seq  = Signal()
+        valid_opcode_seq  = Signal()
+        valid_opcode      = Signal()
+        check_r_key_write = Signal()
+        check_r_key_read  = Signal()
+        valid_r_key       = Signal()
+
+        # NAK validations
+        self.comb += [
+            check_psn.eq(conn_type == QP_CONN_TYPE.RC),
+            valid_psn.eq(~check_psn | (params.psn == expected_psn)),
+            duplicate.eq(~((expected_psn - params.psn) >> 23) & (expected_psn != params.psn)),
+            check_opcode_seq.eq(conn_type == QP_CONN_TYPE.RC),
+            qps[1].op_seq_check_resp.opcode.eq(opcode_op),
+            valid_opcode_seq.eq(~check_opcode_seq | ~qps[1].op_seq_check_resp.invalid_sequence),
+            Case(conn_type, {
+                QP_CONN_TYPE.RC: is_in_flag(opcode_op, IBT_RC_OPS, valid_opcode),
+                QP_CONN_TYPE.UD:
+                    If(params.dest_qp != 1,
+                        is_in_flag(opcode_op, IBT_UD_OPS, valid_opcode)
+                    ).Else(
+                        valid_opcode.eq(opcode_op == BTH_OPCODE_OP.SEND_Only)
+                    ),
+                "default": valid_opcode.eq(0)
+            }),
+            If(params.dma_len != 0,
+                is_in_do(opcode_op, [
+                    ([
+                        BTH_OPCODE_OP.RDMA_WRITE_First,
+                        BTH_OPCODE_OP.RDMA_WRITE_Only,
+                        BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+                    ], check_r_key_write.eq(1))
+                ])
+            ), # o9-55
+            check_r_key_read.eq((opcode_op == BTH_OPCODE_OP.RDMA_READ_Request)
+            & (params.dma_len != 0)), # o9-55
+            valid_r_key.eq(
+                (~check_r_key_write |
+                    is_in(params.r_key, [
+                        Constant(mr.r_key, 32) for mr in mrs
+                        if MR_PERM.REMOTE_WRITE in mr.permissions
+                    ])
+                ) &
+                (~check_r_key_read  |
+                    is_in(params.r_key, [
+                        Constant(mr.r_key, 32) for mr in mrs
+                        if MR_PERM.REMOTE_READ in mr.permissions
+                    ])
+                )
+            )
+        ]
+
+        # MR boundary checks
+        check_memory = Signal()
+        valid_memory = Signal()
+
+        memory_under = Signal()
+        memory_over  = Signal()
+
+        check_r_key_write_bounds = Signal()
+        check_r_key_read_bounds  = Signal()
+        check_l_key_bounds       = Signal()
+        self.comb += [
+            check_memory.eq(sink.payload_length != 0),
+            valid_memory.eq(~check_memory | (~memory_under & ~memory_over)),
+            is_in_do(opcode_op, [
+                ([
+                    BTH_OPCODE_OP.RDMA_WRITE_First,
+                    BTH_OPCODE_OP.RDMA_WRITE_Middle,
+                    BTH_OPCODE_OP.RDMA_WRITE_Last,
+                    BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate,
+                    BTH_OPCODE_OP.RDMA_WRITE_Only,
+                    BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate,
+                ], check_r_key_write_bounds.eq(1)),
+                ([
+                    BTH_OPCODE_OP.RDMA_READ_Request
+                ], check_r_key_read_bounds.eq(1)),
+                ([
+                    BTH_OPCODE_OP.SEND_First,
+                    BTH_OPCODE_OP.SEND_Middle,
+                    BTH_OPCODE_OP.SEND_Last,
+                    BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                    BTH_OPCODE_OP.SEND_Only,
+                    BTH_OPCODE_OP.SEND_Only_with_Immediate
+                ], check_l_key_bounds.eq(1))
+            ])
+        ]
+
+        self.sync += [
+            If(check_r_key_write_bounds,
+                Case(current_mem_loc.mem_key, {
+                    mr.r_key: [
+                        memory_under.eq(current_mem_loc.va < mr.region_start),
+                        # We set greater or equal, because this is done synchronously on RECEIVE
+                        # And so the payload_length is the number of bytes written so far
+                        # Thus, one cycle before validate, payload_length will be one less than the actual size
+                        memory_over.eq(current_mem_loc.va + sink.payload_length >= mr.region_start + mr.region_size)
+                    ]
+                    for mr in mrs if MR_PERM.REMOTE_WRITE in mr.permissions
+                })
+            ).Elif(check_r_key_read_bounds,
+                Case(current_mem_loc.mem_key, {
+                    mr.r_key: [
+                        memory_under.eq(current_mem_loc.va < mr.region_start),
+                        memory_over.eq(sink.va + sink.dma_len > mr.region_start + mr.region_size)
+                    ]
+                    for mr in mrs if MR_PERM.REMOTE_READ in mr.permissions
+                })
+            ).Elif(check_l_key_bounds,
+                Case(current_mem_loc.mem_key, {
+                    mr.l_key: [
+                        memory_under.eq(current_mem_loc.va < mr.region_start),
+                        # We set greater or equal, because this is done synchronously on RECEIVE
+                        # And so the payload_length is the number of bytes written so far
+                        # Thus, one cycle before validate, payload_length will be one less than the actual size
+                        memory_over.eq(current_mem_loc.va + sink.payload_length >= mr.region_start + mr.region_size)
+                    ]
+                    for mr in mrs if MR_PERM.LOCAL_WRITE in mr.permissions
+                })
+            )
+        ]
+
+        rnr = Signal()
+        self.comb += rnr.eq(
+            (( # Cannot receive read request
+                (opcode_op == BTH_OPCODE_OP.RDMA_READ_Request) &
+                ~read_pipe.sink.ready
+            ) |
+            ( # No receive wr posted for request
+                (opcode_conn_type == QP_CONN_TYPE.RC) &
+                is_in(opcode_op, [
+                    BTH_OPCODE_OP.SEND_First,
+                    BTH_OPCODE_OP.SEND_Only,
+                    BTH_OPCODE_OP.SEND_Only_with_Immediate
+                ]) &
+                ~qps[1].receive_queue.source.valid
+            ) |
+            ( # Cannot push to wait_pipe
+                request_wait_pipe.full & ~params.header_only & ~duplicate
+            ))
+        )
+
+        self.fsm = fsm = FSM()
+        fsm.act("RECEIVE",
+            If(~sink.header_only,
+                sink.connect(request_wait_pipe.sink, keep={"valid", "ready", "last", "data"})
+            ).Else(
+                sink.ready.eq(1)
+            ),
+            If(sink.valid & sink.ready & sink.last,
+                NextState("VALIDATE")
+            )
+        )
+
+        valid_fields = Signal()
+        fsm.act("VALIDATE",
+            NextState("RECEIVE"),
+            request_wait_pipe.validate_sink.invalidate.eq(~params.header_only & ~request_wait_pipe.validate_sink.validate),
+            If(sink.valid,
+                If(sink.validate,
+                    current_mem_loc.connect(request_wait_pipe.sink, keep={"va", "mem_key"}),
+                    request_wait_pipe.sink.conn_type.eq(conn_type),
+                    request_wait_pipe.sink.dest_qp.eq(params.dest_qp),
+                    is_in_flag(opcode_op, [
+                        BTH_OPCODE_OP.SEND_First,
+                        BTH_OPCODE_OP.SEND_Middle,
+                        BTH_OPCODE_OP.SEND_Last,
+                        BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                        BTH_OPCODE_OP.SEND_Only,
+                        BTH_OPCODE_OP.SEND_Only_with_Immediate
+                    ], request_wait_pipe.sink.send),
+                    # Validation
+                    # Invalid or duplicate psn
+                    If(~valid_psn,
+                        If(~duplicate,
+                            NAK.emit(NAK.Code.PSN_Sequence_Error, params.dest_qp, msn, params.psn, ack_source, duplicate, qps)
+                        ).Else(
+                            valid_fields.eq(1)
+                        )
+                    ).Elif(~valid_opcode_seq | ~valid_opcode,
+                        NAK.emit(NAK.Code.Invalid_Request, params.dest_qp, msn, params.psn, ack_source, duplicate, qps)
+                    ).Elif(~valid_r_key | ((check_r_key_read | check_r_key_write) & ~valid_memory),
+                        NAK.emit(NAK.Code.Remote_Access_Error, params.dest_qp, msn, params.psn, ack_source, duplicate, qps)
+                    ).Elif(sink.invalid_packet,
+                        NAK.emit(NAK.Code.Invalid_Request, params.dest_qp, msn, params.psn, ack_source, duplicate, qps)
+                    ).Else(
+                        # Valid
+                        valid_fields.eq(1),
+                    )
+                )
+            # Else should never happen
+            ),
+            If(valid_fields,
+                If(opcode_op == BTH_OPCODE_OP.RDMA_READ_Request,
+                    params.connect(read_source, omit={"valid", "ready", "data", "header_only", "ip_address"}),
+                    read_source.valid.eq(read_pipe.sink.ready),
+                    expected_psn_next.eq(expected_psn + psn_jump)
+                ).Else(
+                    expected_psn_next.eq(expected_psn + 1),
+                ),
+                is_in_do(opcode_op, ([
+                    BTH_OPCODE_OP.SEND_First,
+                    BTH_OPCODE_OP.SEND_Middle,
+                    BTH_OPCODE_OP.RDMA_WRITE_First,
+                    BTH_OPCODE_OP.RDMA_WRITE_Middle
+                ], [
+                    msn_next.eq(msn),
+                    va_next.eq(current_mem_loc.va + PMTU),
+                ]), default=[
+                    msn_next.eq(msn + 1)
+                ]),
+
+                # QP update
+                Case(params.dest_qp, {qp.id : [
+                    NextValue(qp.nak_sent, 0),
+                ] for qp in qps[1:]}),
+                If((conn_type == QP_CONN_TYPE.RC) & (opcode_op != BTH_OPCODE_OP.RDMA_READ_Request) & (~rnr), # Read requests are ACKed with a read response
+                    ACK.emit(params.dest_qp, msn_next, params.psn, ack_source)
+                ),
+                If(~duplicate,
+                    If(~rnr,
+                        qp_rcv_wire_next.eq(1),
+                        request_wait_pipe.validate_sink.validate.eq(~params.header_only),
+
+                        # Completion queue
+                        If(opcode_conn_type == QP_CONN_TYPE.RC,
+                            is_in_flag(opcode_op, [
+                                BTH_OPCODE_OP.SEND_Last,
+                                BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                                BTH_OPCODE_OP.SEND_Only,
+                                BTH_OPCODE_OP.SEND_Only_with_Immediate,
+                                BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate,
+                                BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+                            ], pre_cq.sink.valid),
+                            # Consume work request
+                            If(is_in(opcode_op, [
+                                BTH_OPCODE_OP.SEND_First,
+                                BTH_OPCODE_OP.SEND_Only,
+                                BTH_OPCODE_OP.SEND_Only_with_Immediate
+                            ]),
+                                qps[1].receive_queue.source.ready.eq(1)
+                            )
+                        ),
+                        pre_cq.sink.status.eq(WC.Status.SUCCESS),
+                        is_in_do(opcode_op, [
+                        ([
+                            BTH_OPCODE_OP.SEND_Last,
+                            BTH_OPCODE_OP.SEND_Only
+                        ], [
+                            pre_cq.sink.opcode.eq(WC.Opcode.RECV),
+                            pre_cq.sink.w_immdt.eq(0)
+                        ]), ([
+                            BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                            BTH_OPCODE_OP.SEND_Only_with_Immediate,
+                            BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate,
+                            BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+                        ], [
+                            pre_cq.sink.opcode.eq(WC.Opcode.RECV_RDMA_WITH_IMM),
+                            pre_cq.sink.w_immdt.eq(1)
+                        ])]),
+                        pre_cq.sink.immdt.eq(params.immdt),
+                        pre_cq.sink.dma_len.eq(sink.payload_length),
+                        pre_cq.sink.qp_num.eq(sink.dest_qp),
+                        Case(params.dest_qp, {
+                            qp.id: pre_cq.sink.src_qp.eq(qp.other_id)
+                        for qp in qps}),
+                        request_wait_pipe.sink.signal_cq.eq(pre_cq.sink.valid),
+
+                        # Save values to qp
+                        Case(params.dest_qp, {
+                            qp.id : [
+                                NextValue(qp.receive_queue.psn, expected_psn_next),
+                                NextValue(qp.msn, msn_next),
+                            ] + ([
+                                qp.op_seq_check_resp.update.eq(1),
+                                NextValue(qp.receive_queue.rdma_state.va, va_next),
+                                If(is_in(opcode_op, [BTH_OPCODE_OP.RDMA_WRITE_First, BTH_OPCODE_OP.SEND_First]),
+                                    NextValue(qp.receive_queue.rdma_state.mem_key, current_mem_loc.mem_key),
+                                )
+                            ] if qp.id.value != 1 else [
+                                # NOTE: Requests from different ip addresses must not come in quick succession
+                                # FIXME: Potential improvement: pass ip through pipeline to mad_tx
+                                NextValue(qp.ip_address, params.ip_address)
+                            ])
+                        for qp in qps}),
+                    ).Elif(conn_type == QP_CONN_TYPE.RC,
+                        RNR_NAK.emit(0b00001, sink.dest_qp, msn, sink.psn, ack_source, qps)
+                    )
+                )
+            )
+        )
+
+        ## Memory write
+        self.comb += [
+            Case(request_wait_pipe.source.conn_type, {
+            QP_CONN_TYPE.RC:
+                # Only connect when actually needed
+                If(request_wait_pipe.source.valid,
+                    If(request_wait_pipe.source.send,
+                        Case(request_wait_pipe.source.mem_key, {
+                            Constant(mr.l_key, 32): [
+                                request_wait_pipe.source.connect(mr.writer.sink, keep={"valid", "ready", "last", "data"}),
+                                mr.writer.sink.va.eq(request_wait_pipe.source.va)
+                            ]
+                            for mr in mrs if MR_PERM.LOCAL_WRITE in mr.permissions
+                        })
+                    ).Else(
+                        Case(request_wait_pipe.source.mem_key, {
+                            Constant(mr.r_key, 32): [
+                                request_wait_pipe.source.connect(mr.writer.sink, keep={"valid", "ready", "last", "data"}),
+                                mr.writer.sink.va.eq(request_wait_pipe.source.va)]
+                            for mr in mrs if MR_PERM.REMOTE_WRITE in mr.permissions
+                        })
+                    )
+                ),
+            QP_CONN_TYPE.UD:
+                If(request_wait_pipe.source.dest_qp == 1,
+                    request_wait_pipe.source.connect(mad_rx.sink, keep={"valid", "ready", "last", "data"})
+                ).Else(
+                    request_wait_pipe.source.ready.eq(1)
+                )
+            })
+        ]
+
+        self.comb += [
+            If(pre_cq.source.valid &
+                (
+                   (pre_cq.source.dma_len == 0) |
+                   (request_wait_pipe.source.valid & request_wait_pipe.source.last &
+                    request_wait_pipe.source.signal_cq)
+                ),
+                pre_cq.source.connect(cq.sink)
+            )
+        ]

--- a/liteeth/core/rocev2/rocev2.py
+++ b/liteeth/core/rocev2/rocev2.py
@@ -1,0 +1,476 @@
+from litex.gen import *
+
+from litex.soc.interconnect import stream
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Buffer
+
+from liteeth.core.rocev2.common import *
+from liteeth.core.rocev2.mad_cm import LiteEthIBMAD
+from liteeth.core.rocev2 import pad, icrc
+from liteeth.core.rocev2.qp import LiteEthIBSpecialQP, LiteEthIBQP, LiteEthCQ
+
+from liteeth.core.rocev2.requester import LiteEthRDMARequesterTX, LiteEthRDMARequesterRX
+from liteeth.core.rocev2.responder import LiteEthRDMAResponderTX, LiteEthRDMAResponderRX
+
+# ROCEv2 TX ----------------------------------------------------------------------------------------
+
+class LiteEthIBTransportPacketizer(VariablePacketizer):
+    def __init__(self, dw=8):
+        VariablePacketizer.__init__(self,
+            eth_rocev2_description(dw),
+            eth_udp_user_description(dw),
+            IBT_headers,
+            IBT_opmap
+        )
+
+class LiteEthIBTransportTX(LiteXModule):
+    def __init__(self, ip, mad_tx, qps, mrs, with_crc=True, buffered_out=True, dw=8):
+        self.source = source = Endpoint(eth_udp_user_description(dw))
+
+        self.enable = enable = Signal()
+
+        self.responder = responder = LiteEthRDMAResponderTX(mad_tx, qps, mrs, dw=dw)
+        self.requester = requester = LiteEthRDMARequesterTX(qps[1], mrs, dw=dw)
+
+        # # #
+
+        # Add ICRC at the end of messages
+        if with_crc:
+            self.tx_crc = tx_crc = icrc.LiteEthInfinibandICRCInserter(
+                listen_description = eth_mac_description(dw),
+                description        = eth_udp_user_description(dw)
+            )
+            self.comb += [
+                ip.tx.source.connect(tx_crc.calculator_sink, keep={"valid", "data", "last"}),
+                # We listen passively to the output of ip, so no control of ready
+                # (we don't use connect for it)
+                tx_crc.calculator_sink.ready.eq(ip.tx.source.ready),
+            ]
+            self.comb += tx_crc.source.connect(source)
+            source = tx_crc.sink
+
+        # The lower layers, once ready, have to pipe the entire data through without interruptions
+        # Otherwise, the packet on the wire would have holes
+        # We use this fact to cut timing
+        if buffered_out:
+            buff_out = Buffer(eth_udp_user_description(dw), pipe_ready=True)
+            self.submodules.buff_out = buff_out
+            self.comb += buff_out.source.connect(source)
+            source = buff_out.sink
+
+        pad_ins = pad.LiteEthIBTPaddingInserter(dw)
+        self.submodules.pad_ins = pad_ins
+
+        # Packetizer
+        self.packetizer = packetizer = LiteEthIBTransportPacketizer(dw=dw)
+
+        ip_address = Signal(32)
+        choose_responder = Signal()
+        choose_responder_next = Signal()
+        self.fsm = fsm = FSM()
+        fsm.act("IDLE",
+            If(qps[1].qp_state == LiteEthIBQP.ERROR,
+                NextState("ERROR")
+            ).Else(
+                NextState("SEND"),
+                If(responder.source.valid & requester.source.valid,
+                    choose_responder_next.eq(~choose_responder),
+                ).Elif(responder.source.valid,
+                    choose_responder_next.eq(1)
+                ).Elif(requester.source.valid,
+                    choose_responder_next.eq(0)
+                ).Else(
+                    NextState("IDLE")
+                ),
+                If(choose_responder_next,
+                    If(responder.source.dest_qp == 1,
+                        NextValue(ip_address, qps[0].ip_address)
+                    ).Else(
+                        NextValue(ip_address, qps[1].ip_address)
+                    )
+                ).Else(
+                    If(requester.source.dest_qp == 1,
+                        NextValue(ip_address, qps[0].ip_address)
+                    ).Else(
+                        NextValue(ip_address, qps[1].ip_address)
+                    )
+                ),
+                NextValue(choose_responder, choose_responder_next)
+            )
+        )
+
+        fsm.act("SEND",
+            If(choose_responder,
+                responder.source.connect(pad_ins.sink)
+            ).Else(
+                requester.source.connect(pad_ins.sink)
+            ),
+
+            If(source.valid & source.ready & source.last,
+                NextState("IDLE")
+            )
+        )
+
+        fsm.act("ERROR",
+            responder.source.ready.eq(1),
+            requester.source.ready.eq(1),
+            If(qps[1].qp_state != LiteEthIBQP.ERROR,
+                NextState("IDLE")
+            )
+        )
+
+        # Data-Path.
+        self.comb += [
+            pad_ins.source.connect(packetizer.sink, omit={"length"}),
+
+            source.valid.eq(packetizer.source.valid & enable),
+            packetizer.source.connect(source, keep={"ready", "last", "data"}),
+            source.length.eq(pad_ins.source.length + (0x4 if with_crc else 0)),
+            source.dst_port.eq(ROCEV2_PORT),
+            # TODO: Needs to be changed if we add more qps
+            source.ip_address.eq(ip_address)
+        ]
+
+# RX/TX interface ----------------------------------------------------------------------------------
+
+# ROCEv2 RX ----------------------------------------------------------------------------------------
+
+class LiteEthIBTransportDepacketizer(VariableDepacketizer):
+    def __init__(self, dw=8):
+        VariableDepacketizer.__init__(self,
+            eth_udp_user_description(dw),
+            eth_rocev2_description(dw),
+            IBT_headers,
+            IBT_opmap
+        )
+
+class LiteEthIBTransportValidation(LiteXModule):
+    def __init__(self, qps, dw=8):
+        self.sink   = sink   = Endpoint(
+            add_params(eth_rocev2_description(dw), [
+                ("header_only", 1)
+            ])
+        )
+        self.source = source = Endpoint(
+            add_params(eth_rocev2_description(dw), [
+                ("header_only", 1),
+                ("payload_length", PMTU_BITS + 1),
+                ("invalid_packet", 1),
+                ("validate", 1),
+                ("response", 1)
+            ])
+        )
+
+        self.pad_error = pad_error = Signal()
+        self.valid_crc = valid_crc = Signal()
+
+        ## Params to save sink parameters
+        params = Endpoint(add_params(eth_rocev2_description(dw=dw), [("header_only", 1)]))
+        self.sync += sink.connect(params, omit={"valid", "ready", "last", "data", "error"})
+
+        ### Opcode splitting
+        # Connection type and operation extracted from opcode
+        opcode_conn_type = Signal(3)
+        opcode_op        = Signal(5)
+        # Opcode decomposition (must be always correct, not only for validation)
+        self.comb += [
+            If(sink.valid,
+                Cat(opcode_op, opcode_conn_type).eq(sink.opcode)
+            ).Else(
+                Cat(opcode_op, opcode_conn_type).eq(params.opcode)
+            )
+        ]
+
+        ### Signals linked to the qp's state
+        conn_type         = Signal(3, reset_less=True)
+        qp_state          = Signal(max=5, reset_less=True)
+        p_key             = Signal(16, reset_less=True)
+        # Extract qp parameters
+        init_dict = {
+            qp.id : [
+                p_key.eq(qp.p_key),
+                conn_type.eq(qp.conn_type),
+                qp_state.eq(qp.qp_state)
+            ] for qp in qps[1:]
+        }
+        init_dict[1] = [
+            p_key.eq(qps[0].p_key),
+            conn_type.eq(qps[0].conn_type),
+        ]
+        init_dict["default"] = [
+            p_key.eq(0),
+            conn_type.eq(0)
+        ]
+        self.sync += [
+            If(sink.valid,
+                Case(sink.dest_qp, init_dict)
+            )
+        ]
+
+        ### Packet payload/integrity checks
+        # Packet header checks
+        # Silent drop validations
+        valid_tver  = Signal()
+        valid_dest  = Signal()
+        valid_p_key = Signal()
+        check_q_key = Signal()
+        valid_q_key = Signal()
+
+        self.comb += [
+            valid_tver.eq(params.tver == 0),
+            valid_dest.eq(
+                (is_in(params.dest_qp, [qp.id for qp in qps])) & # QP exists
+                ((params.dest_qp != 1) & (is_in(qp_state, [LiteEthIBQP.RTR, LiteEthIBQP.RTS])) |
+                (params.dest_qp == 1)) & # QP is in correct state
+                (opcode_conn_type == conn_type) # Requested conn_type is correct for this QP
+            ),
+            valid_p_key.eq(params.p_key == p_key),
+            check_q_key.eq(params.dest_qp == 1),
+            valid_q_key.eq(~check_q_key | (params.q_key == DEFAULT_CM_Q_Key))
+        ]
+
+        # Payload validations
+        valid_padding = Signal()
+        self.comb += valid_padding.eq(~pad_error)
+
+        expect_full_packet  = Signal()
+        expect_empty_packet = Signal()
+        no_empty_packet     = Signal()
+
+        self.comb += [
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.SEND_First,
+                BTH_OPCODE_OP.SEND_Middle,
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Middle,
+                BTH_OPCODE_OP.RDMA_READ_response_First,
+                BTH_OPCODE_OP.RDMA_READ_response_Middle
+            ], expect_full_packet),
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.SEND_Last,
+                BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                BTH_OPCODE_OP.RDMA_WRITE_Last,
+                BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate,
+                BTH_OPCODE_OP.RDMA_READ_response_Last
+            ], no_empty_packet),
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.RDMA_READ_Request,
+                BTH_OPCODE_OP.Acknowledge
+            ], expect_empty_packet, case=False)
+        ]
+
+        # Misc validations
+        check_dma_len  = Signal()
+        check_zero_pad = Signal()
+        self.comb += [
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Only,
+                BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate,
+                BTH_OPCODE_OP.RDMA_READ_Request
+            ], check_dma_len),
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.SEND_First,
+                BTH_OPCODE_OP.SEND_Middle,
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Middle
+            ], check_zero_pad)
+        ]
+
+        # Payload validations
+        payload_length = Signal(PMTU_BITS + 1)
+        valid_payload = Signal()
+        self.comb += valid_payload.eq(
+            (valid_padding) &
+            (payload_length <= PMTU) &
+            (~expect_empty_packet | (payload_length == 0)) &
+            (~expect_full_packet | (payload_length == PMTU)) &
+            (~no_empty_packet | (payload_length != 0))
+        )
+
+        # Validate header, context, packet and ICRC
+        valid_headers = Signal()
+        valid_packet = Signal()
+        valid_icrc = Signal()
+        self.comb += [
+            valid_headers.eq(
+                valid_tver &
+                valid_dest &
+                valid_p_key &
+                valid_q_key
+                #    valid_syndrome,
+            ),
+            valid_packet.eq(
+                valid_payload &
+                (~check_zero_pad | (params.pad == 0b00)) &
+                (~check_dma_len | (params.dma_len <= 2**31))
+            ),
+            valid_icrc.eq(valid_crc)
+        ]
+
+        ### Request indicator
+        # Whether the receiver is receiving a request or a response to our request
+        self.comb += [
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.RDMA_READ_response_First,
+                BTH_OPCODE_OP.RDMA_READ_response_Middle,
+                BTH_OPCODE_OP.RDMA_READ_response_Last,
+                BTH_OPCODE_OP.RDMA_READ_response_Only,
+                BTH_OPCODE_OP.Acknowledge
+            ], source.response)
+        ]
+
+        self.comb += source.payload_length.eq(payload_length)
+
+        # Control-Path (FSM).
+        self.fsm = fsm = FSM(reset_state="RECEIVE")
+        # Full packet reception is performed here
+        fsm.act("RECEIVE",
+            sink.connect(source, omit={"payload_length", "invalid_packet", "validate", "response"}),
+            If(sink.valid & sink.ready,
+                If(~sink.header_only,
+                    NextValue(payload_length, payload_length + 1),
+                ),
+                If(sink.last,
+                    NextState("VALIDATE")
+                )
+            )
+        )
+
+        # Checks are performed here
+        fsm.act("VALIDATE",
+            source.valid.eq(1),
+            params.connect(source, omit={
+                "valid",
+                "ready",
+                "payload_length",
+                "invalid_packet",
+                "validate",
+                "response"
+            }),
+            NextValue(payload_length, 0),
+            NextState("RECEIVE"),
+
+            If(valid_headers & valid_icrc,
+                If(~valid_packet,
+                    source.invalid_packet.eq(1)
+                ).Else(
+                    source.validate.eq(1)
+                )
+            )
+        )
+
+class LiteEthIBTransportRX(LiteXModule):
+    def __init__(self, ip, tx, mad_rx, qps, cq, mrs, clk_freq, with_crc=True, check_crc=True, buffered_in=True, dw=8):
+        self.sink   = sink   = Endpoint(eth_udp_user_description(dw))
+
+        # # #
+
+        if check_crc:
+            assert with_crc
+
+        pipeline_mods = [sink]
+
+        ### Data-Path.
+        # ICRC
+        if with_crc:
+            self.rx_crc = rx_crc = icrc.LiteEthInfinibandICRCChecker(
+                listen_description = eth_mac_description(dw),
+                description        = eth_udp_user_description(dw)
+            )
+
+            self.comb += [
+                ip.rx.sink.connect(rx_crc.calculator_sink, keep={"valid", "data", "last"}),
+                # We listen passively to the output of ip,
+                # so no control of ready (we don't use connect for it)
+                rx_crc.calculator_sink.ready.eq(ip.rx.sink.ready)
+            ]
+
+            pipeline_mods.append(rx_crc)
+
+        if buffered_in:
+            buff_in = Buffer(eth_udp_user_description(dw), pipe_ready=True)
+            self.submodules.buff_in = buff_in
+            pipeline_mods.append(buff_in)
+
+        # Depacketizer.
+        self.depacketizer = depacketizer = LiteEthIBTransportDepacketizer(dw=dw)
+        pipeline_mods.append(depacketizer)
+
+        # Padding remover
+        pad_rem = pad.LiteEthIBTPaddingRemover(dw)
+        self.submodules.pad_rem = pad_rem
+        pipeline_mods.append(pad_rem)
+
+        # Validation of packet integrity and correctness for generic packets (requests or responses)
+        pack_validation = LiteEthIBTransportValidation(qps, dw)
+        self.submodules.pack_validation = pack_validation
+        pipeline_mods.append(pack_validation)
+
+        # Connections outside the pipeline
+        self.comb += [
+            pack_validation.pad_error.eq(pad_rem.error),
+            pack_validation.valid_crc.eq(rx_crc.valid_crc if check_crc else 1)
+        ]
+
+        pipeline = stream.Pipeline(*pipeline_mods)
+        self.submodules.pipeline = pipeline
+        source = pipeline.source
+
+        # Responder and requester
+        responder = LiteEthRDMAResponderRX(tx.responder, mad_rx, qps, cq, mrs, dw=dw)
+        requester = LiteEthRDMARequesterRX(tx.requester, qps, cq, mrs, clk_freq, dw=dw)
+        self.submodules.responder = responder
+        self.submodules.requester = requester
+
+        # Dispatch validation output
+        self.comb += [
+            If(pipeline.source.response,
+                source.connect(requester.sink, omit={"response", "invalid_packet"})
+            ).Else(
+                source.connect(responder.sink, omit={"response"}),
+                responder.sink.ip_address.eq(sink.ip_address)
+            )
+        ]
+
+# ROCEv2 RX + TX -----------------------------------------------------------------------------------
+class LiteEthIBTransport(LiteXModule):
+    def __init__(self, ip, udp, mrs, clk_freq, dw=8):
+        self.cq = cq = LiteEthCQ(depth=0x10)
+
+        self.qp = qp = LiteEthIBQP(qp_id=0xdeaded)
+
+        special_qp = LiteEthIBSpecialQP()
+        self.submodules.special_qp = special_qp
+
+        self.qps = qps = [special_qp, qp]
+
+        self.mad = mad = LiteEthIBMAD(qps, clk_freq, dw=dw)
+
+        self.tx = tx = LiteEthIBTransportTX(
+            ip           = ip,
+            mad_tx       = mad.tx,
+            qps          = qps,
+            mrs          = mrs,
+            with_crc     = True,
+            buffered_out = True,
+        )
+        self.rx = rx = LiteEthIBTransportRX(
+            ip        = ip,
+            tx        = tx,
+            mad_rx    = mad.rx,
+            qps       = qps,
+            cq        = cq,
+            clk_freq  = clk_freq,
+            mrs       = mrs,
+            with_crc  = True,
+            check_crc = False
+        )
+
+        self.udp_port = udp_port = udp.crossbar.get_port(ROCEV2_PORT, dw)
+        self.comb += [
+            tx.source.connect(udp_port.sink),
+            udp_port.source.connect(rx.sink)
+        ]

--- a/liteeth/core/rocev2/rocev2.py
+++ b/liteeth/core/rocev2/rocev2.py
@@ -1,0 +1,502 @@
+from litex.gen import *
+
+from litex.soc.interconnect import stream
+
+from liteeth.common import *
+
+from litex.soc.interconnect.stream import Buffer
+
+from liteeth.core.rocev2.common import *
+from liteeth.core.rocev2.mad_cm import LiteEthIBMAD
+from liteeth.core.rocev2 import pad, icrc
+from liteeth.core.rocev2.qp import LiteEthIBSpecialQP, LiteEthIBQP
+from liteeth.core.rocev2.cq import LiteEthCQ
+
+from liteeth.core.rocev2.requester import LiteEthRDMARequesterTX, LiteEthRDMARequesterRX
+from liteeth.core.rocev2.responder import LiteEthRDMAResponderTX, LiteEthRDMAResponderRX
+
+# ROCEv2 TX ----------------------------------------------------------------------------------------
+
+class LiteEthIBTransportPacketizer(VariablePacketizer):
+    def __init__(self, dw=8):
+        VariablePacketizer.__init__(self,
+            eth_rocev2_description(dw),
+            eth_udp_user_description(dw),
+            IBT_headers,
+            IBT_opmap
+        )
+
+@ResetInserter()
+class LiteEthIBTransportTX(LiteXModule):
+    def __init__(self, ip, mad_tx, qps, mrs, with_crc=True, buffered_out=True, dw=8):
+        self.source = source = Endpoint(eth_udp_user_description(dw))
+
+        self.enable = enable = Signal()
+
+        self.responder = responder = LiteEthRDMAResponderTX(mad_tx, qps, mrs, dw=dw)
+        self.requester = requester = LiteEthRDMARequesterTX(qps[1], mrs, dw=dw)
+
+        # # #
+
+        # Add ICRC at the end of messages
+        if with_crc:
+            self.tx_crc = tx_crc = icrc.LiteEthInfinibandICRCInserter(
+                listen_description = eth_mac_description(dw),
+                description        = eth_udp_user_description(dw)
+            )
+            self.comb += [
+                ip.tx.source.connect(tx_crc.calculator_sink, keep={"valid", "data", "last"}),
+                # We listen passively to the output of ip, so no control of ready
+                # (we don't use connect for it)
+                tx_crc.calculator_sink.ready.eq(ip.tx.source.ready),
+            ]
+            self.comb += tx_crc.source.connect(source)
+            source = tx_crc.sink
+
+        # The lower layers, once ready, have to pipe the entire data through without interruptions
+        # Otherwise, the packet on the wire would have holes
+        # We use this fact to cut timing
+        if buffered_out:
+            buff_out = Buffer(eth_udp_user_description(dw), pipe_ready=True)
+            self.submodules.buff_out = buff_out
+            self.comb += buff_out.source.connect(source)
+            source = buff_out.sink
+
+        pad_ins = pad.LiteEthIBTPaddingInserter(dw)
+        self.submodules.pad_ins = pad_ins
+
+        # Packetizer
+        self.packetizer = packetizer = LiteEthIBTransportPacketizer(dw=dw)
+
+        ip_address = Signal(32)
+        choose_responder = Signal()
+        choose_responder_next = Signal()
+        self.fsm = fsm = FSM()
+        fsm.act("IDLE",
+            If((choose_responder_next & (
+                    (responder.source.dest_qp == 1) |
+                    is_in(qps[1].qp_state, [LiteEthIBQP.RTR, LiteEthIBQP.RTS])
+                )) | (~choose_responder_next & (
+                    (requester.source.dest_qp == 1) |
+                    (qps[1].qp_state == LiteEthIBQP.RTS)
+                )),
+                NextState("SEND")
+            ).Else(
+                NextState("DUMP")
+            ),
+            If(responder.source.valid & requester.source.valid,
+                choose_responder_next.eq(~choose_responder),
+            ).Elif(responder.source.valid,
+                choose_responder_next.eq(1)
+            ).Elif(requester.source.valid,
+                choose_responder_next.eq(0)
+            ).Else(
+                NextState("IDLE")
+            ),
+            If(choose_responder_next,
+                If(responder.source.dest_qp == 1,
+                    NextValue(ip_address, qps[0].ip_address)
+                ).Else(
+                    NextValue(ip_address, qps[1].ip_address)
+                )
+            ).Else(
+                If(requester.source.dest_qp == 1,
+                    NextValue(ip_address, qps[0].ip_address)
+                ).Else(
+                    NextValue(ip_address, qps[1].ip_address)
+                )
+            ),
+            NextValue(choose_responder, choose_responder_next)
+        )
+
+        fsm.act("SEND",
+            If(choose_responder,
+                responder.source.connect(pad_ins.sink)
+            ).Else(
+                requester.source.connect(pad_ins.sink)
+            ),
+
+            If(source.valid & source.ready & source.last,
+                NextState("IDLE")
+            )
+        )
+
+        fsm.act("DUMP",
+            If(choose_responder,
+                responder.source.ready.eq(1),
+                If(responder.source.valid & responder.source.last,
+                    NextState("IDLE")
+                )
+            ).Else(
+                requester.source.ready.eq(1),
+                If(requester.source.valid & requester.source.last,
+                    NextState("IDLE")
+                )
+            )
+        )
+
+        # Data-Path.
+        self.comb += [
+            pad_ins.source.connect(packetizer.sink, omit={"length"}),
+
+            source.valid.eq(packetizer.source.valid & enable),
+            packetizer.source.connect(source, keep={"ready", "last", "data"}),
+            source.length.eq(pad_ins.source.length + (0x4 if with_crc else 0)),
+            source.dst_port.eq(ROCEV2_PORT),
+            # TODO: Needs to be changed if we add more qps
+            source.ip_address.eq(ip_address)
+        ]
+
+# RX/TX interface ----------------------------------------------------------------------------------
+
+# ROCEv2 RX ----------------------------------------------------------------------------------------
+
+class LiteEthIBTransportDepacketizer(VariableDepacketizer):
+    def __init__(self, dw=8):
+        VariableDepacketizer.__init__(self,
+            eth_udp_user_description(dw),
+            eth_rocev2_description(dw),
+            IBT_headers,
+            IBT_opmap
+        )
+
+class LiteEthIBTransportValidation(LiteXModule):
+    def __init__(self, qps, dw=8):
+        self.sink   = sink   = Endpoint(
+            add_params(eth_rocev2_description(dw), [
+                ("header_only", 1)
+            ])
+        )
+        self.source = source = Endpoint(
+            add_params(eth_rocev2_description(dw), [
+                ("header_only", 1),
+                ("payload_length", PMTU_BITS + 1),
+                ("invalid_packet", 1),
+                ("validate", 1),
+                ("response", 1)
+            ])
+        )
+
+        self.pad_error = pad_error = Signal()
+        self.valid_crc = valid_crc = Signal()
+
+        ## Params to save sink parameters
+        params = Endpoint(add_params(eth_rocev2_description(dw=dw), [("header_only", 1)]))
+        self.sync += sink.connect(params, omit={"valid", "ready", "last", "data", "error"})
+
+        ### Opcode splitting
+        # Connection type and operation extracted from opcode
+        opcode_conn_type = Signal(3)
+        opcode_op        = Signal(5)
+        # Opcode decomposition (must be always correct, not only for validation)
+        self.comb += [
+            If(sink.valid,
+                Cat(opcode_op, opcode_conn_type).eq(sink.opcode)
+            ).Else(
+                Cat(opcode_op, opcode_conn_type).eq(params.opcode)
+            )
+        ]
+
+        ### Signals linked to the qp's state
+        conn_type         = Signal(3, reset_less=True)
+        qp_state          = Signal(max=5, reset_less=True)
+        p_key             = Signal(16, reset_less=True)
+        # Extract qp parameters
+        init_dict = {
+            qp.id : [
+                p_key.eq(qp.p_key),
+                conn_type.eq(qp.conn_type),
+                qp_state.eq(qp.qp_state)
+            ] for qp in qps[1:]
+        }
+        init_dict[1] = [
+            p_key.eq(qps[0].p_key),
+            conn_type.eq(qps[0].conn_type),
+        ]
+        init_dict["default"] = [
+            p_key.eq(0),
+            conn_type.eq(0)
+        ]
+        self.sync += [
+            If(sink.valid,
+                Case(sink.dest_qp, init_dict)
+            )
+        ]
+
+        ### Packet payload/integrity checks
+        # Packet header checks
+        # Silent drop validations
+        valid_tver  = Signal()
+        valid_dest  = Signal()
+        valid_p_key = Signal()
+        check_q_key = Signal()
+        valid_q_key = Signal()
+
+        self.comb += [
+            valid_tver.eq(params.tver == 0),
+            valid_dest.eq(
+                (is_in(params.dest_qp, [qp.id for qp in qps])) & # QP exists
+                ((params.dest_qp != 1) & (is_in(qp_state, [LiteEthIBQP.RTR, LiteEthIBQP.RTS])) |
+                (params.dest_qp == 1)) & # QP is in correct state
+                (opcode_conn_type == conn_type) # Requested conn_type is correct for this QP
+            ),
+            valid_p_key.eq(params.p_key == p_key),
+            check_q_key.eq(params.dest_qp == 1),
+            valid_q_key.eq(~check_q_key | (params.q_key == DEFAULT_CM_Q_Key))
+        ]
+
+        # Payload validations
+        valid_padding = Signal()
+        self.comb += valid_padding.eq(~pad_error)
+
+        expect_full_packet  = Signal()
+        expect_empty_packet = Signal()
+        no_empty_packet     = Signal()
+
+        self.comb += [
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.SEND_First,
+                BTH_OPCODE_OP.SEND_Middle,
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Middle,
+                BTH_OPCODE_OP.RDMA_READ_response_First,
+                BTH_OPCODE_OP.RDMA_READ_response_Middle
+            ], expect_full_packet),
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.SEND_Last,
+                BTH_OPCODE_OP.SEND_Last_with_Immediate,
+                BTH_OPCODE_OP.RDMA_WRITE_Last,
+                BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate,
+                BTH_OPCODE_OP.RDMA_READ_response_Last
+            ], no_empty_packet),
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.RDMA_READ_Request,
+                BTH_OPCODE_OP.Acknowledge
+            ], expect_empty_packet, case=False)
+        ]
+
+        # Misc validations
+        check_dma_len  = Signal()
+        check_zero_pad = Signal()
+        self.comb += [
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Only,
+                BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate,
+                BTH_OPCODE_OP.RDMA_READ_Request
+            ], check_dma_len),
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.SEND_First,
+                BTH_OPCODE_OP.SEND_Middle,
+                BTH_OPCODE_OP.RDMA_WRITE_First,
+                BTH_OPCODE_OP.RDMA_WRITE_Middle
+            ], check_zero_pad)
+        ]
+
+        # Payload validations
+        payload_length = Signal(PMTU_BITS + 1)
+        valid_payload = Signal()
+        self.comb += valid_payload.eq(
+            (valid_padding) &
+            (payload_length <= PMTU) &
+            (~expect_empty_packet | (payload_length == 0)) &
+            (~expect_full_packet | (payload_length == PMTU)) &
+            (~no_empty_packet | (payload_length != 0))
+        )
+
+        # Validate header, context, packet and ICRC
+        valid_headers = Signal()
+        valid_packet = Signal()
+        valid_icrc = Signal()
+        self.comb += [
+            valid_headers.eq(
+                valid_tver &
+                valid_dest &
+                valid_p_key &
+                valid_q_key
+                #    valid_syndrome,
+            ),
+            valid_packet.eq(
+                valid_payload &
+                (~check_zero_pad | (params.pad == 0b00)) &
+                (~check_dma_len | (params.dma_len <= 2**31))
+            ),
+            valid_icrc.eq(valid_crc)
+        ]
+
+        ### Request indicator
+        # Whether the receiver is receiving a request or a response to our request
+        self.comb += [
+            is_in_flag(opcode_op, [
+                BTH_OPCODE_OP.RDMA_READ_response_First,
+                BTH_OPCODE_OP.RDMA_READ_response_Middle,
+                BTH_OPCODE_OP.RDMA_READ_response_Last,
+                BTH_OPCODE_OP.RDMA_READ_response_Only,
+                BTH_OPCODE_OP.Acknowledge
+            ], source.response)
+        ]
+
+        self.comb += source.payload_length.eq(payload_length)
+
+        # Control-Path (FSM).
+        self.fsm = fsm = FSM(reset_state="RECEIVE")
+        # Full packet reception is performed here
+        fsm.act("RECEIVE",
+            sink.connect(source, omit={"payload_length", "invalid_packet", "validate", "response"}),
+            If(sink.valid & sink.ready,
+                If(~sink.header_only,
+                    NextValue(payload_length, payload_length + 1),
+                ),
+                If(sink.last,
+                    NextState("VALIDATE")
+                )
+            )
+        )
+
+        # Checks are performed here
+        fsm.act("VALIDATE",
+            source.valid.eq(1),
+            params.connect(source, omit={
+                "valid",
+                "ready",
+                "payload_length",
+                "invalid_packet",
+                "validate",
+                "response"
+            }),
+            NextValue(payload_length, 0),
+            NextState("RECEIVE"),
+
+            If(valid_headers & valid_icrc,
+                If(~valid_packet,
+                    source.invalid_packet.eq(1)
+                ).Else(
+                    source.validate.eq(1)
+                )
+            )
+        )
+
+@ResetInserter()
+class LiteEthIBTransportRX(LiteXModule):
+    def __init__(self, ip, tx, mad_rx, qps, cq, mrs, clk_freq, with_crc=True, check_crc=True, buffered_in=True, dw=8):
+        self.sink   = sink   = Endpoint(eth_udp_user_description(dw))
+
+        # # #
+
+        if check_crc:
+            assert with_crc
+
+        pipeline_mods = [sink]
+
+        ### Data-Path.
+        # ICRC
+        if with_crc:
+            self.rx_crc = rx_crc = icrc.LiteEthInfinibandICRCChecker(
+                listen_description = eth_mac_description(dw),
+                description        = eth_udp_user_description(dw)
+            )
+
+            self.comb += [
+                ip.rx.sink.connect(rx_crc.calculator_sink, keep={"valid", "data", "last"}),
+                # We listen passively to the output of ip,
+                # so no control of ready (we don't use connect for it)
+                rx_crc.calculator_sink.ready.eq(ip.rx.sink.ready)
+            ]
+
+            pipeline_mods.append(rx_crc)
+
+        if buffered_in:
+            buff_in = Buffer(eth_udp_user_description(dw), pipe_ready=True)
+            self.submodules.buff_in = buff_in
+            pipeline_mods.append(buff_in)
+
+        # Depacketizer.
+        self.depacketizer = depacketizer = LiteEthIBTransportDepacketizer(dw=dw)
+        pipeline_mods.append(depacketizer)
+
+        # Padding remover
+        pad_rem = pad.LiteEthIBTPaddingRemover(dw)
+        self.submodules.pad_rem = pad_rem
+        pipeline_mods.append(pad_rem)
+
+        # Validation of packet integrity and correctness for generic packets (requests or responses)
+        pack_validation = LiteEthIBTransportValidation(qps, dw)
+        self.submodules.pack_validation = pack_validation
+        pipeline_mods.append(pack_validation)
+
+        # Connections outside the pipeline
+        self.comb += [
+            pack_validation.pad_error.eq(pad_rem.error),
+            pack_validation.valid_crc.eq(rx_crc.valid_crc if check_crc else 1)
+        ]
+
+        pipeline = stream.Pipeline(*pipeline_mods)
+        self.submodules.pipeline = pipeline
+        source = pipeline.source
+
+        # Responder and requester
+        responder = LiteEthRDMAResponderRX(tx.responder, mad_rx, qps, cq, mrs, dw=dw)
+        requester = LiteEthRDMARequesterRX(tx.requester, qps, cq, mrs, clk_freq, dw=dw)
+        self.submodules.responder = responder
+        self.submodules.requester = requester
+
+        # Dispatch validation output
+        self.comb += [
+            If(pipeline.source.response,
+                source.connect(requester.sink, omit={"response", "invalid_packet"})
+            ).Else(
+                source.connect(responder.sink, omit={"response"}),
+                responder.sink.ip_address.eq(sink.ip_address)
+            )
+        ]
+
+# ROCEv2 RX + TX -----------------------------------------------------------------------------------
+class LiteEthIBTransport(LiteXModule):
+    def __init__(self, ip, udp, mrs, clk_freq, dw=8):
+        self.cq = cq = LiteEthCQ(depth=0x10)
+
+        self.qp = qp = LiteEthIBQP(qp_id=0xdeaded)
+
+        special_qp = LiteEthIBSpecialQP()
+        self.submodules.special_qp = special_qp
+
+        self.qps = qps = [special_qp, qp]
+
+        self.mad = mad = LiteEthIBMAD(qps, clk_freq, dw=dw)
+
+        self.tx = tx = LiteEthIBTransportTX(
+            ip           = ip,
+            mad_tx       = mad.tx,
+            qps          = qps,
+            mrs          = mrs,
+            with_crc     = True,
+            buffered_out = True,
+            dw           = dw,
+        )
+        self.rx = rx = LiteEthIBTransportRX(
+            ip        = ip,
+            tx        = tx,
+            mad_rx    = mad.rx,
+            qps       = qps,
+            cq        = cq,
+            clk_freq  = clk_freq,
+            mrs       = mrs,
+            with_crc  = True,
+            check_crc = False,
+            dw        = dw,
+        )
+
+        self.udp_port = udp_port = udp.crossbar.get_port(ROCEV2_PORT, dw)
+        self.comb += [
+            tx.source.connect(udp_port.sink),
+            udp_port.source.connect(rx.sink)
+        ]
+
+        reset = Signal(reset=1)
+        self.sync += reset.eq(0)
+        self.sync += [
+            qp.reset_sys.eq(reset),
+            mad.reset.eq(reset),
+            tx.reset.eq(reset),
+            rx.reset.eq(reset)
+        ]

--- a/test/model/icmp.py
+++ b/test/model/icmp.py
@@ -81,6 +81,7 @@ class ICMP(Module):
         ip_packet.ihl             = 0x5
         ip_packet.total_length    = len(packet) + ipv4_header.length
         ip_packet.identification  = 0
+        ip_packet.dont_fragment   = 0
         ip_packet.flags           = 0
         ip_packet.fragment_offset = 0
         ip_packet.ttl             = 0x80

--- a/test/model/ip.py
+++ b/test/model/ip.py
@@ -89,6 +89,7 @@ class IP(Module):
         self.loopback        = loopback
         self.rx_packet       = IPPacket()
         self.table           = {}
+        self.dont_fragment = 0
         self.request_pending = False
 
         self.udp_callback    = None

--- a/test/model/udp.py
+++ b/test/model/udp.py
@@ -79,6 +79,7 @@ class UDP(Module):
         ip_packet.ihl             = 0x5
         ip_packet.total_length    = len(packet) + ipv4_header.length
         ip_packet.identification  = 0
+        ip_packet.dont_fragment   = 0
         ip_packet.flags           = 0
         ip_packet.fragment_offset = 0
         ip_packet.ttl             = 0x80

--- a/test/test_icmp.py
+++ b/test/test_icmp.py
@@ -54,6 +54,7 @@ def expected_ping_reply(payload, quench):
     packet.msgtype  = icmp_type_ping_reply
     packet.code     = 0
     packet.checksum = 0
+    packet.dont_fragment = 0
     packet.quench   = quench
     packet.encode()
     packet.insert_checksum()
@@ -70,6 +71,7 @@ def main_generator(dut):
     request.msgtype  = icmp_type_ping_request
     request.code     = 0
     request.checksum = 0
+    request.dont_fragment = 0
     request.quench   = quench
 
     dut.icmp_model.send(request, target_ip=dut_ip)

--- a/test/test_key_exchanger.py
+++ b/test/test_key_exchanger.py
@@ -1,0 +1,120 @@
+import unittest
+from litex.gen import *
+
+from litex.soc.interconnect.stream import Endpoint
+from liteeth.core.rocev2.rdma_key_exchanger import KeyDecoder
+
+from litex.gen.genlib.misc import WaitTimer
+
+class StrippedKeyExchanger(LiteXModule):
+    def __init__(self, keymem, memr_num, dw):
+        self.request = Signal()
+        self.source = Endpoint([("r_key", 32), ("va", 64), ("key_cnt", log2_int(memr_num))])
+
+        # # #
+
+        key_dec = KeyDecoder(memr_num, dw)
+        self.submodules.key_dec = key_dec
+
+        port = keymem.get_port()
+        self.specials += port
+
+        r_size = 2**8
+        r_dw = len(port.dat_r)
+        ratio_r_port = r_dw//dw
+
+        r_addr = Signal(log2_int(r_size//(r_dw//8)))
+        r_addr_next = Signal().like(r_addr)
+        r_cnt = Signal(log2_int(ratio_r_port))
+        r_buff = Signal(r_dw)
+
+        self.fsm = fsm = FSM()
+        fsm.act("WAIT",
+            If(self.request,
+                NextState("WORK")
+            )
+        )
+
+        fsm.act("WORK",
+            key_dec.sink.valid.eq(1),
+            Case(r_cnt, {
+                i: key_dec.sink.data.eq(r_buff[i*dw:(i+1)*dw])
+                for i in range(ratio_r_port)
+            }),
+            port.adr[:log2_int(r_size//(r_dw//8))].eq(r_addr_next),
+            r_buff.eq(port.dat_r),
+            r_addr_next.eq(r_addr + (key_dec.sink.ready & (r_cnt == ratio_r_port - 1))),
+
+            If(key_dec.source.last & key_dec.source.valid & key_dec.source.ready,
+                NextValue(r_addr, 0),
+                NextValue(r_cnt, 0)
+            ).Elif(key_dec.sink.ready,
+                NextValue(r_addr, r_addr_next),
+                NextValue(r_cnt, r_cnt + 1)
+            )
+        )
+
+        self.comb += key_dec.source.connect(self.source),
+
+keys = "001122330011223344556677001122330011223344556677001122330011223344556677001122330011223344556677001122330011223344556677001122330011223344556677001122330011223344556677001122330011223344556677"
+
+class DUT(LiteXModule):
+    def __init__(self, memr_num, dw):
+        self.done = Signal()
+
+        keymem_size = 2**log2_int(memr_num * 12 + 1, need_pow2=False)
+        keymem = Memory(16, keymem_size // 2, init=[int(keys[4*i+2:4*i+4] + keys[4*i:4*i+2], 16) for i in range(len(keys) // 4)])
+        self.specials += keymem
+
+        key_exchanger = StrippedKeyExchanger(keymem, memr_num, dw)
+        self.submodules.key_exchanger = key_exchanger
+
+        timer = WaitTimer(100)
+        self.submodules.timer = timer
+
+        r_keys = Array([Signal(32) for _ in range(memr_num)])
+        vas    = Array([Signal(64) for _ in range(memr_num)])
+
+        self.fsm = fsm = FSM()
+        fsm.act("WAIT",
+            timer.wait.eq(1),
+            If(timer.done,
+                key_exchanger.request.eq(1),
+                NextState("WAIT_KEYS")
+            )
+        )
+
+        fsm.act("WAIT_KEYS",
+            If(self.key_exchanger.source.valid,
+                NextState("R_KEYS")
+            )
+        )
+
+        fsm.act("R_KEYS",
+            key_exchanger.source.ready.eq(1),
+            If(key_exchanger.source.valid,
+                NextValue(r_keys[key_exchanger.source.key_cnt], key_exchanger.source.r_key),
+                NextValue(vas[key_exchanger.source.key_cnt], key_exchanger.source.va),
+                If(key_exchanger.source.last,
+                    NextState("STOP")
+                )
+            )
+        )
+
+        fsm.act("STOP",
+            self.done.eq(1)
+        )
+
+def simulate(dut):
+    while not (yield dut.done):
+        yield
+
+class TestKeyExchanger(unittest.TestCase):
+    dw = 8
+    def test_exchange(self):
+        dut = DUT(8, self.dw)
+
+        run_simulation(dut, simulate(dut), vcd_name="test.vcd")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_key_exchanger.py
+++ b/test/test_key_exchanger.py
@@ -1,0 +1,120 @@
+import unittest
+from litex.gen import *
+
+from litex.soc.interconnect.stream import Endpoint
+from liteeth.core.rocev2.rdma_key_exchanger import KeyDecoder
+
+from litex.gen.genlib.misc import WaitTimer
+
+class StrippedKeyExchanger(LiteXModule):
+    def __init__(self, keymem, mem_num, dw):
+        self.request = Signal()
+        self.source = Endpoint([("r_key", 32), ("va", 64), ("key_cnt", log2_int(mem_num))])
+
+        # # #
+
+        key_dec = KeyDecoder(mem_num, dw)
+        self.submodules.key_dec = key_dec
+
+        port = keymem.get_port()
+        self.specials += port
+
+        r_size = 2**(bits_for(mem_num * 12))
+        r_dw = len(port.dat_r)
+        ratio_r_port = r_dw//dw
+
+        r_addr = Signal(log2_int(r_size//(r_dw//8)))
+        r_addr_next = Signal().like(r_addr)
+        r_cnt = Signal(log2_int(ratio_r_port))
+        r_buff = Signal(r_dw)
+
+        self.fsm = fsm = FSM()
+        fsm.act("WAIT",
+            If(self.request,
+                NextState("WORK")
+            )
+        )
+
+        fsm.act("WORK",
+            key_dec.sink.valid.eq(1),
+            Case(r_cnt, {
+                i: key_dec.sink.data.eq(r_buff[i*dw:(i+1)*dw])
+                for i in range(ratio_r_port)
+            }),
+            port.adr[:log2_int(r_size//(r_dw//8))].eq(r_addr_next),
+            r_buff.eq(port.dat_r),
+            r_addr_next.eq(r_addr + (key_dec.sink.ready & (r_cnt == ratio_r_port - 1))),
+
+            If(key_dec.source.last & key_dec.source.valid & key_dec.source.ready,
+                NextValue(r_addr, 0),
+                NextValue(r_cnt, 0)
+            ).Elif(key_dec.sink.ready,
+                NextValue(r_addr, r_addr_next),
+                NextValue(r_cnt, r_cnt + 1)
+            )
+        )
+
+        self.comb += key_dec.source.connect(self.source),
+
+keys = "0001b3bb00005cb0761db1000001b40300005cb0761db9100001b58500005cb0761dc1200001b61600005cb0761dc9300001b7d200005cb0761dd1400001b8ed00005cb0761dd9500001b9f800005cb0761de1600001bae400005cb0761de9700001bb2700005cb0761df1800001bc9a00005cb0761df9900001bdc600005cb0761e01a00001be8000005cb0761e09b00001bf3300005cb0761e11c00001c01f00005cb0761e19d00001c11f00005cb0761e21e00001c23200005cb0761e29f00001c34400005cb0761e32000001c44c00005cb0761e3a100001c54000005cb0761e42200001c6cd00005cb0761e4a300001c7cf00005cb0761e52400001c8ed00005cb0761e5a500001c95c00005cb0761e62600001caf800005cb0761e6a700001cb5b00005cb0761e72800001ccbd00005cb0761e7a900001cda300005cb0761e82a00001ce0600005cb0761e8ab00001cf5500005cb0761e92c00001d08b00005cb0761e9ad00001d11000005cb0761ea2e00001d2b600005cb0761eaaf00001d35800005cb0761eb3000001d4fe00005cb0761ebb100001d5f600005cb0761ec3200001d60400005cb0761ecb300001d7fc00005cb0761ed3400001d80600005cb0761edb500001d91d00005cb0761ee3600001daa700005cb0761eeb700001db6800005cb0761ef3800001dc2600005cb0761efb900001dd0a00005cb0761f03a00001deeb00005cb0761f0bb00001dfd700005cb0761f13c00001e01900005cb0761f1bd00001e1e400005cb0761f23e00001e29200005cb0761f2bf00001e3dd00005cb0761f34000001e45400005cb0761f3c100001e55200005cb0761f44200001e6e600005cb0761f4c300001e76500005cb0761f54400001e88800005cb0761f5c500001e95a00005cb0761f64600001ea7000005cb0761f6c700001eb9800005cb0761f74800001ec0500005cb0761f7c900001edd200005cb0761f84a00001ee5e00005cb0761f8cb00001ef1700005cb0761f94c00001f08400005cb0761f9cd00001f1ab00005cb0761fa4e00001f23c00005cb0761facf0"
+
+class DUT(LiteXModule):
+    def __init__(self, mem_num, dw):
+        self.done = Signal()
+
+        keymem_size = 2**bits_for(mem_num * 12 + 1)
+        keymem = Memory(16, keymem_size // 2, init=[int(keys[4*i+2:4*i+4] + keys[4*i:4*i+2], 16) for i in range(len(keys) // 4)])
+        self.specials += keymem
+
+        key_exchanger = StrippedKeyExchanger(keymem, mem_num, dw)
+        self.submodules.key_exchanger = key_exchanger
+
+        timer = WaitTimer(100)
+        self.submodules.timer = timer
+
+        r_keys = Array([Signal(32) for _ in range(mem_num)])
+        vas    = Array([Signal(64) for _ in range(mem_num)])
+
+        self.fsm = fsm = FSM()
+        fsm.act("WAIT",
+            timer.wait.eq(1),
+            If(timer.done,
+                key_exchanger.request.eq(1),
+                NextState("WAIT_KEYS")
+            )
+        )
+
+        fsm.act("WAIT_KEYS",
+            If(self.key_exchanger.source.valid,
+                NextState("R_KEYS")
+            )
+        )
+
+        fsm.act("R_KEYS",
+            key_exchanger.source.ready.eq(1),
+            If(key_exchanger.source.valid,
+                NextValue(r_keys[key_exchanger.source.key_cnt], key_exchanger.source.r_key),
+                NextValue(vas[key_exchanger.source.key_cnt], key_exchanger.source.va),
+                If(key_exchanger.source.last,
+                    NextState("STOP")
+                )
+            )
+        )
+
+        fsm.act("STOP",
+            self.done.eq(1)
+        )
+
+def simulate(dut):
+    while not (yield dut.done):
+        yield
+
+class TestKeyExchanger(unittest.TestCase):
+    dw = 8
+    def test_exchange(self):
+        dut = DUT(64, self.dw)
+
+        run_simulation(dut, simulate(dut), vcd_name="test.vcd")
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_memory_dummies.py
+++ b/test/test_memory_dummies.py
@@ -1,0 +1,234 @@
+import unittest
+import os
+from litex.gen import *
+
+import liteeth.core.rocev2.mr as mr
+
+DEBUG = 0
+
+class DUT(LiteXModule):
+    def __init__(self, write, read, mem_num, region_size, dw):
+        self.mrs_handler = mr.LiteEthIBMemoryRegionsHandler()
+
+        if write:
+            # Memory regions used for RDMA WRITE requests
+            wmem = mr.LiteEthDummyTXMR(4096, dw)
+            self.wmem = wmem = ClockDomainsRenamer({
+                "sys" : "sys",
+                "read"  : "sys",
+                "write": "sys"
+            })(wmem)
+            self.wmem_mrs = []
+            for i in range(mem_num // 2):
+                wmem_port = wmem.get_read_port()
+                wmem_mr = self.mrs_handler.reg_mr(
+                    region_start = 0,
+                    region_size  = region_size,
+                    permissions  = mr.PERM(0),
+                    r_key        = i,
+                    l_key        = i,
+                    read_port    = wmem_port,
+                    write_port   = None
+                )
+
+                self.wmem_mrs.append(wmem_mr)
+
+        if read:
+            # Memory regions used for RDMA READ requests
+            rmem = mr.LiteEthDummyRXMR(4096, dw)
+            self.rmem = rmem = ClockDomainsRenamer({
+                "sys": "sys",
+                "write": "sys",
+                "read": "sys"
+            })(rmem)
+            self.rmem_mrs = []
+            for i in range(mem_num // 2):
+                rmem_port = rmem.get_write_port()
+                rmem_mr = self.mrs_handler.reg_mr(
+                    region_start = 0,
+                    region_size  = region_size,
+                    permissions  = mr.PERM.LOCAL_WRITE | mr.PERM.NO_LOCAL_READ,
+                    r_key        = mem_num // 2 + i,
+                    l_key        = mem_num // 2 + i,
+                    read_port    = None,
+                    write_port   = rmem_port
+                )
+
+                self.rmem_mrs.append(rmem_mr)
+
+PMTU = 1024
+
+# Testing RX
+def write_to_mem(writer, va, data):
+    i = 0
+    while not ((yield writer.sink.valid) and (yield writer.sink.ready) and (yield writer.sink.last)):
+        if (yield writer.sink.valid) and (yield writer.sink.ready):
+            i += 1
+        yield writer.sink.data.eq(data[va + i])
+        yield writer.sink.va.eq(va + i)
+        yield writer.sink.valid.eq(1)
+        if DEBUG:
+            print(f"> Send\t0x{data[i]:02x} from {i}")
+        yield writer.sink.last.eq(i == PMTU - 1)
+        yield
+
+    assert i == PMTU - 1
+    yield writer.sink.valid.eq(0)
+
+def send_read(dut, data):
+    # Skip reset on init
+    yield
+
+    for i, memr in enumerate(dut.rmem_mrs):
+        print(f">>> Writing to memory region {i}")
+        writer = memr.writer
+
+        yield from write_to_mem(writer, 2*PMTU*i, data)
+
+        # Pause
+        for _ in range(5):
+            yield
+
+        yield from write_to_mem(writer, 2*PMTU*i + PMTU, data)
+
+        # Pause
+        for _ in range(5):
+            yield
+
+        print(f"<<< Done writing to memory region {i}")
+
+def receive_read(dut, data):
+    # Skip reset on init
+    yield
+
+    read_port = dut.rmem.read_port
+
+    yield read_port.source.ready.eq(1)
+
+    i = 0
+    while i < len(data):
+        if (yield read_port.source.valid) and (yield read_port.source.ready):
+            data[i] = (yield read_port.source.data)
+            if DEBUG:
+                print(f"< Rec\t0x{data[i]:02x} at {i}")
+            i += 1
+        yield
+
+    yield read_port.source.ready.eq(0)
+
+# Testing TX
+def send_write(dut, data):
+    # Skip reset on init
+    yield
+
+    write_port = dut.wmem.write_port
+
+    yield write_port.sink.valid.eq(1)
+
+    yield write_port.sink.data.eq(data[0])
+    i = 0
+    while True:
+        if (yield write_port.sink.valid) and (yield write_port.sink.ready):
+            if DEBUG:
+                print(f"> Send\t0x{data[i]:02x} from {i}")
+            i += 1
+            if i == 4 * PMTU:
+                break
+            yield write_port.sink.data.eq(data[i])
+        yield
+
+    yield write_port.sink.valid.eq(0)
+    yield
+
+def read_from_mem(reader, va, data):
+    # Skip reset on init
+    yield
+
+    yield reader.sink.valid.eq(1)
+    yield reader.sink.va.eq(va)
+    yield reader.sink.len.eq(PMTU)
+
+    yield reader.source.ready.eq(1)
+
+    i = 0
+    while True:
+        if (yield reader.sink.valid) and (yield reader.sink.ready):
+            yield reader.sink.valid.eq(0)
+        if (yield reader.source.valid):
+            if DEBUG:
+                print(f"< Rec\t0x{(yield reader.source.data):02x} at {va + i}")
+            data[va + i] = (yield reader.source.data)
+            i += 1
+            if ((yield reader.source.ready) and (yield reader.source.last)):
+                break
+        yield
+
+    assert i == PMTU
+    yield reader.source.ready.eq(0)
+
+
+def receive_write(dut, data):
+    # Skip reset on init
+    yield
+
+    for i, memr in enumerate(dut.wmem_mrs):
+        print(f">>> Reading from memory region {i}")
+
+        reader = memr.reader
+
+        yield from read_from_mem(reader, 2*PMTU*i, data)
+
+        # Pause
+        for _ in range(5):
+            yield
+
+        yield from read_from_mem(reader, 2*PMTU*i + PMTU, data)
+
+        # Pause
+        for _ in range(5):
+            yield
+
+        print(f"<<< Done reading from memory region {i}")
+
+class TestMemoryDummies(unittest.TestCase):
+    dw = 8
+    def test_read(self):
+        dut = DUT(
+            write       = False,
+            read        = True,
+            mem_num     = 4,
+            region_size = 2048,
+            dw          = self.dw
+        )
+
+        sent_data = bytearray(os.urandom(4096))
+        received_data = [0] * len(sent_data)
+        run_simulation(dut, [
+            send_read(dut, sent_data),
+            receive_read(dut, received_data)
+        ], vcd_name="test.vcd")
+
+        for s, r in zip(sent_data, received_data):
+            self.assertEqual(s, r)
+
+    def test_write(self):
+        dut = DUT(
+            write       = True,
+            read        = False,
+            mem_num     = 4,
+            region_size = 2048,
+            dw          = self.dw
+        )
+
+        sent_data = bytearray(os.urandom(4096))
+        received_data = [0] * len(sent_data)
+        run_simulation(dut, [
+            send_write(dut, sent_data),
+            receive_write(dut, received_data)
+        ], vcd_name="test.vcd")
+
+        for s, r in zip(sent_data, received_data):
+            self.assertEqual(s, r)
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_packetizer.py
+++ b/test/test_packetizer.py
@@ -1,0 +1,105 @@
+from litex.soc.interconnect.packet import Header, HeaderField
+from migen import *
+
+from litex.soc.interconnect.stream import EndpointDescription
+
+from liteeth.common import *
+
+from liteeth.core.rocev2.common import *
+
+from litex.gen import *
+
+class Feedback(LiteXModule):
+    def __init__(self, outer_description, inner_description):
+        self.pack = pack = VariablePacketizer(outer_description, inner_description, IBT_headers, IBT_opmap)
+        self.depack = depack = VariableDepacketizer(inner_description, outer_description, IBT_headers, IBT_opmap)
+
+        self.comb += pack.source.connect(depack.sink)
+
+feedback = Feedback(eth_rocev2_description(8), eth_udp_description(8))
+
+choices = {}
+
+from random import randint
+
+def random_signal(signal, signal_name=""):
+    global choices
+    l = len(signal)
+    r = randint(0, (1 << l) - 1)
+    choices[signal_name] = r
+    yield signal.eq(r)
+
+def set_packet_params(opcode):
+    # Set opcode
+    yield feedback.pack.sink.opcode.eq(opcode)
+
+    # Randomize parameters
+    for p in feedback.pack.sink.description.param_layout:
+        if p[0] != "opcode":
+            yield from random_signal(getattr(feedback.pack.sink, p[0]), signal_name=p[0])
+
+
+
+cycler = 1
+def set_packet_data():
+    global cycler
+    yield feedback.pack.sink.data.eq(cycler)
+    cycler = 1 + cycler % 3
+
+def packet(opcode, header_only=False):
+    yield from set_packet_params(opcode)
+
+    if not header_only:
+        yield from set_packet_data()
+
+    yield feedback.pack.sink.valid.eq(1)
+    yield feedback.depack.source.ready.eq(1)
+    yield
+
+    while True:
+        if (yield feedback.pack.sink.ready) == 1:
+            if not header_only:
+                yield from set_packet_data()
+                yield
+                yield from set_packet_data()
+                yield feedback.pack.sink.last.eq(1)
+                yield
+            yield feedback.pack.sink.valid.eq(0)
+            yield feedback.pack.sink.last.eq(0)
+            while (yield feedback.depack.source.valid) != 1:
+                yield
+            yield from check_received_packet(opcode)
+            break
+        yield
+
+def check_received_packet(opcode):
+    global choices
+    valid_headers = [bth_header] + [header for i, header in list(enumerate(IBT_headers))[1:] if IBT_opmap[opcode] & (1 << (i - 1))]
+
+    for signame, v in choices.items():
+        validsig = False
+        for header in valid_headers:
+            for p, _ in header.get_layout():
+                if p == signame:
+                    validsig = True
+        if validsig:
+            print(signame, v)
+            x = yield getattr(feedback.depack.source, signame)
+            assert (x) == v
+
+def testbench():
+    header_only = False
+    for opcode in IBT_RC_OPS + IBT_UD_OPS:
+        if opcode in [0b01100, 0b10001, 0b10010, 0b10011, 0b10100]:
+            yield feedback.pack.header_only.eq(1)
+            header_only = True
+        else:
+            yield feedback.pack.header_only.eq(0)
+            header_only = False
+        yield from packet(opcode, header_only)
+        yield
+
+run_simulation(feedback, testbench(), vcd_name="test.vcd")
+
+# from migen.fhdl.verilog import convert
+# convert(Feedback(eth_rocev2_description(8), eth_udp_description(8))).write("test.v")

--- a/test/test_packetizer.py
+++ b/test/test_packetizer.py
@@ -1,0 +1,104 @@
+import unittest
+
+from migen import *
+from litex.gen import *
+
+from liteeth.common import *
+from liteeth.core.rocev2.common import *
+
+class Feedback(LiteXModule):
+    def __init__(self, outer_description, inner_description):
+        self.pack = pack = VariablePacketizer(outer_description, inner_description, IBT_headers, IBT_opmap)
+        self.depack = depack = VariableDepacketizer(inner_description, outer_description, IBT_headers, IBT_opmap)
+
+        self.comb += pack.source.connect(depack.sink)
+
+choices = {}
+
+from random import randint
+
+def random_signal(signal, signal_name=""):
+    global choices
+    l = len(signal)
+    r = randint(0, (1 << l) - 1)
+    choices[signal_name] = r
+    yield signal.eq(r)
+
+def set_packet_params(dut, opcode):
+    # Set opcode
+    yield dut.pack.sink.opcode.eq(opcode)
+
+    # Randomize parameters
+    for p in dut.pack.sink.description.param_layout:
+        if p[0] != "opcode" and p[0] != "header_only":
+            yield from random_signal(getattr(dut.pack.sink, p[0]), signal_name=p[0])
+
+
+
+cycler = 1
+def set_packet_data(dut):
+    global cycler
+    yield dut.pack.sink.data.eq(cycler)
+    cycler = 1 + cycler % 3
+
+def packet(dut, opcode, header_only=False):
+    yield dut.pack.sink.valid.eq(1)
+    yield dut.depack.source.ready.eq(1)
+
+    yield from set_packet_params(dut, opcode)
+
+    if not header_only:
+        yield from set_packet_data(dut)
+    yield
+
+    while True:
+        if (yield dut.pack.sink.ready) == 1:
+            if not header_only:
+                yield from set_packet_data(dut)
+                yield
+                yield from set_packet_data(dut)
+                yield dut.pack.sink.last.eq(1)
+                yield
+            yield dut.pack.sink.valid.eq(0)
+            yield dut.pack.sink.last.eq(0)
+            while (yield dut.depack.source.valid) != 1:
+                yield
+            yield from check_received_packet(dut, opcode)
+            break
+        yield
+
+def check_received_packet(dut, opcode):
+    global choices
+    valid_headers = [bth_header] + [header for i, header in list(enumerate(IBT_headers))[1:] if IBT_opmap[opcode] & (1 << (i - 1))]
+
+    for signame, v in choices.items():
+        validsig = False
+        for header in valid_headers:
+            for p, _ in header.get_layout():
+                if p == signame:
+                    validsig = True
+        if validsig:
+            x = yield getattr(dut.depack.source, signame)
+            if x != v:
+                print(choices)
+                print(signame, x)
+            assert (x) == v
+
+def send_packets(dut):
+    header_only = False
+    for opcode in IBT_RC_OPS + IBT_UD_OPS:
+        if opcode in [0b01100, 0b10001, 0b10010, 0b10011, 0b10100]:
+            yield dut.pack.sink.header_only.eq(1)
+            header_only = True
+        else:
+            yield dut.pack.sink.header_only.eq(0)
+            header_only = False
+        yield from packet(dut, opcode, header_only)
+        yield
+
+class TestStream(unittest.TestCase):
+    dw = 8
+    def test_feedback(self):
+        dut = Feedback(eth_rocev2_description(self.dw), eth_udp_description(self.dw))
+
+        run_simulation(dut, send_packets(dut), vcd_name="test.vcd")

--- a/test/test_rocev2.py
+++ b/test/test_rocev2.py
@@ -1,0 +1,616 @@
+import unittest
+
+from migen import *
+from litex.gen import *
+
+from litex.soc.interconnect.stream import Endpoint, EndpointDescription
+
+from liteeth.common import *
+
+from liteeth.core.rocev2.qp import LiteEthIBQP, LiteEthIBSpecialQP, LiteEthCQ
+from liteeth.core.rocev2.rocev2 import LiteEthIBTransportRX, LiteEthIBTransportTX, LiteEthIBTransportPacketizer
+from liteeth.core.rocev2.mad_cm import LiteEthIBMAD, LiteEthCMPacketizer
+from liteeth.core.udp import LiteEthUDPPacketizer, LiteEthUDPDepacketizer
+from liteeth.core.ip import LiteEthIPV4Packetizer, LiteEthIPV4Depacketizer
+from liteeth.core.rocev2.icrc import LiteEthInfinibandICRCInserter
+import liteeth.core.rocev2.mr as mr
+
+from liteeth.core.rocev2.rdma_streamer import LiteEthRDMAStreamer
+
+from collections import namedtuple
+dummy_udp_port = namedtuple("udp_port", "address_width data_width")
+dummy_udp_port.address_width = 24
+dummy_udp_port.data_width = 8
+
+class WR:
+    def __init__(self, wr_opcode, l_key, va, dma_len, ack_req, immdt=None, r_key=None):
+        if immdt is not None:
+            assert wr_opcode in [WR_OPCODE.SEND, WR_OPCODE.RDMA_WRITE]
+        if r_key is not None:
+            assert wr_opcode in [WR_OPCODE.RDMA_WRITE, WR_OPCODE.RDMA_READ]
+        if wr_opcode in [WR_OPCODE.RDMA_WRITE, WR_OPCODE.RDMA_READ]:
+            assert r_key is not None
+
+        self.wr_opcode = wr_opcode
+        self.l_key   = l_key
+        self.va      = va
+        self.dma_len = dma_len
+        self.ack_req = ack_req
+        self.immdt   = immdt if immdt else 0
+        self.w_immdt = (immdt is not None)
+        self.r_key   = r_key if r_key else 0
+
+    def post(self, wr_sink):
+        yield wr_sink.wr_opcode.eq(self.wr_opcode)
+        yield wr_sink.l_key.eq(self.l_key)
+        yield wr_sink.va.eq(self.va)
+        yield wr_sink.dma_len.eq(self.dma_len)
+        yield wr_sink.ack_req.eq(self.ack_req)
+        yield wr_sink.w_immdt.eq(self.w_immdt)
+        yield wr_sink.immdt.eq(self.immdt)
+        yield wr_sink.r_key.eq(self.r_key)
+
+class IPModule_dummy(LiteXModule):
+    class IPTX(LiteXModule):
+        def __init__(self, dw):
+            self.sink = sink = Endpoint(eth_ipv4_user_description(dw))
+            self.source = source = Endpoint(eth_mac_description(dw))
+
+            self.packetizer = packetizer = LiteEthIPV4Packetizer(dw=8)
+
+            self.comb += [
+                packetizer.sink.target_ip.eq(sink.ip_address),
+                packetizer.sink.total_length.eq(ipv4_header.length + sink.length),
+                packetizer.sink.version.eq(0x4),     # ipv4
+                packetizer.sink.ihl.eq(ipv4_header.length//4),
+                # RDMA
+                packetizer.sink.dont_fragment.eq(1),
+                packetizer.sink.identification.eq(0),
+                packetizer.sink.ttl.eq(0x80),
+                packetizer.sink.sender_ip.eq(convert_ip("192.1.168.50"))
+            ]
+
+            self.comb += [
+                sink.connect(packetizer.sink, keep={"valid", "ready", "last", "data"}),
+                packetizer.source.connect(source)
+            ]
+
+    class IPRX(LiteXModule):
+        def __init__(self, dw):
+            self.sink = sink = Endpoint(eth_mac_description(dw))
+            self.source = source = Endpoint(eth_ipv4_user_description(dw))
+
+            self.depacketizer = depacketizer = LiteEthIPV4Depacketizer(dw=8)
+
+            self.comb += [
+                depacketizer.source.connect(source, keep={
+                    "protocol",
+                    "error",
+                    "last_be"}),
+                source.length.eq(depacketizer.source.total_length - ipv4_header_length),
+                source.ip_address.eq(depacketizer.source.sender_ip),
+            ]
+
+            self.comb += [
+                sink.connect(depacketizer.sink),
+                depacketizer.source.connect(source, keep={"valid", "ready", "last", "data"})
+            ]
+
+    def __init__(self, dw):
+        self.tx = self.IPTX(dw)
+        self.rx = self.IPRX(dw)
+
+class UDPModule_dummy(LiteXModule):
+    class UDPTX(LiteXModule):
+        def __init__(self, dw):
+            self.sink = sink = Endpoint(eth_udp_user_description(dw))
+            self.source = source = Endpoint(eth_ipv4_user_description(dw))
+
+            self.packetizer = packetizer = LiteEthUDPPacketizer(dw=8)
+
+            self.comb += [
+            sink.connect(packetizer.sink, keep={
+                "last_be",
+                "src_port",
+                "dst_port"}),
+            packetizer.sink.length.eq(sink.length + udp_header.length),
+            packetizer.sink.checksum.eq(0), # UDP Checksum is not used, we only rely on MAC CRC.
+        ]
+
+            self.comb += [
+                sink.connect(packetizer.sink, keep={"valid", "ready", "last", "data"}),
+                packetizer.source.connect(source),
+            ]
+
+    class UDPRX(LiteXModule):
+        def __init__(self, dw):
+            self.sink = sink = Endpoint(eth_ipv4_user_description(dw))
+            self.source = source = Endpoint(eth_udp_user_description(dw))
+
+            self.depacketizer = depacketizer = LiteEthUDPDepacketizer(dw=8)
+
+            self.comb += [
+                sink.connect(depacketizer.sink),
+                depacketizer.source.connect(source, keep={
+                    "src_port",
+                    "dst_port",
+                    "error"}),
+                source.ip_address.eq(sink.ip_address),
+                source.length.eq(depacketizer.source.length - udp_header.length),
+            ]
+
+            self.comb += [
+                sink.connect(depacketizer.sink),
+                depacketizer.source.connect(source, keep={"valid", "ready", "last", "data"})
+            ]
+
+    def __init__(self, ip, dw):
+        self.tx = tx = self.UDPTX(dw)
+        self.rx = rx = self.UDPRX(dw)
+
+        self.comb += [
+            tx.source.connect(ip.tx.sink),
+            ip.rx.source.connect(rx.sink)
+        ]
+
+class DUT(LiteXModule):
+    qp_psn = 0
+    sp_qp_psn = 0
+
+    def __init__(self):
+        # Packetizer will feed into the rocev2 module as if packets were being received through udp
+        self.mad_pack = mad_pack = LiteEthCMPacketizer(dw=8)
+        self.ib_pack = ib_pack = LiteEthIBTransportPacketizer(dw=8)
+
+        self.udp_pack = udp_pack = UDPModule_dummy.UDPTX(dw=8)
+        self.ip_pack = ip_pack = IPModule_dummy.IPTX(dw=8)
+        #self.ip_buff = ip_buff = stream.Buffer(eth_ipv4_user_description(dw=8))
+
+        self.direct_ib_sink = direct_ib_sink = Endpoint(eth_rocev2_description(dw=8))
+        self.direct_bytestream_sink = direct_bytestream_sink = Endpoint(eth_mac_description(dw=8))
+        self.direct_bytestream = Signal()
+        self.mad_packet = Signal()
+
+        # The memory region is replaced with a dummy
+
+        self.mrs_handler = mr.LiteEthIBMemoryRegionsHandler()
+
+        mem_num = 16
+        # Memory regions used for RDMA WRITE requests
+        wmems = []
+        for i in range(mem_num // 2):
+            wmem = Memory(16, 2**10) # 2**11 bytes
+            wmem_port = wmem.get_port()
+            wmem_mr = self.mrs_handler.reg_mr(
+                region_start = 0,
+                region_size  = 2**11,
+                permissions  = mr.PERM(0),
+                r_key        = i,
+                l_key        = i,
+                memory       = wmem,
+                read_port    = wmem_port,
+                write_port   = None
+            )
+
+            self.specials += wmem, wmem_port
+
+            wmems.append(wmem_mr)
+
+        # Memory regions used for RDMA READ requests
+        rmems = []
+        for i in range(mem_num // 2):
+            rmem = Memory(16, 2**10) # 2**11 bytes
+            rmem_port = rmem.get_port(write_capable=True)
+            rmem_mr = self.mrs_handler.reg_mr(
+                region_start = 0,
+                region_size  = 2**11,
+                permissions  = mr.PERM.LOCAL_WRITE | mr.PERM.NO_LOCAL_READ,
+                r_key        = mem_num // 2 + i,
+                l_key        = mem_num // 2 + i,
+                memory       = rmem,
+                read_port    = None,
+                write_port   = rmem_port
+            )
+
+            self.specials += rmem, rmem_port
+
+            rmems.append(rmem_mr)
+
+        keymem_size = 2**log2_int(mem_num * 12 + 1, need_pow2=False)
+        self.keymem = keymem = Memory(16, keymem_size // 2)
+        keymem_port = keymem.get_port(write_capable=True)
+        self.mrs_handler.reg_mr(
+            region_start = 0,
+            region_size  = keymem_size,
+            permissions  = mr.PERM.LOCAL_WRITE | mr.PERM.NO_LOCAL_READ,
+            r_key        = 0xdeaded,
+            l_key        = 0xdeaded,
+            memory       = keymem,
+            read_port    = None,
+            write_port   = keymem_port
+        )
+
+        self.specials += keymem, keymem_port
+
+        cq = LiteEthCQ(depth=0x10)
+        self.submodules.cq = cq
+
+        qp = LiteEthIBQP(qp_id=0xdeaded)
+        self.submodules += qp
+
+        special_qp = LiteEthIBSpecialQP()
+        self.submodules += special_qp
+
+        self.qps = qps = [special_qp, qp]
+
+        self.mad = mad = LiteEthIBMAD(qps, 10e6, dw=8)
+
+        self.ip_dummy = ip_dummy = IPModule_dummy(dw=8)
+        self.udp_dummy = udp_dummy = UDPModule_dummy(ip_dummy, dw=8)
+
+        self.rocev2_tx = rocev2_tx = LiteEthIBTransportTX(ip_dummy, mad.tx, qps, self.mrs_handler.mrs, with_crc=True, buffered_out=True)
+        self.rocev2_rx = rocev2_rx = LiteEthIBTransportRX(ip_dummy, rocev2_tx, mad.rx, qps, cq, self.mrs_handler.mrs, int(125e6), with_crc=True)
+
+        self.crc_ins = crc_ins = LiteEthInfinibandICRCInserter(eth_mac_description(dw=8), eth_rocev2_description(dw=8))
+
+        # Streamer
+        rdma_streamer = LiteEthRDMAStreamer(qp, cq, wmems, rmems, 8)
+        self.submodules.rdma_streamer = rdma_streamer
+
+        self.length = Signal(16)
+
+        # send_direct_bytestream:
+        # direct_bytestream_sink --> crc_ins --> ip_dummy_rx --> udp_dummy.rx --> rocev2_rx
+        #                               ^-----/                                       |
+        #                                                                             v
+        #                                        ip_dummy_tx <-- udp_dummy.tx <-- rocev2_tx
+        #####################################################################################################
+        # send_mad_packet:
+        # mad_pack --> ib_pack --> udp_pack --> ip_pack --> ip_dummy_rx --> udp_dummy.rx --> rocev2_rx
+        #                                                                                        |
+        #                                                                                        v
+        #                                                   ip_dummy_tx <-- udp_dummy.tx <-- rocev2_tx
+        #####################################################################################################
+        # send_ib_packet:
+        # direct_ib_sink --> ib_pack --> udp_pack --> ip_pack --> ip_dummy_rx --> udp_dummy.rx --> rocev2_rx
+        #                                                                                              |
+        #                                                                                              v
+        #                                                         ip_dummy_tx <-- udp_dummy.tx <-- rocev2_tx
+
+        self.comb += [
+            rocev2_tx.enable.eq(1),
+            If(self.direct_bytestream,
+                direct_bytestream_sink.connect(crc_ins.sink, keep={"valid", "ready", "last", "data"}),
+                #crc_ins.source.connect(ip_buff.sink, keep={"valid", "ready", "last", "data"}),
+                #ip_buff.source.connect(ip_dummy.rx.sink, keep={"valid", "ready", "last", "data"}),
+                crc_ins.source.connect(ip_dummy.rx.sink, keep={"valid", "ready", "last", "data"}),
+                ip_dummy.rx.sink.connect(crc_ins.calculator_sink, keep={"valid", "data", "last"}),
+                # We listen passively to the output of ip, so no control of ready (we don't use connect for it)
+                crc_ins.calculator_sink.ready.eq(ip_dummy.rx.sink.ready)
+            ).Else(
+                If(self.mad_packet,
+                    mad_pack.source.connect(ib_pack.sink, keep={"valid", "ready", "last", "data"})
+                ).Else(
+                    direct_ib_sink.connect(ib_pack.sink, keep={"valid", "ready", "last", "data"})
+                ),
+                ib_pack.source.connect(udp_pack.sink),
+                udp_pack.source.connect(ip_pack.sink),
+                ip_pack.source.connect(ip_dummy.rx.sink),
+            ),
+
+            udp_dummy.rx.source.connect(rocev2_rx.sink),
+            rocev2_tx.source.connect(udp_dummy.tx.sink),
+
+            ip_dummy.tx.source.ready.eq(1)
+        ]
+
+
+        ########
+
+        self.comb += [
+            mad.ipcm.source.ready.eq(1)
+        ]
+
+        from liteeth.core.rocev2.rdma_key_exchanger import LiteEthRDMAKeyExchanger
+        self.key_exchanger = LiteEthRDMAKeyExchanger(
+            qp       = qp,
+            cq       = cq,
+            keymem   = self.keymem,
+            memr_num = mem_num,
+            dw       = 8
+        )
+
+        self.fsm = fsm = FSM(reset_state="WAIT_RTS")
+        fsm.act("WAIT_RTS",
+            If(qp.qp_state == LiteEthIBQP.RTS,
+                NextState("REQUEST")
+            )
+        )
+
+        fsm.act("REQUEST",
+            self.key_exchanger.request.eq(1),
+            NextState("WAIT_KEYS")
+        )
+
+        fsm.act("WAIT_KEYS",
+            If(self.key_exchanger.source.valid,
+                NextState("R_KEYS")
+            )
+        )
+
+        fsm.act("R_KEYS",
+            self.key_exchanger.source.ready.eq(1),
+            If(self.key_exchanger.source.valid,
+                NextValue(self.rdma_streamer.r_keys[self.key_exchanger.source.key_cnt], self.key_exchanger.source.r_key),
+                NextValue(self.rdma_streamer.vas[self.key_exchanger.source.key_cnt], self.key_exchanger.source.va),
+                If(self.key_exchanger.source.last,
+                    NextState("SEND")
+                )
+            )
+        )
+
+
+        cnt = Signal(8)
+
+        fsm.act("SEND",
+            self.rdma_streamer.enable.eq(1),
+
+            NextValue(cnt, cnt + 1),
+            self.rdma_streamer.sink.valid.eq(1),
+            self.rdma_streamer.sink.data.eq(cnt),
+
+            self.rdma_streamer.source.ready.eq(1),
+
+            If(qp.qp_state != LiteEthIBQP.RTS,
+                NextState("R_KEYS")
+            )
+        )
+
+    def set_mad_packet_params(self, attrib):
+        # MAD
+        yield self.mad_pack.sink.BaseVersion.eq(0x01)
+        yield self.mad_pack.sink.MgmtClass.eq(0x07)
+        yield self.mad_pack.sink.ClassVersion.eq(0x02)
+        yield self.mad_pack.sink.Method.eq(0x03)
+        yield self.mad_pack.sink.AttributeID.eq(attrib)
+
+        # CM
+        yield self.mad_pack.sink.Local_QPN.eq(0x11)
+        yield self.mad_pack.sink.Responder_Resources.eq(0x01)
+        yield self.mad_pack.sink.Initiator_Depth.eq(0x01)
+        yield self.mad_pack.sink.Partition_Key.eq(0xffff)
+        yield self.mad_pack.sink.Starting_PSN.eq(0xcafeed)
+        yield self.mad_pack.sink.Primary_Local_Port_GID.eq(Cat(convert_ip("192.168.1.1"), Constant(0xffff, 16)))
+
+        self.qp_psn = 0xcafeed
+
+    def set_ib_packet_params(self, opcode, psn, dest_qp=0xdeaded, length=PMTU):
+        yield self.length.eq(length)
+        # Set opcode
+        yield self.ib_pack.sink.opcode.eq(opcode)
+        yield self.ib_pack.sink.psn.eq(psn)
+        yield self.ib_pack.sink.tver.eq(0)
+        yield self.ib_pack.sink.dest_qp.eq(dest_qp)
+        yield self.ib_pack.sink.pad.eq((4 - (length % 4)) % 4)
+
+        yield self.ib_pack.sink.se.eq(0)
+        yield self.ib_pack.sink.m.eq(0)
+        yield self.ib_pack.sink.a.eq(1)
+        yield self.ib_pack.sink.se.eq(0)
+        yield self.ib_pack.sink.p_key.eq(DEFAULT_P_KEY)
+
+        if dest_qp == 1:
+            yield self.ib_pack.sink.q_key.eq(DEFAULT_CM_Q_Key)
+            yield self.ib_pack.sink.src_qp.eq(1)
+
+        psn += 1
+
+    def set_rdma_params(self):
+        virtual_address = 0
+        dma_len = 10
+        yield self.ib_pack.sink.va.eq(virtual_address)
+        yield self.ib_pack.sink.r_key.eq(0xdeadbeef)
+        yield self.ib_pack.sink.dma_len.eq(dma_len)
+
+    # Configures Infiniband transport layer packetizer
+    def setup_ib(self, opcode, psn, dest_qp=0xdeaded, length=PMTU):
+        header_only = (length == 0)
+        yield from self.set_ib_packet_params(opcode, psn, dest_qp, length)
+
+        opcode_conn_type = (opcode & 0b11100000) >> 5
+        opcode_op        = opcode & 0b00011111
+        if opcode_op in [
+            BTH_OPCODE_OP.RDMA_WRITE_First,
+            BTH_OPCODE_OP.RDMA_WRITE_Middle,
+            BTH_OPCODE_OP.RDMA_WRITE_Last,
+            BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate,
+            BTH_OPCODE_OP.RDMA_WRITE_Only,
+            BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+        ]:
+            yield from self.set_rdma_params()
+
+        yield self.ib_pack.header_only.eq(header_only)
+
+    # Sends an Infiniband transport layer packet
+    def send_ib_packet(self, opcode, dest_qp=0xdeaded, length=PMTU):
+        header_only = (length == 0)
+        yield self.mad_packet.eq(0)
+        yield from self.setup_ib(opcode, self.qp_psn, dest_qp=dest_qp, length=length)
+        self.qp_psn += 1
+
+        yield self.direct_ib_sink.valid.eq(1)
+        i = 0
+        if not header_only:
+            yield self.direct_ib_sink.data.eq(i)
+        yield
+
+        while (yield self.direct_ib_sink.ready) == 0:
+            yield
+
+        if not header_only:
+            while i < length - 1:
+                if (yield self.direct_ib_sink.ready) == 1:
+                    i += 1
+                    yield self.direct_ib_sink.data.eq(i)
+                yield
+
+        yield self.direct_ib_sink.data.eq(0xee)
+        j = 0
+        while j < 4:
+            if (yield self.direct_ib_sink.ready):
+                j += 1
+                if j == 4:
+                    yield self.direct_ib_sink.last.eq(1)
+            yield
+
+        yield self.direct_ib_sink.last.eq(0)
+        yield self.direct_ib_sink.valid.eq(0)
+        yield
+
+    # Sends a MAD Communication Management packet
+    def send_mad_packet(self, attrib):
+        length = 256
+        yield self.mad_packet.eq(1)
+
+        # Setup MAD and Transport layer packetizers
+        yield from self.set_mad_packet_params(attrib)
+        yield from self.setup_ib(BTH_OPCODE.UD.SEND_Only, self.sp_qp_psn, dest_qp=1, length=length)
+        self.sp_qp_psn += 1
+        yield self.mad_pack.header_only.eq(0)
+
+        # Turn on packetizer
+        i = 0
+        yield self.mad_pack.sink.data.eq(i)
+        yield self.mad_pack.sink.valid.eq(1)
+        yield
+
+        # Wait for packetizer to start accepting data
+        while (yield self.mad_pack.sink.ready) == 0:
+            if (yield self.mad_pack.source.ready) and (yield self.mad_pack.source.valid):
+                i += 1
+            yield
+
+        # Send data
+        while i < length - 1:
+            if (yield self.mad_pack.sink.ready):
+                i += 1
+                yield self.mad_pack.sink.data.eq(i)
+            yield
+
+        yield self.mad_pack.sink.data.eq(0xee)
+        j = 0
+        while j < 4:
+            if (yield self.mad_pack.sink.ready):
+                j += 1
+                if j == 4:
+                    yield self.mad_pack.sink.last.eq(1)
+            yield
+
+        # Turn off packetizer
+        yield self.mad_pack.sink.last.eq(0)
+        yield self.mad_pack.sink.valid.eq(0)
+        yield self.mad_packet.eq(0)
+        yield
+
+    def send_direct_stream(self, bytestring):
+        yield self.direct_bytestream_sink.valid.eq(1)
+        for i, byte in enumerate(bytestring):
+            yield self.direct_bytestream_sink.data.eq(byte)
+            if i == len(bytestring) - 1:
+                yield self.direct_bytestream_sink.last.eq(1)
+            yield
+            while not (yield self.direct_bytestream_sink.ready):
+                yield
+        yield self.direct_bytestream_sink.last.eq(0)
+        yield self.direct_bytestream_sink.valid.eq(0)
+        yield
+
+def add_byte(out, n):
+    if n < 0 or n > 255:
+        raise ValueError
+    out += f"\\x{n:02x}"
+
+# Do side operations on every clock front
+@passive
+def record_msg(dut):
+    out = ""
+    while True:
+        if ((yield dut.ib_pack.source.ready) and (yield dut.ib_pack.source.valid)):
+            add_byte(out, (yield dut.ib_pack.source.data))
+            if (yield dut.ib_pack.source.last):
+                print(out + "\n")
+                out = ""
+        yield
+
+from random import randint
+choices = {}
+def random_signal(signal, signal_name=""):
+    global choices
+    l = len(signal)
+    r = randint(0, (1 << l) - 1)
+    choices[signal_name] = r
+    yield signal.eq(r)
+
+def receiver_send(dut):
+    yield from dut.send_mad_packet(MAD_ATTRIB_ID.ConnectRequest)
+    print(1)
+    yield from dut.send_mad_packet(MAD_ATTRIB_ID.ReadyToUse)
+    print(2)
+    yield from dut.send_ib_packet(BTH_OPCODE_OP.SEND_Only)
+    print(3)
+    yield from dut.send_mad_packet(MAD_ATTRIB_ID.DisconnectRequest)
+
+def receiver_direct(dut):
+    packets = [
+        "10e2d5000000207bd293899a080045000134200a400040119626c0aa0102c0aa0132d87212b7012000006400ffff00000001800000128001000000000001010702030000000000000002f2c97e400010000000000000407ec9f2000000000000000001061c06227bd2fffe93899a00000000000000000000150100000010000000a04b1dd4a7ffff37f0ffffffff00000000000000000000ffffc0aa010200000000000000000000ffffc0aa01324d8c60000040008800000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040ab40000000000000000000000000c0aa0102000000000000000000000000c0aa01320000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000c962f010",
+        "w256",
+        "10e2d5000000207bd293899a080045000134200d400040119623c0aa0102c0aa0132d87212b7012000006400ffff00000001800000138001000000000001010702030000000000000002f2c97e400014000000000000407ec9f2fedcabed000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000092fdfef0",
+        "w1024",
+        "10e2d5000000207bd293899a0800450000ec2107400040119571c0aa0102c0aa0132d8d512b700d800000400ffff00deaded80fedfed000050fb000056d1cf3b830000005162000056d1cf3b8b1000005245000056d1cf3b932000005309000056d1cf3b9b3000005450000056d1cf3ba3400000559b000056d1cf3bab50000056ce000056d1cf3bb360000057ac000056d1cf3bbb700000584a000056d1cf3bc38000005933000056d1cf3bcb9000005a69000056d1cf3bd3a000005be3000056d1cf3bdbb000005c23000056d1cf3be3c000005dc9000056d1cf3bebd000005e6d000056d1cf3bf3e000005f59000056d1cf3bfbf0836fdfe2",
+        "w2000",
+        "10e2d5000000207bd293899a08004500013422ca400040119366c0aa0102c0aa0132d87212b7012000006400ffff00000001800000148001000000000001010702030000000000000002f2c97e400015000000000000407ec9f2fedcabeddeaded0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000fc813e59",
+        "w3000"
+    ]
+
+    for _ in range(1):
+        yield dut.direct_bytestream.eq(1)
+        packetn = 0
+        for packetdata in packets:
+            if packetdata[0] == "w":
+                t = int(packetdata[1:])
+                for _ in range(t):
+                    yield
+                print(f"Waited for {t} cycles")
+            else:
+                yield from dut.send_direct_stream(bytes.fromhex(packetdata[28:-8]))
+                print(f"Sent packet number {packetn}")
+                packetn += 1
+
+        print("Waiting for completion")
+        for _ in range(2000):
+            yield
+        print("Done!")
+
+        yield dut.direct_bytestream.eq(0)
+        yield
+
+def sender_send(dut):
+    wr = WR(WR_OPCODE.RDMA_WRITE, 0x11111111, 0x0, 0x100, 0b0, r_key=0x11111111)
+    yield from wr.post(dut.qps[1].send_queue.sink)
+    while (yield dut.qps[1].qp_state) != LiteEthIBQP.RTS:
+        yield
+    yield dut.qps[1].send_queue.sink.valid.eq(1)
+    yield
+    yield dut.qps[1].send_queue.sink.valid.eq(0)
+    yield
+
+class TestRoCEv2(unittest.TestCase):
+    def test_exchange(self):
+        dut = DUT()
+
+        run_simulation(dut, [receiver_send(dut), record_msg(dut)], vcd_name="test.vcd")
+
+    def test_direct(self):
+        dut = DUT()
+
+        run_simulation(dut, [receiver_direct(dut), sender_send(dut)], vcd_name="test.vcd")

--- a/test/test_rocev2.py
+++ b/test/test_rocev2.py
@@ -1,0 +1,633 @@
+import unittest
+
+from migen import *
+from litex.gen import *
+
+from litex.soc.interconnect.stream import Endpoint, EndpointDescription
+
+from liteeth.common import *
+
+from liteeth.core.rocev2.qp import LiteEthIBQP, LiteEthIBSpecialQP
+from liteeth.core.rocev2.cq import LiteEthCQ
+from liteeth.core.rocev2.rocev2 import LiteEthIBTransportRX, LiteEthIBTransportTX, LiteEthIBTransportPacketizer
+from liteeth.core.rocev2.mad_cm import LiteEthIBMAD, LiteEthCMPacketizer
+from liteeth.core.udp import LiteEthUDPPacketizer, LiteEthUDPDepacketizer
+from liteeth.core.ip import LiteEthIPV4Packetizer, LiteEthIPV4Depacketizer
+from liteeth.core.rocev2.icrc import LiteEthInfinibandICRCInserter
+import liteeth.core.rocev2.mr as mr
+
+from liteeth.core.rocev2.rdma_streamer import LiteEthRDMAStreamer
+
+from collections import namedtuple
+dummy_udp_port = namedtuple("udp_port", "address_width data_width")
+dummy_udp_port.address_width = 24
+dummy_udp_port.data_width = 8
+
+class WR:
+    def __init__(self, wr_opcode, l_key, va, dma_len, ack_req, immdt=None, r_key=None):
+        if immdt is not None:
+            assert wr_opcode in [WR_OPCODE.SEND, WR_OPCODE.RDMA_WRITE]
+        if r_key is not None:
+            assert wr_opcode in [WR_OPCODE.RDMA_WRITE, WR_OPCODE.RDMA_READ]
+        if wr_opcode in [WR_OPCODE.RDMA_WRITE, WR_OPCODE.RDMA_READ]:
+            assert r_key is not None
+
+        self.wr_opcode = wr_opcode
+        self.l_key   = l_key
+        self.va      = va
+        self.dma_len = dma_len
+        self.ack_req = ack_req
+        self.immdt   = immdt if immdt else 0
+        self.w_immdt = (immdt is not None)
+        self.r_key   = r_key if r_key else 0
+
+    def post(self, wr_sink):
+        yield wr_sink.wr_opcode.eq(self.wr_opcode)
+        yield wr_sink.l_key.eq(self.l_key)
+        yield wr_sink.va.eq(self.va)
+        yield wr_sink.dma_len.eq(self.dma_len)
+        yield wr_sink.ack_req.eq(self.ack_req)
+        yield wr_sink.w_immdt.eq(self.w_immdt)
+        yield wr_sink.immdt.eq(self.immdt)
+        yield wr_sink.r_key.eq(self.r_key)
+
+class IPModule_dummy(LiteXModule):
+    class IPTX(LiteXModule):
+        def __init__(self, dw):
+            self.sink = sink = Endpoint(eth_ipv4_user_description(dw))
+            self.source = source = Endpoint(eth_mac_description(dw))
+
+            self.packetizer = packetizer = LiteEthIPV4Packetizer(dw=8)
+
+            self.comb += [
+                packetizer.sink.target_ip.eq(sink.ip_address),
+                packetizer.sink.total_length.eq(ipv4_header.length + sink.length),
+                packetizer.sink.version.eq(0x4),     # ipv4
+                packetizer.sink.ihl.eq(ipv4_header.length//4),
+                # RDMA
+                packetizer.sink.dont_fragment.eq(1),
+                packetizer.sink.identification.eq(0),
+                packetizer.sink.ttl.eq(0x80),
+                packetizer.sink.sender_ip.eq(convert_ip("192.1.168.50"))
+            ]
+
+            self.comb += [
+                sink.connect(packetizer.sink, keep={"valid", "ready", "last", "data"}),
+                packetizer.source.connect(source)
+            ]
+
+    class IPRX(LiteXModule):
+        def __init__(self, dw):
+            self.sink = sink = Endpoint(eth_mac_description(dw))
+            self.source = source = Endpoint(eth_ipv4_user_description(dw))
+
+            self.depacketizer = depacketizer = LiteEthIPV4Depacketizer(dw=8)
+
+            self.comb += [
+                depacketizer.source.connect(source, keep={
+                    "protocol",
+                    "error",
+                    "last_be"}),
+                source.length.eq(depacketizer.source.total_length - ipv4_header_length),
+                source.ip_address.eq(depacketizer.source.sender_ip),
+            ]
+
+            self.comb += [
+                sink.connect(depacketizer.sink),
+                depacketizer.source.connect(source, keep={"valid", "ready", "last", "data"})
+            ]
+
+    def __init__(self, dw):
+        self.tx = self.IPTX(dw)
+        self.rx = self.IPRX(dw)
+
+class UDPModule_dummy(LiteXModule):
+    class UDPTX(LiteXModule):
+        def __init__(self, dw):
+            self.sink = sink = Endpoint(eth_udp_user_description(dw))
+            self.source = source = Endpoint(eth_ipv4_user_description(dw))
+
+            self.packetizer = packetizer = LiteEthUDPPacketizer(dw=8)
+
+            self.comb += [
+            sink.connect(packetizer.sink, keep={
+                "last_be",
+                "src_port",
+                "dst_port"}),
+            packetizer.sink.length.eq(sink.length + udp_header.length),
+            packetizer.sink.checksum.eq(0), # UDP Checksum is not used, we only rely on MAC CRC.
+        ]
+
+            self.comb += [
+                sink.connect(packetizer.sink, keep={"valid", "ready", "last", "data"}),
+                packetizer.source.connect(source),
+            ]
+
+    class UDPRX(LiteXModule):
+        def __init__(self, dw):
+            self.sink = sink = Endpoint(eth_ipv4_user_description(dw))
+            self.source = source = Endpoint(eth_udp_user_description(dw))
+
+            self.depacketizer = depacketizer = LiteEthUDPDepacketizer(dw=8)
+
+            self.comb += [
+                sink.connect(depacketizer.sink),
+                depacketizer.source.connect(source, keep={
+                    "src_port",
+                    "dst_port",
+                    "error"}),
+                source.ip_address.eq(sink.ip_address),
+                source.length.eq(depacketizer.source.length - udp_header.length),
+            ]
+
+            self.comb += [
+                sink.connect(depacketizer.sink),
+                depacketizer.source.connect(source, keep={"valid", "ready", "last", "data"})
+            ]
+
+    def __init__(self, ip, dw):
+        self.tx = tx = self.UDPTX(dw)
+        self.rx = rx = self.UDPRX(dw)
+
+        self.comb += [
+            tx.source.connect(ip.tx.sink),
+            ip.rx.source.connect(rx.sink)
+        ]
+
+class DUT(LiteXModule):
+    qp_psn = 0
+    sp_qp_psn = 0
+
+    def __init__(self):
+        # Packetizer will feed into the rocev2 module as if packets were being received through udp
+        self.mad_pack = mad_pack = LiteEthCMPacketizer(dw=8)
+        self.ib_pack = ib_pack = LiteEthIBTransportPacketizer(dw=8)
+
+        self.udp_pack = udp_pack = UDPModule_dummy.UDPTX(dw=8)
+        self.ip_pack = ip_pack = IPModule_dummy.IPTX(dw=8)
+        #self.ip_buff = ip_buff = stream.Buffer(eth_ipv4_user_description(dw=8))
+
+        self.direct_ib_sink = direct_ib_sink = Endpoint(eth_rocev2_description(dw=8))
+        self.direct_bytestream_sink = direct_bytestream_sink = Endpoint(eth_mac_description(dw=8))
+        self.direct_bytestream = Signal()
+        self.mad_packet = Signal()
+
+        # The memory region is replaced with a dummy
+
+        self.mr_handler = mr_handler = mr.LiteEthIBMemoryRegionsHandler()
+
+        mem_num = 8
+        total_mem_size = 0x800 * mem_num
+        self.wmem = wmem = mr.LiteEthDummyTXMR(total_mem_size // 2, 8)
+        self.wmem = wmem = ClockDomainsRenamer({
+            "sys": "sys",
+            "write": "sys",
+            "read": "sys"
+        })(wmem)
+        # Memory regions used for RDMA WRITE requests
+        wmem_port = wmem.get_read_port()
+        wmem_mr = mr_handler.reg_mr(
+            region_start = 0,
+            region_size  = total_mem_size // 2,
+            permissions  = mr.PERM(0),
+            r_key        = 0x11111111,
+            l_key        = 0x11111111,
+            read_port    = wmem_port,
+            write_port   = None
+        )
+        wmem_l_key = wmem_mr.l_key
+
+        rmem = mr.LiteEthDummyRXMR(total_mem_size // 2, 8)
+        self.rmem = rmem = ClockDomainsRenamer({
+            "sys": "sys",
+            "write": "sys",
+            "read": "sys"
+        })(rmem)
+        # Memory regions used for RDMA READ requests
+        rmem_port = rmem.get_write_port()
+        rmem_mr = mr_handler.reg_mr(
+            region_start = 0,
+            region_size  = total_mem_size // 2,
+            permissions  = mr.PERM.LOCAL_WRITE | mr.PERM.NO_LOCAL_READ,
+            r_key        = 0x22222222,
+            l_key        = 0x22222222,
+            read_port    = None,
+            write_port   = rmem_port
+        )
+        rmem_l_key = rmem_mr.l_key
+
+        keymem_size = 2**log2_int(mem_num * 12 + 1, need_pow2=False)
+        self.keymem = keymem = Memory(16, keymem_size // 2)
+        keymem_port = keymem.get_port(write_capable=True)
+        mr_handler.reg_mr(
+            region_start = 0,
+            region_size  = keymem_size,
+            permissions  = mr.PERM.LOCAL_WRITE | mr.PERM.NO_LOCAL_READ,
+            r_key        = 0xdeaded,
+            l_key        = 0xdeaded,
+            read_port    = None,
+            write_port   = keymem_port
+        )
+
+        self.specials += keymem, keymem_port
+
+        cq = LiteEthCQ(depth=0x10)
+        self.submodules.cq = cq
+
+        qp = LiteEthIBQP(qp_id=0xdeaded)
+        self.submodules += qp
+
+        special_qp = LiteEthIBSpecialQP()
+        self.submodules += special_qp
+
+        self.qps = qps = [special_qp, qp]
+
+        self.mad = mad = LiteEthIBMAD(qps, 10e6, dw=8)
+
+        self.ip_dummy = ip_dummy = IPModule_dummy(dw=8)
+        self.udp_dummy = udp_dummy = UDPModule_dummy(ip_dummy, dw=8)
+
+        self.rocev2_tx = rocev2_tx = LiteEthIBTransportTX(ip_dummy, mad.tx, qps, mr_handler.mrs, with_crc=True, buffered_out=True)
+        self.rocev2_rx = rocev2_rx = LiteEthIBTransportRX(ip_dummy, rocev2_tx, mad.rx, qps, cq, mr_handler.mrs, int(125e6), with_crc=True)
+
+        self.crc_ins = crc_ins = LiteEthInfinibandICRCInserter(eth_mac_description(dw=8), eth_rocev2_description(dw=8))
+
+        qp_port = qp.crossbar.get_port(qp_id = "0xdeaded", depth=16)
+        cq_port = cq.crossbar.get_port(qp_id = "0xdeaded", depth=16)
+
+        # Streamer
+        rdma_streamer = LiteEthRDMAStreamer(qp_port, cq_port, wmem, rmem, wmem_l_key, rmem_l_key, mem_num, 8)
+        self.submodules.rdma_streamer = rdma_streamer
+
+        self.length = Signal(16)
+
+        # send_direct_bytestream:
+        # direct_bytestream_sink --> crc_ins --> ip_dummy_rx --> udp_dummy.rx --> rocev2_rx
+        #                               ^-----/                                       |
+        #                                                                             v
+        #                                        ip_dummy_tx <-- udp_dummy.tx <-- rocev2_tx
+        #####################################################################################################
+        # send_mad_packet:
+        # mad_pack --> ib_pack --> udp_pack --> ip_pack --> ip_dummy_rx --> udp_dummy.rx --> rocev2_rx
+        #                                                                                        |
+        #                                                                                        v
+        #                                                   ip_dummy_tx <-- udp_dummy.tx <-- rocev2_tx
+        #####################################################################################################
+        # send_ib_packet:
+        # direct_ib_sink --> ib_pack --> udp_pack --> ip_pack --> ip_dummy_rx --> udp_dummy.rx --> rocev2_rx
+        #                                                                                              |
+        #                                                                                              v
+        #                                                         ip_dummy_tx <-- udp_dummy.tx <-- rocev2_tx
+
+        self.comb += [
+            rocev2_tx.enable.eq(1),
+            If(self.direct_bytestream,
+                direct_bytestream_sink.connect(crc_ins.sink, keep={"valid", "ready", "last", "data"}),
+                #crc_ins.source.connect(ip_buff.sink, keep={"valid", "ready", "last", "data"}),
+                #ip_buff.source.connect(ip_dummy.rx.sink, keep={"valid", "ready", "last", "data"}),
+                crc_ins.source.connect(ip_dummy.rx.sink, keep={"valid", "ready", "last", "data"}),
+                ip_dummy.rx.sink.connect(crc_ins.calculator_sink, keep={"valid", "data", "last"}),
+                # We listen passively to the output of ip, so no control of ready (we don't use connect for it)
+                crc_ins.calculator_sink.ready.eq(ip_dummy.rx.sink.ready)
+            ).Else(
+                If(self.mad_packet,
+                    mad_pack.source.connect(ib_pack.sink, keep={"valid", "ready", "last", "data"})
+                ).Else(
+                    direct_ib_sink.connect(ib_pack.sink, keep={"valid", "ready", "last", "data"})
+                ),
+                ib_pack.source.connect(udp_pack.sink),
+                udp_pack.source.connect(ip_pack.sink),
+                ip_pack.source.connect(ip_dummy.rx.sink),
+            ),
+
+            udp_dummy.rx.source.connect(rocev2_rx.sink),
+            rocev2_tx.source.connect(udp_dummy.tx.sink),
+
+            ip_dummy.tx.source.ready.eq(1)
+        ]
+
+
+        ########
+
+        self.comb += [
+            mad.ipcm.source.ready.eq(1)
+        ]
+
+        from liteeth.core.rocev2.rdma_key_exchanger import LiteEthRDMAKeyExchanger
+        self.key_exchanger = LiteEthRDMAKeyExchanger(
+            qp       = qp_port,
+            cq       = cq_port,
+            keymem   = self.keymem,
+            mem_num = mem_num,
+            dw       = 8
+        )
+
+        reset = Signal(reset=1)
+        self.sync += reset.eq(0)
+        self.comb += [
+            self.rmem.reset_sys.eq(reset),
+            self.wmem.reset_sys.eq(reset),
+            self.rdma_streamer.reset.eq(reset),
+            self.key_exchanger.reset.eq(reset)
+        ]
+
+        self.fsm = fsm = FSM(reset_state="WAIT_RTS")
+        fsm.act("WAIT_RTS",
+            If(qp.qp_state == LiteEthIBQP.RTS,
+                NextState("REQUEST")
+            )
+        )
+
+        fsm.act("REQUEST",
+            self.key_exchanger.request.eq(1),
+            NextState("WAIT_KEYS")
+        )
+
+        fsm.act("WAIT_KEYS",
+            If(self.key_exchanger.source.valid,
+                NextState("R_KEYS")
+            )
+        )
+
+        fsm.act("R_KEYS",
+            self.key_exchanger.source.ready.eq(1),
+            If(self.key_exchanger.source.valid,
+                self.key_exchanger.source.connect(self.rdma_streamer.key_sink, keep={"valid", "ready", "r_key", "va"}),
+                If(self.key_exchanger.source.last,
+                    NextState("SEND")
+                )
+            )
+        )
+
+
+        cnt = Signal(8)
+
+        fsm.act("SEND",
+            self.rdma_streamer.enable.eq(1),
+
+            # NextValue(cnt, cnt + 1),
+            # self.rdma_streamer.sink.valid.eq(1),
+            # self.rdma_streamer.sink.data.eq(cnt),
+
+            # self.rdma_streamer.source.ready.eq(1),
+
+            self.rdma_streamer.source.ready.eq(1),
+
+            If(qp.qp_state != LiteEthIBQP.RTS,
+                NextState("R_KEYS")
+            )
+        )
+
+    def set_mad_packet_params(self, attrib):
+        # MAD
+        yield self.mad_pack.sink.BaseVersion.eq(0x01)
+        yield self.mad_pack.sink.MgmtClass.eq(0x07)
+        yield self.mad_pack.sink.ClassVersion.eq(0x02)
+        yield self.mad_pack.sink.Method.eq(0x03)
+        yield self.mad_pack.sink.AttributeID.eq(attrib)
+
+        # CM
+        yield self.mad_pack.sink.Local_QPN.eq(0x11)
+        yield self.mad_pack.sink.Responder_Resources.eq(0x01)
+        yield self.mad_pack.sink.Initiator_Depth.eq(0x01)
+        yield self.mad_pack.sink.Partition_Key.eq(0xffff)
+        yield self.mad_pack.sink.Starting_PSN.eq(0xcafeed)
+        yield self.mad_pack.sink.Primary_Local_Port_GID.eq(Cat(convert_ip("192.168.1.1"), Constant(0xffff, 16)))
+
+        self.qp_psn = 0xcafeed
+
+    def set_ib_packet_params(self, opcode, psn, dest_qp=0xdeaded, length=PMTU):
+        yield self.length.eq(length)
+        # Set opcode
+        yield self.ib_pack.sink.opcode.eq(opcode)
+        yield self.ib_pack.sink.psn.eq(psn)
+        yield self.ib_pack.sink.tver.eq(0)
+        yield self.ib_pack.sink.dest_qp.eq(dest_qp)
+        yield self.ib_pack.sink.pad.eq((4 - (length % 4)) % 4)
+
+        yield self.ib_pack.sink.se.eq(0)
+        yield self.ib_pack.sink.m.eq(0)
+        yield self.ib_pack.sink.a.eq(1)
+        yield self.ib_pack.sink.se.eq(0)
+        yield self.ib_pack.sink.p_key.eq(DEFAULT_P_KEY)
+
+        if dest_qp == 1:
+            yield self.ib_pack.sink.q_key.eq(DEFAULT_CM_Q_Key)
+            yield self.ib_pack.sink.src_qp.eq(1)
+
+        psn += 1
+
+    def set_rdma_params(self):
+        virtual_address = 0
+        dma_len = 10
+        yield self.ib_pack.sink.va.eq(virtual_address)
+        yield self.ib_pack.sink.r_key.eq(0xdeadbeef)
+        yield self.ib_pack.sink.dma_len.eq(dma_len)
+
+    # Configures Infiniband transport layer packetizer
+    def setup_ib(self, opcode, psn, dest_qp=0xdeaded, length=PMTU):
+        header_only = (length == 0)
+        yield from self.set_ib_packet_params(opcode, psn, dest_qp, length)
+
+        opcode_conn_type = (opcode & 0b11100000) >> 5
+        opcode_op        = opcode & 0b00011111
+        if opcode_op in [
+            BTH_OPCODE_OP.RDMA_WRITE_First,
+            BTH_OPCODE_OP.RDMA_WRITE_Middle,
+            BTH_OPCODE_OP.RDMA_WRITE_Last,
+            BTH_OPCODE_OP.RDMA_WRITE_Last_with_Immediate,
+            BTH_OPCODE_OP.RDMA_WRITE_Only,
+            BTH_OPCODE_OP.RDMA_WRITE_Only_with_Immediate
+        ]:
+            yield from self.set_rdma_params()
+
+        yield self.ib_pack.sink.header_only.eq(header_only)
+
+    # Sends an Infiniband transport layer packet
+    def send_ib_packet(self, opcode, dest_qp=0xdeaded, length=PMTU):
+        header_only = (length == 0)
+        yield self.mad_packet.eq(0)
+        yield from self.setup_ib(opcode, self.qp_psn, dest_qp=dest_qp, length=length)
+        self.qp_psn += 1
+
+        yield self.direct_ib_sink.valid.eq(1)
+        i = 0
+        if not header_only:
+            yield self.direct_ib_sink.data.eq(i)
+        yield
+
+        while (yield self.direct_ib_sink.ready) == 0:
+            yield
+
+        if not header_only:
+            while i < length - 1:
+                if (yield self.direct_ib_sink.ready) == 1:
+                    i += 1
+                    yield self.direct_ib_sink.data.eq(i)
+                yield
+
+        yield self.direct_ib_sink.data.eq(0xee)
+        j = 0
+        while j < 4:
+            if (yield self.direct_ib_sink.ready):
+                j += 1
+                if j == 4:
+                    yield self.direct_ib_sink.last.eq(1)
+            yield
+
+        yield self.direct_ib_sink.last.eq(0)
+        yield self.direct_ib_sink.valid.eq(0)
+        yield
+
+    # Sends a MAD Communication Management packet
+    def send_mad_packet(self, attrib):
+        length = 256
+        yield self.mad_packet.eq(1)
+
+        # Setup MAD and Transport layer packetizers
+        yield from self.set_mad_packet_params(attrib)
+        yield from self.setup_ib(BTH_OPCODE.UD.SEND_Only, self.sp_qp_psn, dest_qp=1, length=length)
+        self.sp_qp_psn += 1
+        yield self.mad_pack.sink.header_only.eq(0)
+
+        # Turn on packetizer
+        i = 0
+        yield self.mad_pack.sink.data.eq(i)
+        yield self.mad_pack.sink.valid.eq(1)
+        yield
+
+        # Wait for packetizer to start accepting data
+        while (yield self.mad_pack.sink.ready) == 0:
+            if (yield self.mad_pack.source.ready) and (yield self.mad_pack.source.valid):
+                i += 1
+            yield
+
+        # Send data
+        while i < length - 1:
+            if (yield self.mad_pack.sink.ready):
+                i += 1
+                yield self.mad_pack.sink.data.eq(i)
+            yield
+
+        yield self.mad_pack.sink.data.eq(0xee)
+        j = 0
+        while j < 4:
+            if (yield self.mad_pack.sink.ready):
+                j += 1
+                if j == 4:
+                    yield self.mad_pack.sink.last.eq(1)
+            yield
+
+        # Turn off packetizer
+        yield self.mad_pack.sink.last.eq(0)
+        yield self.mad_pack.sink.valid.eq(0)
+        yield self.mad_packet.eq(0)
+        yield
+
+    def send_direct_stream(self, bytestring):
+        yield self.direct_bytestream_sink.valid.eq(1)
+        for i, byte in enumerate(bytestring):
+            yield self.direct_bytestream_sink.data.eq(byte)
+            if i == len(bytestring) - 1:
+                yield self.direct_bytestream_sink.last.eq(1)
+            yield
+            while not (yield self.direct_bytestream_sink.ready):
+                yield
+        yield self.direct_bytestream_sink.last.eq(0)
+        yield self.direct_bytestream_sink.valid.eq(0)
+        yield
+
+def add_byte(out, n):
+    if n < 0 or n > 255:
+        raise ValueError
+    out += f"\\x{n:02x}"
+
+# Do side operations on every clock front
+@passive
+def record_msg(dut):
+    out = ""
+    while True:
+        if ((yield dut.ib_pack.source.ready) and (yield dut.ib_pack.source.valid)):
+            add_byte(out, (yield dut.ib_pack.source.data))
+            if (yield dut.ib_pack.source.last):
+                print(out + "\n")
+                out = ""
+        yield
+
+from random import randint
+choices = {}
+def random_signal(signal, signal_name=""):
+    global choices
+    l = len(signal)
+    r = randint(0, (1 << l) - 1)
+    choices[signal_name] = r
+    yield signal.eq(r)
+
+def receiver_send(dut):
+    yield from dut.send_mad_packet(MAD_ATTRIB_ID.ConnectRequest)
+    print(1)
+    yield from dut.send_mad_packet(MAD_ATTRIB_ID.ReadyToUse)
+    print(2)
+    yield from dut.send_ib_packet(BTH_OPCODE_OP.SEND_Only)
+    print(3)
+    yield from dut.send_mad_packet(MAD_ATTRIB_ID.DisconnectRequest)
+
+def receiver_direct(dut):
+    vlan = True
+    crc = True
+    packet_start = 28 + (8 if vlan else 0)
+    packet_end = (-8 if crc else 0)
+
+    packets = [
+        "10e2d5000000b8599f077e2a810000010800450201349d404000401118eec0aa0102c0aa0132fa4f12b7012000006440ffff00000001000001cc800100000000000101070203000000000000000357feb735001000000000000035b7fe57000015b30000000001066b13b8599f0300077e2a00000000000000000001441000000010000000b0cf7bf6b7ffff37f0ffffffff00000000000000000000ffffc0aa010200000000000000000000ffffc0aa01325ba590000040009000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000040affa000000000000000000000000c0aa0102000000000000000000000000c0aa013200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002fcc9e99",
+        "w256",
+        "10e2d5000000b8599f077e2a810000010800450201349d414000401118edc0aa0102c0aa0132fa4f12b7012000006440ffff00000001000001cd800100000000000101070203000000000000000357feb735001400000000000035b7fe57fedcabed0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000a286b250",
+        "w256",
+        "10e2d5000000b8599f077e2a810000010800450200ec9d4d400040111929c0aa0102c0aa0132fa4f12b700d800000440ffff00deaded80fedfed001eeac8000055f5d63c3020001eecca000055f5d63c3820001eeecc000055f5d63c4020001ef0ce000055f5d63c4820001ef2d0000055f5d63c5020001ef4d2000055f5d63c5820001ef6d4000055f5d63c6020001ef8d6000055f5d63c6820001efad8000055f5d63c7030001efcda000055f5d63c7830001efedc000055f5d63c8030001f00de000055f5d63c8830001f02e0000055f5d63c9030001f04e2000055f5d63c9830001f06e4000055f5d63ca030001f08e6000055f5d63ca8301e083ed6",
+        "w1024",
+        "10e2d5000000b8599f077e2a810000010800450200309d4e4000401119e4c0aa0102c0aa0132fa4f12b7001c00001140ffff00deaded00cf7bf70000000259caeaf7",
+        "10e2d5000000b8599f077e2a810000010800450200309d4f4000401119e3c0aa0102c0aa0132fa4f12b7001c00001140ffff00deaded00cf7bf900000004a4da30ef"
+    ]
+
+    for _ in range(1):
+        yield dut.direct_bytestream.eq(1)
+        packetn = 0
+        for packetdata in packets:
+            if packetdata[0] == "w":
+                t = int(packetdata[1:])
+                for _ in range(t):
+                    yield
+                print(f"Waited for {t} cycles")
+            else:
+                yield from dut.send_direct_stream(bytes.fromhex(packetdata[packet_start:packet_end]))
+                print(f"Sent packet number {packetn}")
+                packetn += 1
+
+        print("Waiting for completion")
+        for _ in range(2000):
+            yield
+        print("Done!")
+
+        yield dut.direct_bytestream.eq(0)
+        yield
+
+def sender_send(dut):
+    wr = WR(WR_OPCODE.RDMA_WRITE, 0x11111111, 0x0, 0x100, 0b0, r_key=0x11111111)
+    yield from wr.post(dut.qps[1].send_queue.sink)
+    while (yield dut.qps[1].qp_state) != LiteEthIBQP.RTS:
+        yield
+    yield dut.qps[1].send_queue.sink.valid.eq(1)
+    yield
+    yield dut.qps[1].send_queue.sink.valid.eq(0)
+    yield
+
+class TestRoCEv2(unittest.TestCase):
+    def test_exchange(self):
+        dut = DUT()
+
+        run_simulation(dut, [receiver_send(dut), record_msg(dut)], vcd_name="test.vcd")
+
+    def test_direct(self):
+        dut = DUT()
+
+        run_simulation(dut, [receiver_direct(dut), sender_send(dut)], vcd_name="test.vcd")

--- a/test/test_wait_pipe.py
+++ b/test/test_wait_pipe.py
@@ -1,0 +1,151 @@
+import unittest
+
+from litex.gen import *
+
+from litex.soc.interconnect.stream import EndpointDescription
+from liteeth.core.rocev2.common import WaitPipe
+
+PMTU = 256
+
+class Packet:
+    def __init__(self, data=None, param=0):
+        self.data = data if data else []
+        self.param = param
+        self.length = len(data)
+
+    def cmp(self, other):
+        return (self.data == other.data
+            and self.param == other.param
+            and self.length == other.length)
+
+    def cmp_headers(self, other):
+        return (self.param == other.param)
+
+def push_packet(dut, packet, valid):
+    print(f"Sending packet {packet.data}")
+    yield dut.sink.valid.eq(1)
+    yield dut.sink.parameter.eq(packet.param)
+
+    if packet.length == 0:
+        yield dut.sink.last.eq(1)
+        yield
+    else:
+        i = 0
+        while i < packet.length:
+            yield dut.sink.data.eq(packet.data[i])
+            yield dut.sink.last.eq(i == packet.length - 1)
+            yield
+            if (yield dut.sink.valid) and (yield dut.sink.ready):
+                i += 1
+    yield dut.sink.last.eq(0)
+
+    yield dut.sink.valid.eq(0)
+    if valid:
+        yield dut.validate.eq(1)
+        yield dut.invalidate.eq(0)
+    else:
+        yield dut.validate.eq(0)
+        yield dut.invalidate.eq(1)
+    yield
+
+    yield dut.validate.eq(0)
+    yield dut.invalidate.eq(0)
+
+def pop_packet(dut, packet=None, header_only=False):
+    yield dut.header_only.eq(header_only)
+    yield dut.source.ready.eq(1)
+    yield
+
+    param = (yield dut.source.parameter)
+    length = (yield dut.length)
+    if packet:
+        packet.param = param
+        packet.length = length
+
+    if not header_only:
+        i = 0
+        while i < length:
+            data = (yield dut.source.data)
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                if (yield dut.source.last):
+                    packet.length = i + 1
+                if packet:
+                    packet.data.append(data)
+                i += 1
+            yield
+
+    yield dut.source.ready.eq(0)
+
+def push_packets(dut, packets, valid_map=None, delay=0):
+    valid_map = valid_map if valid_map else [True] * len(packets)
+    assert len(valid_map) == len(packets)
+
+    for i, packet in enumerate(packets):
+        yield from push_packet(dut, packet, valid_map[i])
+        while (yield dut.full):
+            yield from push_packet(dut, packet, valid_map[i])
+
+        if i != len(packets) - 1:
+            for _ in range(delay):
+                yield
+
+def pop_packets(dut, packets, n=1, header_only_map=None, delay=0):
+    header_only_map = header_only_map if header_only_map else [False] * n
+    assert len(header_only_map) == n
+
+    c = 0
+    while c < n:
+        if (yield dut.source.valid):
+            packets.append(Packet([]))
+            yield from pop_packet(dut, packets[-1], header_only=header_only_map[c])
+            if c != n - 1:
+                for _ in range(delay):
+                    yield
+            c += 1
+        yield
+
+class TestWaitPipe(unittest.TestCase):
+    dw = 8
+    def test_wait_pipe(self):
+        layout = EndpointDescription([("data", self.dw)], [("parameter", 10)])
+        dut = WaitPipe(layout, 3, PMTU, self.dw)
+
+        valid_map = [True, False, True, True, False, False, True, False, False]
+        send_packets = [Packet([(j * i) % PMTU for i in range(PMTU - (9 - j) * 5)], (j * 7) % 3) for j in range(1, 10)]
+        rcv_packets = []
+
+        run_simulation(dut, [push_packets(dut, send_packets, valid_map), pop_packets(dut, rcv_packets, sum(valid_map, 0))], vcd_name="test.vcd")
+        sent_packets = [packet for (packet, valid) in zip(send_packets, valid_map) if valid]
+        for s, r in zip(sent_packets, rcv_packets):
+            self.assertTrue(s.cmp(r))
+
+    def test_wait_pipe_full(self):
+        layout = EndpointDescription([("data", self.dw)], [("parameter", 10)])
+        dut = WaitPipe(layout, 3, PMTU, self.dw)
+
+        valid_map = [True, False, True, True, False, False, True, False, False]
+        send_packets = [Packet([(j * i) % PMTU for i in range(PMTU - (9 - j) * 5)], (j * 7) % 3) for j in range(1, 10)]
+        rcv_packets = []
+
+        run_simulation(dut, [push_packets(dut, send_packets, valid_map, delay=0), pop_packets(dut, rcv_packets, sum(valid_map, 0), delay=PMTU * 5)], vcd_name="test.vcd")
+        sent_packets = [packet for (packet, valid) in zip(send_packets, valid_map) if valid]
+        for s, r in zip(sent_packets, rcv_packets):
+            self.assertTrue(s.cmp(r))
+
+    def test_wait_pipe_header_only(self):
+        layout = EndpointDescription([("data", self.dw)], [("parameter", 10)])
+        dut = WaitPipe(layout, 3, PMTU, self.dw)
+
+        header_only_map = [True, False, True, True, False, False, True, False, False]
+        send_packets = [Packet([(j * i) % PMTU for i in range(0 if header_only_map[j - 1] else 100)], (j * 7) % 3) for j in range(1, 10)]
+        rcv_packets = []
+
+        run_simulation(dut, [push_packets(dut, send_packets), pop_packets(dut, rcv_packets, len(send_packets), header_only_map)], vcd_name="test.vcd")
+        for i, (s, r) in enumerate(zip(send_packets, rcv_packets)):
+            if header_only_map[i]:
+                self.assertTrue(s.cmp_headers(r))
+            else:
+                self.assertTrue(s.cmp(r))
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_wait_pipe.py
+++ b/test/test_wait_pipe.py
@@ -1,0 +1,248 @@
+import unittest
+
+from litex.gen import *
+
+from litex.soc.interconnect.stream import EndpointDescription
+from liteeth.core.rocev2.common import WaitPipe
+
+PMTU = 256
+
+class Packet:
+    def __init__(self, data=None, param=0):
+        self.data = data if data else []
+        self.param = param
+        self.length = len(data)
+
+    def cmp(self, other):
+        check = (self.data == other.data
+            and self.param == other.param
+            and self.length == other.length)
+        if not check:
+            if self.data != other.data:
+                print("Data differs!")
+            if self.param != other.param:
+                print("Param differs!")
+            if self.length != other.length:
+                print("Length differs!")
+        return check
+
+    def cmp_headers(self, other):
+        return (self.param == other.param)
+
+def push_packet(dut, packet, valid, validate_delay):
+    #print(f"Sending packet {packet.data}")
+    yield dut.sink.valid.eq(1)
+    yield dut.sink.parameter.eq(packet.param)
+
+    if validate_delay > 0:
+        if packet.length == 0:
+            yield dut.sink.last.eq(1)
+            yield dut.sink.header_only.eq(1)
+            while not ((yield dut.sink.valid) and (yield dut.sink.ready)):
+                yield
+        else:
+            i = 0
+            while i < packet.length:
+                yield dut.sink.data.eq(packet.data[i])
+                yield dut.sink.last.eq(i == packet.length - 1)
+                yield
+                if (yield dut.sink.valid) and (yield dut.sink.ready):
+                    i += 1
+        yield dut.sink.last.eq(0)
+
+        yield dut.sink.valid.eq(0)
+        for _ in range(validate_delay - 1):
+            yield
+        if valid:
+            yield dut.validate_sink.validate.eq(1)
+            yield dut.validate_sink.invalidate.eq(0)
+        else:
+            yield dut.validate_sink.validate.eq(0)
+            yield dut.validate_sink.invalidate.eq(1)
+        yield
+    else:
+        if packet.length == 0:
+            if valid:
+                yield dut.validate_sink.validate.eq(1)
+                yield dut.validate_sink.invalidate.eq(0)
+            else:
+                yield dut.validate_sink.validate.eq(0)
+                yield dut.validate_sink.invalidate.eq(1)
+
+            yield dut.sink.last.eq(1)
+            yield dut.sink.header_only.eq(1)
+            yield
+            while not ((yield dut.sink.valid) and (yield dut.sink.ready)):
+                yield
+        else:
+            i = 0
+            while i < packet.length:
+                if i == packet.length - 1:
+                    if valid:
+                        yield dut.validate_sink.validate.eq(1)
+                        yield dut.validate_sink.invalidate.eq(0)
+                    else:
+                        yield dut.validate_sink.validate.eq(0)
+                        yield dut.validate_sink.invalidate.eq(1)
+                yield dut.sink.data.eq(packet.data[i])
+                yield dut.sink.last.eq(i == packet.length - 1)
+                yield
+                if (yield dut.sink.valid) and (yield dut.sink.ready):
+                    i += 1
+        yield dut.sink.last.eq(0)
+        yield dut.sink.valid.eq(0)
+
+    yield dut.validate_sink.validate.eq(0)
+    yield dut.validate_sink.invalidate.eq(0)
+
+    yield dut.sink.header_only.eq(0)
+
+def pop_packet(dut, packet=None):
+    yield dut.source.ready.eq(1)
+
+    # Get to the first cycle where a read happens
+    while not ((yield dut.source.valid) and (yield dut.source.ready)):
+        yield
+
+    param = (yield dut.source.parameter)
+    if packet:
+        packet.param = param
+
+    if not (yield dut.source.header_only):
+        i = 0
+        while True:
+            data = (yield dut.source.data)
+            if (yield dut.source.valid) and (yield dut.source.ready):
+                if packet:
+                    packet.data.append(data)
+                if (yield dut.source.last):
+                    break
+                i += 1
+            yield
+        packet.length = i + 1
+
+    yield dut.source.ready.eq(0)
+
+    yield
+
+
+def push_packets(dut, packets, valid_map=None, discarding=True, validate_delay=1, delay=0):
+    valid_map = valid_map if valid_map else [True] * len(packets)
+    assert len(valid_map) == len(packets)
+
+    for i, packet in enumerate(packets):
+        print(i)
+        yield from push_packet(dut, packet, valid_map[i], validate_delay)
+        while (yield dut.full):
+            if discarding:
+                yield from push_packet(dut, packet, valid_map[i], validate_delay)
+            else:
+                yield
+
+        if i != len(packets) - 1:
+            for _ in range(delay):
+                yield
+
+def pop_packets(dut, packets, n=1, delay=0):
+    c = 0
+    while c < n:
+        packets.append(Packet([]))
+        yield from pop_packet(dut, packets[-1])
+        # print(f"Received packet {packets[-1].data} {packets[-1].param}")
+        if c != n - 1:
+            for _ in range(delay):
+                yield
+        c += 1
+
+class BaseCase(unittest.TestCase):
+    def setUp(self):
+        print('\n', unittest.TestCase.id(self))
+
+class TestWaitPipe(BaseCase):
+    dw = 8
+    def test_wait_pipe(self):
+        layout = EndpointDescription([("data", self.dw)], [("parameter", 10), ("length", 32)])
+        dut = WaitPipe(layout, 3, PMTU, self.dw)
+
+        valid_map = [True, False, True, True, False, False, True, False, False]
+        send_packets = [Packet([(j * i) % PMTU for i in range(PMTU - (9 - j) * 5)], (j * 7) % 3) for j in range(1, 10)]
+        rcv_packets = []
+
+        run_simulation(dut, [push_packets(dut, send_packets, valid_map), pop_packets(dut, rcv_packets, sum(valid_map, 0))], vcd_name="test.vcd")
+        sent_packets = [packet for (packet, valid) in zip(send_packets, valid_map) if valid]
+        for s, r in zip(sent_packets, rcv_packets):
+            self.assertTrue(s.cmp(r))
+
+    def test_wait_pipe_full(self):
+        layout = EndpointDescription([("data", self.dw)], [("parameter", 10), ("length", 32)])
+        dut = WaitPipe(layout, 3, PMTU, dw=self.dw)
+
+        valid_map = [True, False, True, True, False, False, True, False, False]
+        send_packets = [Packet([(j * i) % PMTU for i in range(PMTU - (9 - j) * 5)], (j * 7) % 3) for j in range(1, 10)]
+        rcv_packets = []
+
+        run_simulation(dut, [push_packets(dut, send_packets, valid_map, discarding=True, delay=0), pop_packets(dut, rcv_packets, sum(valid_map, 0), delay=PMTU * 5)], vcd_name="test.vcd")
+        sent_packets = [packet for (packet, valid) in zip(send_packets, valid_map) if valid]
+        for s, r in zip(sent_packets, rcv_packets):
+            self.assertTrue(s.cmp(r))
+
+    def test_wait_pipe_full_non_discarding(self):
+        layout = EndpointDescription([("data", self.dw)], [("parameter", 10), ("length", 32)])
+        dut = WaitPipe(layout, 3, PMTU, dw=self.dw)
+
+        valid_map = [True, False, True, True, False, False, True, False, False]
+        send_packets = [Packet([(j * i) % PMTU for i in range(PMTU - (9 - j) * 5)], (j * 7) % 3) for j in range(1, 10)]
+        rcv_packets = []
+
+        run_simulation(dut, [push_packets(dut, send_packets, valid_map, discarding=False, delay=0), pop_packets(dut, rcv_packets, sum(valid_map, 0), delay=PMTU * 5)], vcd_name="test.vcd")
+        sent_packets = [packet for (packet, valid) in zip(send_packets, valid_map) if valid]
+        for s, r in zip(sent_packets, rcv_packets):
+            self.assertTrue(s.cmp(r))
+
+    def test_wait_pipe_header_only(self):
+        layout = EndpointDescription([("data", self.dw)], [("parameter", 10), ("length", 32)])
+        dut = WaitPipe(layout, 8, PMTU, self.dw, buffered_in=False)
+
+        header_only_map = [True, False, True, True, False, False, True, False, False]
+        send_packets = [Packet([(j * i) % PMTU for i in range(0 if header_only_map[j - 1] else 100)], (j * 7) % 3) for j in range(1, 10)]
+        rcv_packets = []
+
+        run_simulation(dut, [push_packets(dut, send_packets), pop_packets(dut, rcv_packets, len(send_packets))], vcd_name="test.vcd")
+        for i, (s, r) in enumerate(zip(send_packets, rcv_packets)):
+            if header_only_map[i]:
+                self.assertTrue(s.cmp_headers(r))
+            else:
+                self.assertTrue(s.cmp(r))
+
+    def test_wait_pipe_header_only_non_discard(self):
+        layout = EndpointDescription([("data", self.dw)], [("parameter", 10), ("length", 32)])
+        dut = WaitPipe(layout, 3, PMTU, buffered_in=False, discarding=False, dw=self.dw)
+
+        send_packets = [Packet([], j) for j in range(1, 10)]
+        rcv_packets = []
+
+        run_simulation(dut, [push_packets(dut, send_packets, discarding=False), pop_packets(dut, rcv_packets, len(send_packets), delay=10)], vcd_name="test.vcd")
+        for s, r in zip(send_packets, rcv_packets):
+            self.assertTrue(s.cmp_headers(r))
+
+   # TODO: This test requires for validate to depend combinatorially on ready (which seems to be impossible to do with the Migen simulator)
+   # This is due to the fact that validate_delay is 0 here and thus validate should be asserted for one cycle on last when ready is asserted.
+   # def test_wait_pipe_header_mixed_non_discard(self):
+   #     layout = EndpointDescription([("data", self.dw)], [("parameter", 10), ("length", 32)])
+   #     dut = WaitPipe(layout, 3, PMTU, buffered_in=False, discarding=False, dw=self.dw)
+
+   #     header_only_map = [True, True, True, True, False, True, False, True, True]
+   #     send_packets = [Packet([(j * i) % PMTU for i in range(0 if header_only_map[j - 1] else 100)], j) for j in range(1, 10)]
+   #     rcv_packets = []
+
+   #     run_simulation(dut, [push_packets(dut, send_packets, discarding=False, validate_delay=0), pop_packets(dut, rcv_packets, len(send_packets), delay=10)], vcd_name="test.vcd")
+   #     for i, (s, r) in enumerate(zip(send_packets, rcv_packets)):
+   #         print(f"{s.param} {s.length} {s.data}")
+   #         print(f"{r.param} {r.length} {r.data}")
+   #         if header_only_map[i]:
+   #             self.assertTrue(s.cmp_headers(r))
+   #         else:
+   #             self.assertTrue(s.cmp(r))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds **RoCEv2** (RDMA over Converged Ethernet v2 with RDMA being Remote Direct Memory Access) functionality to LiteEth.

In particular, this pull request is built to be compliant with the [InfiniBand Architecture Specification Volume 1 (Release 1.2.1)](https://www.afs.enea.it/asantoro/V1r1_2_1.Release_12062007.pdf).
It implements the **Transport Layer** (Chapter 9) of the InfiniBand protocol as well as the **CM (Communication Management)** protocol (Chapter 12) and part of the **IP CM** protocol (Annex A11) for standard connection establishment.
This is done on top of the UDP/IP (similarly to the `LiteEthUDPIPCore`) to comply with the [Annex 17 - RoCEv2](https://www.scribd.com/document/350043431/Annex17-RoCEv2-2) of the InfiniBand specification.

The changes are gathered in the `LiteEthRoCEv2Core` which includes the RDMA on top of the IP/UDP stack (which remains usable for normal UDP connections through ports other than 4791, which is the IANA assigned port for the RoCEv2 protocol).

Both the responder and requester side of the protocol is implemented, meaning that the FPGA can function as the passive or active **TCA (Target Channel Adapter)** which can have one **QP (Queue Pair)** in **RC (Reliable Connection)** mode, as well as a **Special QP (QP1)** used for **CM** in **UD (Unreliable Datagram)** mode.

Only the responder side of the **CM** protocol is implemented here, so the connection establishment must be done by the other device. 

Thus, an **HCA (Host Channel Adapter)** can establish a connection and send **RDMA Read** and **Write** operations, as well as **Send** operations to this module, and receive acknowledgements as specified in the protocol. Additionally, the module can send **RDMA Read** and **Write** requests as well as **Send** requests, to which the **HCA** has to respond. This allows existing hardware such as Mellanox ConnectX cards to communicate with the FPGA through the use of **Infiniband's Verbs API** as well as other calls to the [rdma-core](https://github.com/linux-rdma/rdma-core) library. Regular networking cards can also communicate through RoCEv2 with Software ROCE, also implemented in the [rdma-core](https://github.com/linux-rdma/rdma-core) library.

Note that for the FPGA to be the requester in this connection, for it to send RDMA requests, the HCA has to transfer its memory regions' keys to the FPGA. The way of doing this is not specified in the protocol. The **LiteEthKeyExchanger** module shows an example of how it can be done.

## Tests

This module has been tested using a 1000BASE-T and 1000BASE-LX connection to a Mellanox ConnectX-4 Lx, as well as a regular networking card using Software ROCE.

It can be tested using the test.c script I am sharing through this [gist](https://gist.github.com/Skinbow/15e6304ae51d3682bd6f678bb04ea273).

Here are some tests results that I obtained with the Mellanox card:

Test of a RDMA_WRITE followed by an RDMA READ on the same memory region (twice):
```
$ ./test -C 2 -c -a 192.170.1.50 -S 32 -V
Sent:
\x05\x0c\xd4\x74\xe5\xd3\x27\x44\x45\x64\x29\x56\x09\x49\x69\x46\x39\x80\xcc\x48\xd5\x1b\xf0\xce\xf3\xe4\x7a\x95\x02\x79\x37\xf8
Received:
\x05\x0c\xd4\x74\xe5\xd3\x27\x44\x45\x64\x29\x56\x09\x49\x69\x46\x39\x80\xcc\x48\xd5\x1b\xf0\xce\xf3\xe4\x7a\x95\x02\x79\x37\xf8

Data matches
Sent:
\xdc\xc2\x6b\x56\x2b\x8f\xe9\x2b\x60\x63\x9b\xf0\xd0\x58\x2f\x28\x1d\x3b\xd0\xe1\xf3\xc6\xe1\x09\x68\xc9\x2b\xc3\xc8\xc9\x8b\x44
Received:
\xdc\xc2\x6b\x56\x2b\x8f\xe9\x2b\x60\x63\x9b\xf0\xd0\x58\x2f\x28\x1d\x3b\xd0\xe1\xf3\xc6\xe1\x09\x68\xc9\x2b\xc3\xc8\xc9\x8b\x44

Data matches
```
with the transmission showing in Wireshark:
<img width="1063" height="590" alt="Screenshot from 2026-04-02 15-03-45" src="https://github.com/user-attachments/assets/e81f5da5-bd01-4c5a-ba3a-ff011060e2e7" />

Benchmarks with RDMA_WRITEs:
```
$ ./test -b -w -C 1000 -c -a 192.170.1.50 -S 1024
Sent 8 1024-byte RDMA_WRITEs 1000 times in 71.88ms
This amounts to a transfer rate of MB/s: 113.962990
$ ./test -b -w -C 1000 -c -a 192.170.1.50 -S 2048
Sent 8 2048-byte RDMA_WRITEs 1000 times in 142.63ms
This amounts to a transfer rate of MB/s: 114.872999
$ ./test -b -w -C 1000 -c -a 192.170.1.50 -S 32768
Sent 8 32768-byte RDMA_WRITEs 1000 times in 2.27s
This amounts to a transfer rate of MB/s: 115.677083
```

Benchmarks with RDMA_READs
```
$ ./test -b -r -C 1000 -c -a 192.170.1.50 -S 1024
Sent 8 1024-byte RDMA_READs 1000 times in 71.22ms
This amounts to a transfer rate of MB/s: 115.028594
$ ./test -b -r -C 1000 -c -a 192.170.1.50 -S 2048
Sent 8 2048-byte RDMA_READs 1000 times in 142.70ms
This amounts to a transfer rate of MB/s: 114.817430
$ ./test -b -r -C 1000 -c -a 192.170.1.50 -S 32768
Sent 8 32768-byte RDMA_READs 1000 times in 2.27s
This amounts to a transfer rate of MB/s: 115.701172
```

Benchmarks with RDMA_READs and RDMA_WRITEs in quick succession:
```
$ ./test -b -rw -C 1000 -c -a 192.170.1.50 -S 2048 -B
Sent 8 2048-byte RDMA_WRITEs and RDMA_READs 1000 times in 76.81ms
This amounts to a bidirectional transfer rate of MB/s: 213.298131
```

## Related changes

This pull request relies on a couple of changes throughout the [LiteX](https://github.com/enjoy-digital/litex), such as an additional `last` signal in the `LiteDRAMDMAWriter` of [LiteDRAM](https://github.com/enjoy-digital/litedram)'s frontend/dma.py (see ["Added last signal to LiteDRAMWriter#377"](https://github.com/enjoy-digital/litedram/pull/377)).
It also relies on a small change to the `Header` class in [LiteX](https://github.com/enjoy-digital/litex)'s soc/interconnect/packet.py (see ["Allow for changing starting position of header#2441"](https://github.com/enjoy-digital/litex/pull/2441)).