### PR TITLE
mac/rate_limiter: add boot-enable support and test collateral.

### DIFF
--- a/doc/mac_rate_limiter_hardware.md
+++ b/doc/mac_rate_limiter_hardware.md
@@ -1,0 +1,561 @@
+# MAC TX Token Bucket Hardware Implementation
+
+This document describes the actual digital hardware implementation of
+[`liteeth/mac/rate_limiter.py`](/mnt/WORKSPACE/Workspaces/litecompute/liteeth/liteeth/mac/rate_limiter.py)
+as it is integrated by
+[`liteeth/mac/core.py`](/mnt/WORKSPACE/Workspaces/litecompute/liteeth/liteeth/mac/core.py).
+
+The focus here is hardware structure: math, signal meaning, state transitions,
+cycle-level behavior, and why each implementation decision was taken.
+
+## 1. Placement In The MAC TX Pipeline
+
+The limiter is inserted in the TX datapath after all width conversion / CDC and
+after optional MAC-side framing stages, but before IFG insertion or the PHY.
+
+Common placement:
+
+```text
+core.sink
+  -> CDC / width conversion
+  -> padding
+  -> CRC inserter
+  -> preamble inserter
+  -> token bucket limiter
+  -> gap inserter
+  -> PHY
+```
+
+If the PHY provides its own IFG insertion:
+
+```text
+core.sink
+  -> CDC / width conversion
+  -> padding
+  -> CRC inserter
+  -> preamble inserter
+  -> token bucket limiter
+  -> PHY
+```
+
+Why this placement:
+- The limiter always runs in `eth_tx`.
+- The limiter always sees PHY-width words.
+- The limiter measures transmitted stream byte count directly, not a pre-conversion approximation.
+- IFG waveform generation stays in the gap stage or PHY; limiter shaping is still frame-boundary based.
+- Even though the limiter is placed before the explicit IFG inserter, its worst-case reservation uses `eth_mtu = 1530`, which in this codebase is defined as the total per-frame TX charge budget including IFG.
+
+## 2. Top-Level Interface
+
+The module is:
+
+```python
+LiteEthMACTokenBucket(dw, rate=0, burst=None)
+```
+
+Stream interface:
+
+```text
+sink   : eth_phy_description(dw)
+source : eth_phy_description(dw)
+```
+
+Configuration interface:
+
+```text
+enable : 1 bit   internal eth_tx-domain enable latch
+rate   : 32 bits Q16.16 bytes / eth_tx cycle
+burst  : 32 bits bytes
+```
+
+CSR interface:
+
+```text
+_enable : CSRStorage(1)
+_rate   : CSRStorage(32)
+_burst  : CSRStorage(32)
+```
+
+## 3. Core Design Decision
+
+The implementation is intentionally frame-gated and non-buffering.
+
+That means:
+- It can stop a frame before the first word.
+- It must not create a bubble once a frame has started.
+- It therefore reserves against a worst-case start threshold, then charges the exact observed frame size at frame end.
+
+This is why the module does not have a separate packet buffer and does not try
+to admit a frame only after knowing its exact length. That would require
+storing the whole frame or precomputing the exact length upstream.
+
+## 4. Token Math
+
+### 4.1 Units
+
+Tokens are stored in Q16.16 fixed-point bytes.
+
+```text
+1 byte = 0x0001_0000 tokens
+```
+
+So:
+
+```text
+tokens               : 48-bit Q16.16 accumulator
+rate                 : 32-bit Q16.16 bytes/cycle
+charge_tokens        = frame_charge << 16
+effective_burst_q16  = effective_burst << 16
+```
+
+### 4.2 Maximum Reservation Constant
+
+The implementation defines:
+
+```text
+max_frame_charge = eth_mtu
+```
+
+In this codebase, `eth_mtu` is already treated as the full TX charge budget
+used by the MAC, including IFG. This matters because the limiter is placed
+before the IFG stage in the TX pipeline, so the reservation constant must
+already include that downstream gap cost. The limiter therefore must not add
+IFG / preamble / FCS on top of it again when building the worst-case
+reservation threshold.
+
+With current constants:
+
+```text
+eth_mtu             = 1530
+
+max_frame_charge = 1530 bytes
+```
+
+This is the frame-start threshold and minimum effective burst.
+
+Important consequence:
+- `frame_can_start` uses `max_frame_charge`, not the exact upcoming frame size.
+- Therefore every frame start requires enough tokens for the worst-case frame.
+
+This is the key hardware simplification that guarantees no mid-frame stall.
+
+### 4.3 Exact Frame Charge
+
+Once a frame is actually transmitted, the exact charge is:
+
+```text
+frame_charge = observed_frame_bytes
+```
+
+`observed_frame_bytes` is measured directly from accepted output beats
+(`source.valid & source.ready`) using `last_be` on the final beat.
+
+No additional overhead term is added by the limiter itself.
+
+### 4.4 Burst Clamp
+
+The configured burst is clamped upward:
+
+```text
+effective_burst = max(burst, max_frame_charge)
+```
+
+So even if software programs a smaller burst, the hardware internally forces it
+to at least one `eth_mtu` reservation.
+
+Why:
+- Without that clamp, a legal configuration could make `frame_can_start`
+  permanently false.
+- The clamp preserves the "one whole frame can always start" rule.
+
+### 4.5 Refill Equation
+
+Each `eth_tx` cycle:
+
+```text
+refilled_tokens =
+    effective_burst_q16                      if tokens + rate >= effective_burst_q16
+    tokens + rate                            otherwise
+```
+
+This is a saturating accumulator.
+
+### 4.6 End-Of-Frame Debit
+
+On the final transmitted beat:
+
+```text
+tokens_next = refilled_tokens - (frame_charge << 16)
+```
+
+Notably:
+- refill and debit happen in the same cycle
+- debit uses the exact observed frame length
+
+## 5. Byte Counting Logic
+
+The limiter counts bytes from the outgoing stream itself.
+
+### 5.1 Last Word Byte Decode
+
+`last_be` is decoded into `last_bytes`:
+
+```text
+last_be == 1 << 0  -> 1 byte valid
+last_be == 1 << 1  -> 2 bytes valid
+last_be == 1 << 2  -> 3 bytes valid
+...
+default            -> byte_width bytes valid
+```
+
+For non-final beats:
+
+```text
+beat_bytes = byte_width
+```
+
+For the final beat:
+
+```text
+beat_bytes = last_bytes
+```
+
+### 5.2 Running Length
+
+The implementation uses:
+
+```text
+byte_count           : bytes already accepted before current beat
+current_frame_bytes  = byte_count + beat_bytes
+frame_charge         = current_frame_bytes
+```
+
+Update rule:
+
+```text
+if transfer and last:
+    byte_count <- 0
+elif transfer:
+    byte_count <- current_frame_bytes
+```
+
+So `byte_count` is the running byte length of the in-flight frame.
+
+## 6. Clock Domain Crossing
+
+The limiter datapath itself is in `eth_tx`.
+
+CSR crossing strategy:
+
+```text
+_enable -> MultiReg -> csr_enable
+_rate   -> BusSynchronizer(sys -> eth_tx)
+_burst  -> BusSynchronizer(sys -> eth_tx)
+```
+
+Why the split:
+- `enable` is one bit, so a simple `MultiReg` is enough.
+- `rate` and `burst` are 32-bit control words and need coherent transfer, so
+  `BusSynchronizer` is used.
+
+### 6.1 Configuration Commit Policy
+
+The live control signals are only updated in `IDLE`:
+
+```text
+if fsm.ongoing("IDLE"):
+    enable <- csr_enable
+    rate   <- rate_cdc.o
+    burst  <- burst_cdc.o
+```
+
+This is an important implementation decision:
+- no configuration change can occur in the middle of an active frame
+- all control updates are naturally frame-boundary safe
+
+## 7. Handshake And Control Signals
+
+Important internal signals:
+
+```text
+transfer              = source.valid & source.ready
+frame_can_start       = (tokens >= (max_frame_charge << 16)) | ~enable
+effective_burst       = max(burst, max_frame_charge)
+effective_burst_q16   = effective_burst << 16
+charge_tokens         = frame_charge << 16
+```
+
+Data path wiring:
+
+```text
+sink.connect(source, omit={"ready", "valid"})
+```
+
+This means payload, `last`, `last_be`, and `error` pass combinationally from
+input to output. Only `valid` and `ready` are controlled by the limiter FSM.
+
+## 8. State Machine
+
+The implementation is a 2-state FSM in `eth_tx`.
+
+There is no explicit `WAIT` state. The waiting behavior is folded into `IDLE`
+through `frame_can_start`.
+
+### 8.1 State List
+
+```text
+IDLE
+SEND
+```
+
+### 8.2 IDLE
+
+Behavior:
+
+```text
+source.valid = sink.valid & frame_can_start
+sink.ready   = source.ready & frame_can_start
+```
+
+Meaning:
+- if limiter disabled: `frame_can_start = 1`, so this behaves as a pass-through
+- if limiter enabled and tokens are insufficient: both `source.valid` and
+  `sink.ready` are held low for the first beat
+
+Transition:
+
+```text
+if transfer and not source.last:
+    IDLE -> SEND
+```
+
+If the frame is a single-beat frame, it remains in `IDLE`.
+
+### 8.3 SEND
+
+Behavior:
+
+```text
+source.valid = sink.valid
+sink.ready   = source.ready
+```
+
+Meaning:
+- once a frame has started, the limiter becomes fully transparent
+- no extra throttling is inserted during the body of the frame
+
+Transition:
+
+```text
+if transfer and source.last:
+    SEND -> IDLE
+```
+
+### 8.4 ASCII FSM Diagram
+
+```text
+                 +----------------------------------+
+                 |                                  |
+                 |  transfer & source.last          |
+                 |                                  v
+        +-----------------+                 +-----------------+
+        |      IDLE       |                 |      SEND       |
+        |-----------------|                 |-----------------|
+        | source.valid =  |                 | source.valid =  |
+        | sink.valid &    |                 | sink.valid      |
+        | frame_can_start |                 |                 |
+        |                 |                 | sink.ready =    |
+        | sink.ready =    |                 | source.ready    |
+        | source.ready &  |                 |                 |
+        | frame_can_start |                 |                 |
+        +-----------------+                 +-----------------+
+                 |                                  ^
+                 | transfer & ~source.last          |
+                 +----------------------------------+
+```
+
+## 9. Cycle-Level Timing
+
+### 9.1 Disabled Mode
+
+In disabled mode, `frame_can_start = 1` because of `| ~enable`.
+
+```text
+clk        : __/--\__/--\__/--\__/--\__/--\__/--\__
+enable     : 0--------------------------------------
+sink.valid : 0____/===========================\_____
+sink.ready : 1--------------------------------------
+source.valid:0____/===========================\_____
+source.ready:1--------------------------------------
+state      : IDLE.....SEND....................IDLE..
+```
+
+Behavior:
+- no throttling
+- tokens are forced to full burst every cycle
+
+### 9.2 Enabled, Not Enough Tokens At Start
+
+```text
+clk         : __/--\__/--\__/--\__/--\__/--\__/--\__/--\__
+enable      : 1--------------------------------------------
+tokens>=thr : 0-----------0-----------1---------------------
+sink.valid  : ____/=====================================\___
+sink.ready  : 0-----------0-----------1=====================
+source.valid: 0-----------0-----------1=====================
+source.ready: 1---------------------------------------------
+state       : IDLE..................................SEND....
+```
+
+Behavior:
+- first beat is backpressured until enough tokens exist
+- frame starts only when threshold is met
+
+### 9.3 Enabled, Frame In Progress
+
+```text
+clk         : __/--\__/--\__/--\__/--\__/--\__/--\__
+state       : IDLE..SEND..SEND..SEND..SEND..IDLE....
+sink.valid  : ____/===============================\__
+sink.ready  : ____/===============================\__
+source.valid: ____/===============================\__
+source.ready: 1--------------------------------------
+transfer    : ____/===============================\__
+byte_count  : 0 -> b1 -> b2 -> b3 -> reset to 0
+tokens      : refill, refill, refill, refill-debit
+```
+
+Behavior:
+- no internal bubble once `SEND` has been entered
+- exact debit happens on the last beat cycle
+
+### 9.4 Two Back-To-Back Frames, Rate-Limited
+
+```text
+Frame A ends, debit applied, tokens drop below threshold
+
+clk          : __/--\__/--\__/--\__/--\__/--\__/--\__/--\__/--\__
+frame A      : .........[==================A==================]....
+frame B req  : ................................[==== held ====][B].
+state        : IDLE..SEND.................IDLE...........IDLE..SEND
+tokens       : high........debit->low.....refill...refill...enough
+frame_can_start
+             : 1................0...................0.......1......
+sink.ready   : 1 for A..........0 for first beat of B.......1......
+source.valid : pass A...........0 while blocked.............1......
+```
+
+Behavior:
+- frame B can be presented by upstream
+- limiter blocks only the first beat
+- frame B begins only after token refill reaches threshold
+
+## 10. Why The Math Uses Worst-Case Start Threshold
+
+This is the central hardware tradeoff.
+
+If the limiter started a frame with fewer than worst-case tokens, it would need
+one of these mechanisms:
+- mid-frame stall
+- full-frame buffering
+- a trusted upstream exact-length sideband
+
+The current implementation chooses none of those.
+
+So it uses:
+
+```text
+start condition = tokens >= eth_mtu
+```
+
+This gives:
+- simple hardware
+- no extra RAM
+- no mid-frame stall
+- deterministic frame-boundary throttle only
+
+The cost is:
+- short frames are admitted conservatively
+- burst utilization is less precise than a buffered exact-length shaper
+
+## 11. Reset / Initialization Behavior
+
+Initial token value:
+
+```text
+tokens reset = burst << 16
+```
+
+If `burst is None`, constructor logic replaces it with:
+
+```text
+burst = max_frame_charge
+```
+
+While disabled:
+
+```text
+tokens <- effective_burst_q16
+```
+
+every `eth_tx` cycle.
+
+This means:
+- disabling the limiter refills the bucket to full
+- enabling later starts from a full burst budget
+
+## 12. Practical Notes For Hardware Review
+
+### 12.1 Datapath Latency
+
+The limiter adds no payload buffering and no word reformatting.
+Its effect is only:
+- start-of-frame gating in `IDLE`
+- transparent pass-through in `SEND`
+
+### 12.2 Critical Logic
+
+The likely timing-relevant combinational logic is:
+- `effective_burst = max(burst, max_frame_charge)`
+- saturating refill compare
+- `frame_can_start` threshold compare
+- `last_be` decode
+
+At current widths this is small:
+- 32-bit compare for burst clamp
+- 48-bit compare/add for tokens
+- small decode for `last_be`
+
+### 12.3 Safe Reconfiguration
+
+Because live config latches only in `IDLE`, software should program:
+
+```text
+1. burst
+2. rate
+3. enable
+```
+
+at startup.
+
+This is not a functional requirement for steady-state use, but it is the clean
+software sequence because the live config only commits on frame boundaries.
+
+## 13. Summary
+
+The implemented limiter is a compact frame-gated token bucket with:
+- Q16.16 token accounting
+- exact end-of-frame debit
+- worst-case start reservation
+- no mid-frame bubbles
+- coherent `sys -> eth_tx` CSR synchronization
+- frame-boundary-safe config updates
+
+In short:
+
+```text
+Throttle only before the first beat.
+Pass through every beat once the frame starts.
+Debit observed frame bytes at frame end.
+Refill every eth_tx cycle with saturation.
+```

--- a/examples/wishbone_mii_rate_limiter.yml
+++ b/examples/wishbone_mii_rate_limiter.yml
@@ -1,0 +1,23 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 OpenAI
+# SPDX-License-Identifier: BSD-2-Clause
+
+# PHY --------------------------------------------------------------------------
+phy       : LiteEthPHYMII
+vendor    : xilinx
+toolchain : vivado
+
+# Core -------------------------------------------------------------------------
+clk_freq               : 100e6
+core                   : wishbone
+endianness             : big
+with_tx_rate_limiter   : true
+tx_rate_limiter_rate   : 65536
+tx_rate_limiter_burst  : 2048
+
+# SoC --------------------------------------------------------------------------
+soc:
+    mem_map:
+        ethmac: 0x50000000

--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -31,6 +31,10 @@ class LiteEthMAC(LiteXModule):
         tx_cdc_buffered    = False,
         rx_cdc_depth       = 32,
         rx_cdc_buffered    = False,
+        with_tx_rate_limiter = False,
+        tx_rate_limiter_enable = False,
+        tx_rate_limiter_rate = 0,
+        tx_rate_limiter_burst = None,
     ):
         assert dw%8 == 0
         assert interface  in ["crossbar", "wishbone", "hybrid"]
@@ -47,8 +51,12 @@ class LiteEthMAC(LiteXModule):
             tx_cdc_buffered   = tx_cdc_buffered,
             rx_cdc_depth      = rx_cdc_depth,
             rx_cdc_buffered   = rx_cdc_buffered,
+            with_tx_rate_limiter  = with_tx_rate_limiter,
+            tx_rate_limiter_enable = tx_rate_limiter_enable,
+            tx_rate_limiter_rate   = tx_rate_limiter_rate,
+            tx_rate_limiter_burst  = tx_rate_limiter_burst,
         )
-        self.csrs = []
+        self.csrs = self.core.get_csrs()
 
         # Crossbar Mode.
         # --------------

--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -11,7 +11,7 @@
 from litex.gen import *
 
 from liteeth.common import *
-from liteeth.mac    import gap, preamble, crc, padding, last_be
+from liteeth.mac    import gap, preamble, crc, padding, last_be, rate_limiter
 from liteeth.mac.common import *
 
 from migen.genlib.cdc import PulseSynchronizer
@@ -37,6 +37,10 @@ class LiteEthMACCore(LiteXModule):
     - tx_cdc_buffered  : Use buffered TX CDC (default: False).
     - rx_cdc_depth     : Depth of RX CDC FIFO (default: 32).
     - rx_cdc_buffered  : Use buffered RX CDC (default: False).
+    - with_tx_rate_limiter: Enable MAC TX token-bucket rate limiter (default: False).
+    - tx_rate_limiter_enable: Boot-time default state of limiter enable CSR (default: False).
+    - tx_rate_limiter_rate: Refill rate in Q16.16 bytes per eth_tx cycle (default: 0).
+    - tx_rate_limiter_burst: Burst budget in bytes (default: full-frame reservation).
     """
     def __init__(self, phy, dw,
         with_sys_datapath = False,
@@ -46,6 +50,10 @@ class LiteEthMACCore(LiteXModule):
         tx_cdc_buffered   = False,
         rx_cdc_depth      = 32,
         rx_cdc_buffered   = False,
+        with_tx_rate_limiter = False,
+        tx_rate_limiter_enable = False,
+        tx_rate_limiter_rate = 0,
+        tx_rate_limiter_burst = None,
         ):
 
         # Endpoints.
@@ -75,12 +83,15 @@ class LiteEthMACCore(LiteXModule):
             with_preamble_crc = phy.with_preamble_crc
         if hasattr(phy, "with_padding"):
             with_padding = phy.with_padding
+        tx_includes_preamble_crc = with_preamble_crc
 
         # CSRs.
         # -----
         # Control/Status Registers for optional features.
         if with_preamble_crc:
             self.preamble_crc = CSRStatus(reset=1)
+
+        core = self
 
         # TX Data-Path (Core --> PHY).
         # ------------------------------------------------------------------------------------------
@@ -160,6 +171,17 @@ class LiteEthMACCore(LiteXModule):
                 self.submodules += tx_gap
                 self.pipeline.append(tx_gap)
 
+            def add_rate_limiter(self):
+                """Add MAC TX token-bucket rate limiter."""
+                core.tx_rate_limiter = tx_rate_limiter = rate_limiter.LiteEthMACTokenBucket(
+                    dw     = phy_dw,
+                    enable = tx_rate_limiter_enable,
+                    rate   = tx_rate_limiter_rate,
+                    burst  = tx_rate_limiter_burst,
+                )
+                self.submodules += tx_rate_limiter
+                self.pipeline.append(tx_rate_limiter)
+
             def add_domain_switch(self):
                 """
                 Add stages for clock domain switch and width handling.
@@ -195,6 +217,9 @@ class LiteEthMACCore(LiteXModule):
         # Add domain switch if using system datapath.
         if with_sys_datapath:
             tx_datapath.add_domain_switch()
+        # Add TX rate limiter in eth_tx domain at PHY width.
+        if with_tx_rate_limiter:
+            tx_datapath.add_rate_limiter()
         # Add gap unless PHY has integrated inserter.
         # Gap insertion has to occurr in phy tx domain to ensure gap is correctly maintained.
         if not getattr(phy, "integrated_ifg_inserter", False):

--- a/liteeth/mac/rate_limiter.py
+++ b/liteeth/mac/rate_limiter.py
@@ -1,0 +1,147 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 OpenAI
+# SPDX-License-Identifier: BSD-2-Clause
+
+from litex.gen import *
+
+from migen.genlib.cdc import MultiReg
+
+from litex.gen.genlib.cdc import BusSynchronizer
+
+from liteeth.common import *
+
+
+class LiteEthMACTokenBucket(LiteXModule):
+    def __init__(self, dw, enable=False, rate=0, burst=None):
+        assert dw in [8, 16, 32, 64]
+
+        self.sink   = sink   = stream.Endpoint(eth_phy_description(dw))
+        self.source = source = stream.Endpoint(eth_phy_description(dw))
+
+        self.enable = Signal()
+        self.rate   = Signal(32)
+        self.burst  = Signal(32)
+
+        # `eth_mtu` already includes eth_interpacket_gap, so it is the full
+        # per-frame charge budget — no extra overhead adjustment needed.
+        max_frame_charge = eth_mtu
+        if burst is None:
+            burst = max_frame_charge
+
+        self._enable = CSRStorage(1,  name="enable", description="Enable MAC TX token-bucket rate limiter.", reset=enable)
+        self._rate   = CSRStorage(32, name="rate",   description="Refill rate in Q16.16 bytes per eth_tx cycle.", reset=rate)
+        self._burst  = CSRStorage(32, name="burst",  description="Burst budget in bytes.", reset=burst)
+
+        # # #
+
+        byte_width               = dw // 8
+        byte_count_bits          = bits_for(max_frame_charge + byte_width)
+        token_bits               = 48
+
+        csr_enable = Signal()
+
+        self.specials += MultiReg(self._enable.storage, csr_enable, "eth_tx")
+
+        self.rate_cdc = rate_cdc = BusSynchronizer(32, "sys", "eth_tx")
+        self.burst_cdc = burst_cdc = BusSynchronizer(32, "sys", "eth_tx")
+        self.comb += [
+            rate_cdc.i.eq(self._rate.storage),
+            burst_cdc.i.eq(self._burst.storage),
+        ]
+
+        # Decode how many bytes are valid on the final beat.
+        last_bytes = Signal(max=byte_width + 1)
+        last_be_cases = {2**i: last_bytes.eq(i + 1) for i in range(byte_width)}
+        last_be_cases["default"] = last_bytes.eq(byte_width)
+        self.comb += Case(sink.last_be, last_be_cases)
+
+        # Per-beat tracking.
+        beat_bytes          = Signal(max=byte_width + 1)
+        current_frame_bytes = Signal(byte_count_bits)
+        transfer            = Signal()
+
+        # Token bucket state.
+        charge_tokens        = Signal(token_bits)
+        effective_burst      = Signal(32)
+        effective_burst_tokens = Signal(token_bits)
+        frame_can_start      = Signal()
+
+        # Refill pipeline.
+        tokens_plus_rate   = Signal(token_bits + 1)
+        refill_saturates   = Signal()
+        refilled_tokens    = Signal(token_bits)
+
+        byte_count = Signal(byte_count_bits)
+        tokens     = Signal(token_bits, reset=(burst << 16))
+
+        self.comb += [
+            sink.connect(source, omit={"ready", "valid"}),
+            beat_bytes.eq(Mux(sink.last, last_bytes, byte_width)),
+            current_frame_bytes.eq(byte_count + beat_bytes),
+            charge_tokens.eq(current_frame_bytes << 16),
+            # Never allow a burst smaller than one full frame reservation.
+            If(self.burst < max_frame_charge,
+                effective_burst.eq(max_frame_charge)
+            ).Else(
+                effective_burst.eq(self.burst)
+            ),
+            effective_burst_tokens.eq(effective_burst << 16),
+            tokens_plus_rate.eq(tokens + self.rate),
+            refill_saturates.eq(tokens_plus_rate >= effective_burst_tokens),
+            # Saturating refill value used by the explicit synchronous accumulator.
+            If(refill_saturates,
+                refilled_tokens.eq(effective_burst_tokens)
+            ).Else(
+                refilled_tokens.eq(tokens_plus_rate[:token_bits])
+            ),
+            # Admission is frame-gated: a frame starts only with a worst-case budget.
+            frame_can_start.eq((tokens >= (max_frame_charge << 16)) | ~self.enable),
+            transfer.eq(source.valid & source.ready),
+        ]
+
+        self.fsm = fsm = ClockDomainsRenamer("eth_tx")(FSM(reset_state="IDLE"))
+        fsm.act("IDLE",
+            # Hold the first beat until the bucket can cover any legal frame.
+            source.valid.eq(sink.valid & frame_can_start),
+            sink.ready.eq(source.ready & frame_can_start),
+            If(transfer & ~source.last,
+                NextState("SEND")
+            )
+        )
+        fsm.act("SEND",
+            # Once a frame starts, pass it through without inserting bubbles.
+            source.valid.eq(sink.valid),
+            sink.ready.eq(source.ready),
+            If(transfer & source.last,
+                NextState("IDLE")
+            )
+        )
+
+        self.sync.eth_tx += [
+            If(fsm.ongoing("IDLE"),
+                # Commit CSR updates only between frames.
+                self.enable.eq(csr_enable),
+                self.rate.eq(rate_cdc.o),
+                self.burst.eq(burst_cdc.o),
+            ),
+            # Refill: explicit per-cycle accumulation with burst saturation.
+            # This is the default token update — every cycle adds `rate`.
+            tokens.eq(refilled_tokens),
+            # Charge: deduct on last beat (overrides refill via last-writer-wins).
+            If(self.enable & transfer & source.last,
+                tokens.eq(refilled_tokens - charge_tokens),
+            ),
+            # Bypass: when disabled, keep bucket full (overrides all above).
+            If(~self.enable,
+                tokens.eq(effective_burst_tokens),
+            ),
+            If(transfer,
+                If(source.last,
+                    byte_count.eq(0)
+                ).Else(
+                    byte_count.eq(current_frame_bytes)
+                )
+            )
+        ]

--- a/test/test_mac_core_with_rate_limiter.py
+++ b/test/test_mac_core_with_rate_limiter.py
@@ -1,0 +1,242 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 luanvt
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+import random
+
+from migen import *
+
+from litex.soc.interconnect.stream_sim import *
+
+from liteeth.common import *
+from liteeth.mac.core import LiteEthMACCore
+
+from test.model import phy, mac
+
+from litex.gen.sim import *
+
+VCD_NAME = "sim.vcd"
+
+# dw=8 at 10 ns/cycle -> 80 Mbps wire rate.
+# 10 Mbps shaping = 1/8 byte per cycle in Q16.16.
+RATE_10MBPS = 8192
+CLK_PERIOD_NS = 10
+CSR_COMMIT_DELAY_CYCLES = 32
+N_PACKETS = 4
+PAYLOAD_LENGTH = eth_mtu - mac_header.length - eth_fcs_length - eth_preamble_length
+
+
+def expected_refill_cycles(charge_bytes, rate):
+    return -(-(charge_bytes << 16) // rate)
+
+
+def make_packet(seed, payload_length=PAYLOAD_LENGTH):
+    packet = mac.MACPacket([((seed + i) & 0xff) for i in range(payload_length)])
+    packet.target_mac    = 0x010203040506
+    packet.sender_mac    = 0x090A0B0C0D0E
+    packet.ethernet_type = 0x0800
+    packet.encode_header()
+    return packet
+
+
+class TXMonitor:
+    def __init__(self, endpoint, dw):
+        self.endpoint = endpoint
+        self.dw       = dw
+        self.frames   = []
+        self.starts   = []
+        self.gaps     = []
+
+    def _beat_bytes(self, last, last_be):
+        if not last:
+            return self.dw // 8
+        for byte in range(self.dw // 8):
+            if last_be == (1 << byte):
+                return byte + 1
+        return self.dw // 8
+
+    @passive
+    def generator(self):
+        cycle          = 0
+        current_frame  = []
+        previous_cycle = None
+
+        while True:
+            if (yield self.endpoint.valid) and (yield self.endpoint.ready):
+                data    = (yield self.endpoint.data)
+                last    = (yield self.endpoint.last)
+                last_be = (yield self.endpoint.last_be)
+
+                if not current_frame:
+                    self.starts.append(cycle)
+                elif cycle != (previous_cycle + 1):
+                    self.gaps.append((len(self.frames), previous_cycle, cycle))
+
+                for byte in range(self._beat_bytes(last, last_be)):
+                    current_frame.append((data >> (8*byte)) & 0xff)
+
+                previous_cycle = cycle
+
+                if last:
+                    self.frames.append(current_frame)
+                    current_frame  = []
+                    previous_cycle = None
+
+            cycle += 1
+            yield
+
+
+class DUT(LiteXModule):
+    def __init__(self, logger_randomizer_level=0):
+        self.phy_model = phy.PHY(8, debug=False)
+        self.mac_model = mac.MAC(self.phy_model, debug=False, loopback=True)
+        self.core      = LiteEthMACCore(
+            phy                  = self.phy_model,
+            dw                   = 8,
+            with_preamble_crc    = True,
+            with_tx_rate_limiter = True,
+            tx_rate_limiter_rate = RATE_10MBPS,
+            tx_rate_limiter_burst = eth_mtu,
+        )
+
+        self.streamer = PacketStreamer(eth_phy_description(8), last_be=1)
+        self.streamer_randomizer = Randomizer(eth_phy_description(8), level=0)
+
+        self.logger_randomizer = Randomizer(eth_phy_description(8), level=logger_randomizer_level)
+        self.logger = PacketLogger(eth_phy_description(8))
+
+        self.tx_monitor = TXMonitor(self.phy_model.sink, 8)
+        self.expected_packets = []
+        self.received_packets = []
+
+        self.comb += [
+            Record.connect(self.streamer.source, self.streamer_randomizer.sink),
+            Record.connect(self.streamer_randomizer.source, self.core.sink),
+            Record.connect(self.core.source, self.logger_randomizer.sink),
+            Record.connect(self.logger_randomizer.source, self.logger.sink)
+        ]
+
+        self.pipeline = stream.Pipeline(
+            self.streamer,
+            self.streamer_randomizer,
+            self.core,
+            self.logger_randomizer,
+            self.logger,
+        )
+
+
+def control_generator(dut):
+    yield dut.core.tx_rate_limiter._rate.storage.eq(RATE_10MBPS)
+    yield dut.core.tx_rate_limiter._burst.storage.eq(eth_mtu)
+    for _ in range(CSR_COMMIT_DELAY_CYCLES):
+        yield
+    yield dut.core.tx_rate_limiter._enable.storage.eq(1)
+
+
+def main_generator(dut):
+    for _ in range(CSR_COMMIT_DELAY_CYCLES + 8):
+        yield
+
+    packets = [make_packet(seed=i*17) for i in range(N_PACKETS)]
+    dut.expected_packets = packets
+
+    for packet in packets:
+        dut.streamer.send(packet)
+
+    for _ in packets:
+        yield from dut.logger.receive()
+        dut.received_packets.append(dut.logger.packet)
+
+
+class TestMACCoreWithRateLimiter(unittest.TestCase):
+    def test_tx_rate_limiter_integration(self):
+        dut = DUT()
+        generators = {
+            "sys": [
+                main_generator(dut),
+                control_generator(dut),
+                dut.streamer.generator(),
+                dut.streamer_randomizer.generator(),
+                dut.logger_randomizer.generator(),
+                dut.logger.generator(),
+            ],
+            "eth_tx": [
+                dut.phy_model.phy_sink.generator(),
+                dut.phy_model.generator(),
+                dut.tx_monitor.generator(),
+            ],
+            "eth_rx": [
+                dut.phy_model.phy_source.generator(),
+            ]
+        }
+        clocks = {
+            "sys":    CLK_PERIOD_NS,
+            "eth_rx": CLK_PERIOD_NS,
+            "eth_tx": CLK_PERIOD_NS,
+        }
+        run_simulation(dut, generators, clocks, vcd_name=VCD_NAME)
+
+        self.assertEqual(len(dut.received_packets), N_PACKETS)
+        for expected, received in zip(dut.expected_packets, dut.received_packets):
+            s, l, e = check(expected, received)
+            self.assertEqual(e, 0)
+
+        self.assertEqual(len(dut.tx_monitor.frames), N_PACKETS)
+        self.assertEqual(dut.tx_monitor.gaps, [])
+        for frame in dut.tx_monitor.frames:
+            self.assertEqual(len(frame), eth_mtu)
+
+        refill = expected_refill_cycles(eth_mtu, RATE_10MBPS)
+        expected_spacing = eth_mtu + refill
+        spacings = [dut.tx_monitor.starts[i+1] - dut.tx_monitor.starts[i]
+            for i in range(N_PACKETS - 1)]
+        for spacing in spacings:
+            self.assertAlmostEqual(spacing, expected_spacing, delta=1)
+
+    def test_tx_rate_limiter_integration_with_random_logger_ready(self):
+        random.seed(2026)
+        dut = DUT(logger_randomizer_level=50)
+        generators = {
+            "sys": [
+                main_generator(dut),
+                control_generator(dut),
+                dut.streamer.generator(),
+                dut.streamer_randomizer.generator(),
+                dut.logger_randomizer.generator(),
+                dut.logger.generator(),
+            ],
+            "eth_tx": [
+                dut.phy_model.phy_sink.generator(),
+                dut.phy_model.generator(),
+                dut.tx_monitor.generator(),
+            ],
+            "eth_rx": [
+                dut.phy_model.phy_source.generator(),
+            ]
+        }
+        clocks = {
+            "sys":    CLK_PERIOD_NS,
+            "eth_rx": CLK_PERIOD_NS,
+            "eth_tx": CLK_PERIOD_NS,
+        }
+        run_simulation(dut, generators, clocks, vcd_name="sim_random_logger_ready.vcd")
+
+        self.assertEqual(len(dut.received_packets), N_PACKETS)
+        for expected, received in zip(dut.expected_packets, dut.received_packets):
+            s, l, e = check(expected, received)
+            self.assertEqual(e, 0)
+
+        self.assertEqual(len(dut.tx_monitor.frames), N_PACKETS)
+        self.assertEqual(dut.tx_monitor.gaps, [])
+        for frame in dut.tx_monitor.frames:
+            self.assertEqual(len(frame), eth_mtu)
+
+        refill = expected_refill_cycles(eth_mtu, RATE_10MBPS)
+        expected_spacing = eth_mtu + refill
+        spacings = [dut.tx_monitor.starts[i+1] - dut.tx_monitor.starts[i]
+            for i in range(N_PACKETS - 1)]
+        for spacing in spacings:
+            self.assertAlmostEqual(spacing, expected_spacing, delta=1)

--- a/test/test_mac_rate_limiter.py
+++ b/test/test_mac_rate_limiter.py
@@ -1,0 +1,441 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 luanvt
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+import random
+
+from migen import *
+
+from liteeth.common import *
+from liteeth.mac import rate_limiter as rate_limiter_mod
+
+from litex.gen.sim import *
+
+VCD_NAME = "sim.vcd"
+
+# Simulated link: dw=8, eth_tx at 10 MHz -> 80 Mbps wire.
+# 10 Mbps shaped rate: 10/80 = 1/8 of line rate.
+# Q16.16: 65536 / 8 = 8192
+RATE_10MBPS = 8192
+
+# Simulation clock periods in ns.
+SYS_CLK_PERIOD_NS    = 1000  # 1 MHz
+ETH_TX_CLK_PERIOD_NS = 100   # 10 MHz
+ETH_TX_CYCLES_PER_SYS = SYS_CLK_PERIOD_NS // ETH_TX_CLK_PERIOD_NS
+
+# Delay long enough for sys-domain CSR writes to cross and commit in eth_tx.
+CSR_COMMIT_DELAY_SYS_CYCLES = 24
+SENDER_START_DELAY_ETH_CYCLES = CSR_COMMIT_DELAY_SYS_CYCLES * ETH_TX_CYCLES_PER_SYS + 80
+
+# Tolerance in cycles for timing assertions (covers FSM transition + CDC latency).
+TIMING_TOLERANCE = 10
+
+
+def expected_refill_cycles(charge_bytes, rate):
+    """Cycles needed to refill charge_bytes at the given Q16.16 rate."""
+    return -(-(charge_bytes << 16) // rate)
+
+
+def make_frame(length, seed=0):
+    return [((seed + i) % 256) for i in range(length)]
+
+
+def wait_for_frames(dut, count, limit):
+    for _ in range(limit):
+        if len(dut.monitor.frames) >= count:
+            return
+        yield
+    raise TimeoutError(f"Timed out waiting for {count} frame(s)")
+
+
+def send_frame(sink, frame):
+    for n, byte in enumerate(frame):
+        yield sink.valid.eq(1)
+        yield sink.data.eq(byte)
+        yield sink.last.eq(n == (len(frame) - 1))
+        yield sink.last_be.eq(n == (len(frame) - 1))
+        while True:
+            yield
+            if (yield sink.ready):
+                break
+
+    yield sink.valid.eq(0)
+    yield sink.data.eq(0)
+    yield sink.last.eq(0)
+    yield sink.last_be.eq(0)
+    yield
+
+
+def send_frame_with_stall_count(sink, frame):
+    stall_cycles = 0
+
+    for n, byte in enumerate(frame):
+        yield sink.valid.eq(1)
+        yield sink.data.eq(byte)
+        yield sink.last.eq(n == (len(frame) - 1))
+        yield sink.last_be.eq(n == (len(frame) - 1))
+        while True:
+            yield
+            if (yield sink.ready):
+                break
+            stall_cycles += 1
+
+    yield sink.valid.eq(0)
+    yield sink.data.eq(0)
+    yield sink.last.eq(0)
+    yield sink.last_be.eq(0)
+    yield
+
+    return stall_cycles
+
+
+class TXMonitor:
+    def __init__(self, endpoint, dw):
+        self.endpoint = endpoint
+        self.dw       = dw
+        self.frames   = []
+        self.starts   = []
+        self.gaps     = []
+
+    def _beat_bytes(self, last, last_be):
+        if not last:
+            return self.dw // 8
+        for byte in range(self.dw // 8):
+            if last_be == (1 << byte):
+                return byte + 1
+        return self.dw // 8
+
+    @passive
+    def generator(self):
+        cycle          = 0
+        current_frame  = []
+        previous_cycle = None
+
+        while True:
+            yield self.endpoint.ready.eq(1)
+            if (yield self.endpoint.valid) and (yield self.endpoint.ready):
+                data    = (yield self.endpoint.data)
+                last    = (yield self.endpoint.last)
+                last_be = (yield self.endpoint.last_be)
+
+                if not current_frame:
+                    self.starts.append(cycle)
+                elif cycle != (previous_cycle + 1):
+                    self.gaps.append((len(self.frames), previous_cycle, cycle))
+
+                for byte in range(self._beat_bytes(last, last_be)):
+                    current_frame.append((data >> (8*byte)) & 0xff)
+
+                previous_cycle = cycle
+
+                if last:
+                    self.frames.append(current_frame)
+                    current_frame  = []
+                    previous_cycle = None
+
+            cycle += 1
+            yield
+
+
+class DUT(LiteXModule):
+    def __init__(self, rate=0, burst=None):
+        self.limiter = rate_limiter_mod.LiteEthMACTokenBucket(
+            dw    = 8,
+            rate  = rate,
+            burst = burst,
+        )
+        self.monitor = TXMonitor(self.limiter.source, 8)
+
+
+def run_dut(dut, eth_tx_generator):
+    generators = {
+        "sys":    [],
+        "eth_tx": [eth_tx_generator, dut.monitor.generator()],
+    }
+    clocks = {
+        "sys":    SYS_CLK_PERIOD_NS,
+        "eth_tx": ETH_TX_CLK_PERIOD_NS,
+    }
+    run_simulation(dut, generators, clocks, vcd_name=VCD_NAME)
+
+
+def run_dut_with_generators(dut, sys_generators, eth_tx_generators):
+    generators = {
+        "sys":    sys_generators,
+        "eth_tx": eth_tx_generators + [dut.monitor.generator()],
+    }
+    clocks = {
+        "sys":    SYS_CLK_PERIOD_NS,
+        "eth_tx": ETH_TX_CLK_PERIOD_NS,
+    }
+    run_simulation(dut, generators, clocks, vcd_name=VCD_NAME)
+
+
+class TestMACRateLimiter(unittest.TestCase):
+    def test_disabled_bypass(self):
+        """Disabled limiter passes all frames transparently."""
+        short_frame = make_frame(64, seed=0x10)
+        long_frame  = make_frame(1500, seed=0x80)
+        dut = DUT()
+
+        def sender():
+            yield from send_frame(dut.limiter.sink, short_frame)
+            yield from send_frame(dut.limiter.sink, long_frame)
+            yield from wait_for_frames(dut, 2, 4096)
+
+        run_dut(dut, sender())
+
+        self.assertEqual(dut.monitor.frames, [short_frame, long_frame])
+        self.assertEqual(dut.monitor.gaps, [])
+
+    def test_steady_state_pacing(self):
+        """Single-frame burst at 10 Mbps — every frame after the first is paced."""
+        frame_len    = eth_mtu                               # 1530 bytes on stream = charge
+        frame_charge = eth_mtu                               # 1530 bytes charged
+        n_frames     = 4
+        frames       = [make_frame(frame_len, seed=i) for i in range(n_frames)]
+        dut          = DUT(rate=RATE_10MBPS, burst=frame_charge)
+        stall_counts = []
+
+        refill = expected_refill_cycles(frame_charge, RATE_10MBPS)
+
+        def sender():
+            # Wait for sys-domain CSR writes to cross and commit in eth_tx.
+            for _ in range(SENDER_START_DELAY_ETH_CYCLES):
+                yield
+            for f in frames:
+                stall_counts.append(
+                    (yield from send_frame_with_stall_count(dut.limiter.sink, f)))
+
+        def control():
+            yield dut.limiter._rate.storage.eq(RATE_10MBPS)
+            yield dut.limiter._burst.storage.eq(frame_charge)
+            for _ in range(CSR_COMMIT_DELAY_SYS_CYCLES):
+                yield
+            yield dut.limiter._enable.storage.eq(1)
+
+        def waiter():
+            yield from wait_for_frames(dut, n_frames, n_frames * (refill + frame_len) + 512)
+
+        run_dut_with_generators(dut, [control()], [sender(), waiter()])
+
+        # Data integrity — all frames received intact, no mid-frame bubbles.
+        self.assertEqual(len(dut.monitor.frames), n_frames)
+        for tx, expected in zip(dut.monitor.frames, frames):
+            self.assertEqual(tx, expected)
+        self.assertEqual(dut.monitor.gaps, [])
+
+        # Frame 1 passes immediately from the burst budget.
+        self.assertEqual(stall_counts[0], 0)
+
+        # Subsequent frames must wait for 10 Mbps refill.
+        for i in range(1, n_frames):
+            self.assertAlmostEqual(stall_counts[i], refill,
+                delta=frame_len + TIMING_TOLERANCE,
+                msg=f"Frame {i} stall {stall_counts[i]} outside ±{frame_len + TIMING_TOLERANCE} of {refill}")
+
+        # Uniform steady-state spacing.
+        spacings = [dut.monitor.starts[i+1] - dut.monitor.starts[i]
+                    for i in range(1, n_frames - 1)]
+        for j, s in enumerate(spacings[1:], 2):
+            self.assertAlmostEqual(s, spacings[0], delta=1,
+                msg=f"Spacing[{j}]={s} differs from spacing[1]={spacings[0]}")
+
+    def test_burst_then_pacing(self):
+        """Burst budget absorbs initial spike, then paces at 10 Mbps."""
+        rng          = random.Random(0xB057)
+        # Randomize packet length near MTU to keep burst/pacing assertions stable.
+        frame_len    = rng.randint(max(64, eth_mtu - 64), eth_mtu)
+        frame_charge = frame_len
+        n_burst      = 3
+        n_total      = 6
+        frames       = [make_frame(frame_len, seed=i*3) for i in range(n_total)]
+        dut          = DUT(rate=RATE_10MBPS, burst=n_burst * frame_charge)
+        stall_counts = []
+
+        refill = expected_refill_cycles(frame_charge, RATE_10MBPS)
+
+        def sender():
+            for _ in range(SENDER_START_DELAY_ETH_CYCLES):
+                yield
+            for f in frames:
+                stall_counts.append(
+                    (yield from send_frame_with_stall_count(dut.limiter.sink, f)))
+
+        def control():
+            yield dut.limiter._rate.storage.eq(RATE_10MBPS)
+            yield dut.limiter._burst.storage.eq(n_burst * frame_charge)
+            # Let sys-domain CSR writes cross and commit before enabling shaping.
+            for _ in range(CSR_COMMIT_DELAY_SYS_CYCLES):
+                yield
+            yield dut.limiter._enable.storage.eq(1)
+
+        def waiter():
+            yield from wait_for_frames(dut, n_total, n_total * (refill + frame_len) + 512)
+
+        run_dut_with_generators(dut, [control()], [sender(), waiter()])
+
+        self.assertEqual(len(dut.monitor.frames), n_total)
+        for tx, expected in zip(dut.monitor.frames, frames):
+            self.assertEqual(tx, expected)
+        self.assertEqual(dut.monitor.gaps, [])
+
+        # First n_burst frames pass without stalls (covered by burst budget).
+        for i in range(n_burst):
+            self.assertEqual(stall_counts[i], 0,
+                msg=f"Burst frame {i} stalled ({stall_counts[i]} cycles)")
+
+        # Frames beyond the burst must wait for 10 Mbps refill.
+        # Stall is slightly less than `refill` because the bucket also
+        # accumulates tokens during frame transmission itself.
+        for i in range(n_burst, n_total):
+            self.assertGreater(stall_counts[i], refill // 2,
+                msg=f"Post-burst frame {i}: stall {stall_counts[i]} too short (expected ~{refill})")
+            self.assertAlmostEqual(stall_counts[i], refill,
+                delta=frame_len * 3,
+                msg=f"Post-burst frame {i}: stall {stall_counts[i]} outside ±{frame_len*3} of {refill}")
+
+    def test_mixed_frame_sizes(self):
+        """Smaller frames charge less — shorter gaps at 10 Mbps."""
+        small_len  = 64
+        large_len  = eth_mtu  # 1530
+        small_charge = small_len
+        large_charge = large_len
+
+        refill_small = expected_refill_cycles(small_charge, RATE_10MBPS)
+        refill_large = expected_refill_cycles(large_charge, RATE_10MBPS)
+
+        small = make_frame(small_len, seed=0xAA)
+        large = make_frame(large_len, seed=0xCC)
+        # Sequence: small → large → small → large
+        frames = [small, large, small, large]
+        dut    = DUT(rate=RATE_10MBPS, burst=large_charge)
+
+        def sender():
+            for _ in range(SENDER_START_DELAY_ETH_CYCLES):
+                yield
+            for f in frames:
+                yield from send_frame(dut.limiter.sink, f)
+
+        def control():
+            yield dut.limiter._rate.storage.eq(RATE_10MBPS)
+            yield dut.limiter._burst.storage.eq(large_charge)
+            for _ in range(CSR_COMMIT_DELAY_SYS_CYCLES):
+                yield
+            yield dut.limiter._enable.storage.eq(1)
+
+        def waiter():
+            yield from wait_for_frames(dut, len(frames), len(frames) * (refill_large + large_len) + 512)
+
+        run_dut_with_generators(dut, [control()], [sender(), waiter()])
+
+        self.assertEqual(len(dut.monitor.frames), len(frames))
+        for tx, expected in zip(dut.monitor.frames, frames):
+            self.assertEqual(tx, expected)
+        self.assertEqual(dut.monitor.gaps, [])
+
+        spacings = [dut.monitor.starts[i+1] - dut.monitor.starts[i]
+                    for i in range(len(frames) - 1)]
+
+        # Gap after a small frame (charge 64) should be shorter than after a large frame (charge 1530).
+        spacing_after_small_0 = spacings[0]  # after 64-byte frame
+        spacing_after_large_0 = spacings[1]  # after 1530-byte frame
+        self.assertLess(spacing_after_small_0, spacing_after_large_0,
+            msg=f"Gap after small ({spacing_after_small_0}) should be < gap after large ({spacing_after_large_0})")
+
+    def test_slow_sender_no_stall(self):
+        """Sender slower than 10 Mbps — bucket refills fully, no stalls."""
+        frame_len    = eth_mtu
+        frame_charge = eth_mtu
+        n_frames     = 4
+        refill       = expected_refill_cycles(frame_charge, RATE_10MBPS)
+        # Sender idles well beyond one refill period between frames.
+        sender_gap   = refill + 500
+        frames       = [make_frame(frame_len, seed=i*7) for i in range(n_frames)]
+        dut          = DUT(rate=RATE_10MBPS, burst=frame_charge)
+        stall_counts = []
+
+        def sender():
+            for _ in range(SENDER_START_DELAY_ETH_CYCLES):
+                yield
+            for f in frames:
+                stall_counts.append(
+                    (yield from send_frame_with_stall_count(dut.limiter.sink, f)))
+                for _ in range(sender_gap):
+                    yield
+
+        def control():
+            yield dut.limiter._rate.storage.eq(RATE_10MBPS)
+            yield dut.limiter._burst.storage.eq(frame_charge)
+            for _ in range(CSR_COMMIT_DELAY_SYS_CYCLES):
+                yield
+            yield dut.limiter._enable.storage.eq(1)
+
+        def waiter():
+            yield from wait_for_frames(dut, n_frames, n_frames * (sender_gap + frame_len) + 512)
+
+        run_dut_with_generators(dut, [control()], [sender(), waiter()])
+
+        self.assertEqual(len(dut.monitor.frames), n_frames)
+        for tx, expected in zip(dut.monitor.frames, frames):
+            self.assertEqual(tx, expected)
+        self.assertEqual(dut.monitor.gaps, [])
+
+        # Every frame should pass without stalls since sender is slower than 10 Mbps.
+        for i, sc in enumerate(stall_counts):
+            self.assertEqual(sc, 0, msg=f"Frame {i} had {sc} stall cycles")
+
+    def test_runtime_rate_change(self):
+        """CSR rate change mid-traffic — spacing decreases when rate increases."""
+        frame_len    = eth_mtu
+        frame_charge = eth_mtu
+        rate_slow    = RATE_10MBPS           # 10 Mbps
+        rate_fast    = RATE_10MBPS * 4       # 40 Mbps
+        n_frames     = 6
+        frames       = [make_frame(frame_len, seed=i*11) for i in range(n_frames)]
+        dut          = DUT(rate=rate_slow, burst=frame_charge)
+
+        refill_slow = expected_refill_cycles(frame_charge, rate_slow)
+
+        def sender():
+            for _ in range(SENDER_START_DELAY_ETH_CYCLES):
+                yield
+            for f in frames:
+                yield from send_frame(dut.limiter.sink, f)
+
+        def control():
+            yield dut.limiter._rate.storage.eq(rate_slow)
+            yield dut.limiter._burst.storage.eq(frame_charge)
+            for _ in range(CSR_COMMIT_DELAY_SYS_CYCLES):
+                yield
+            yield dut.limiter._enable.storage.eq(1)
+
+        def rate_switch():
+            # Wait for first 3 frames at 10 Mbps, then update the sys-side CSR.
+            yield from wait_for_frames(dut, 3, 4 * refill_slow)
+            # In simulation, the CSR storage can be driven directly from this
+            # generator; the limiter still samples the synchronized value in IDLE.
+            yield dut.limiter._rate.storage.eq(rate_fast)
+
+        def waiter():
+            yield from wait_for_frames(dut, n_frames, n_frames * refill_slow + 512)
+
+        run_dut_with_generators(dut, [control()], [sender(), rate_switch(), waiter()])
+
+        self.assertEqual(len(dut.monitor.frames), n_frames)
+        for tx, expected in zip(dut.monitor.frames, frames):
+            self.assertEqual(tx, expected)
+        self.assertEqual(dut.monitor.gaps, [])
+
+        spacings = [dut.monitor.starts[i+1] - dut.monitor.starts[i]
+                    for i in range(n_frames - 1)]
+
+        # Early spacings (10 Mbps) should be much longer than late spacings (40 Mbps).
+        # Use frame index 1→2 as slow sample, index 4→5 as fast sample.
+        slow_spacing = spacings[1]
+        fast_spacing = spacings[-1]
+        self.assertGreater(slow_spacing, fast_spacing * 2,
+            msg=f"Slow spacing ({slow_spacing}) should be >2x fast spacing ({fast_spacing})")


### PR DESCRIPTION
Plumb a tx rate-limiter boot-enable parameter through LiteEth MAC layers into the token-bucket CSR reset path, with supporting hardware notes, example config, and focused rate-limiter tests.