### PR TITLE
Add packet fifo based backpressure

### DIFF
--- a/liteeth/common.py
+++ b/liteeth/common.py
@@ -175,6 +175,13 @@ def eth_phy_description(dw):
     ]
     return EndpointDescription(payload_layout)
 
+# Packet
+def eth_packet_description(dw):
+    payload_layout = [
+        ("data", dw),
+    ]
+    return EndpointDescription(payload_layout)
+
 # MAC
 def eth_mac_description(dw):
     payload_layout = mac_header.get_layout() + [

--- a/liteeth/mac/packet.py
+++ b/liteeth/mac/packet.py
@@ -1,0 +1,225 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2015-2021 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2015-2018 Sebastien Bourdeauducq <sb@m-labs.hk>
+# Copyright (c) 2021 Leon Schuermann <leon@is.currently.online>
+# Copyright (c) 2017 whitequark <whitequark@whitequark.org>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import math
+
+from litex.gen import *
+
+from litex.soc.interconnect.packet import PacketFIFO
+
+from liteeth.common import *
+
+# MAC Packet Writer Frontend -----------------------------------------------------------------------
+
+class LiteEthMACPacketWriter(LiteXModule):
+    def __init__(self, dw, depth, eth_mtu=eth_mtu_default, fifo_depth=1, timestamp=None):
+        # Endpoint / Signals.
+        self.sink   = sink   = stream.Endpoint(eth_phy_description(dw))
+        self.source = source = stream.Endpoint(eth_packet_description(dw))
+
+        self.enable  = Signal(reset=1)
+        self.done    = Signal()
+        self.drop    = Signal()
+        self.error   = Signal()
+        self.offset  = Signal(bits_for(depth*dw//8))
+        self.length  = Signal(bits_for(depth*dw//8))
+
+        # Parameters Check / Compute.
+        assert dw in [8, 16, 32, 64]
+        assert depth > 0
+        assert fifo_depth > 0
+        if timestamp is not None:
+            timestampbits  = len(timestamp)
+            self.timestamp = Signal(timestampbits)
+
+        # # #
+
+        length  = Signal.like(self.length)
+        error   = Signal()
+        pkt_len = Signal.like(self.length)
+
+        # Packet FIFO.
+        packet_fifo = PacketFIFO(
+            eth_phy_description(dw),
+            payload_depth = fifo_depth * depth,
+            param_depth   = fifo_depth,
+        )
+        self.submodules += packet_fifo
+        self.comb += sink.connect(packet_fifo.sink)
+        if timestamp is not None:
+            timestamp_value = Signal(timestampbits)
+            self.comb += self.timestamp.eq(timestamp_value)
+
+        # Decode Length increment from last_be.
+        length_inc = Signal(4)
+        self.comb += Case(packet_fifo.source.last_be, {
+            0b00000001 : length_inc.eq(1),
+            0b00000010 : length_inc.eq(2),
+            0b00000100 : length_inc.eq(3),
+            0b00001000 : length_inc.eq(4),
+            0b00010000 : length_inc.eq(5),
+            0b00100000 : length_inc.eq(6),
+            0b01000000 : length_inc.eq(7),
+            "default"  : length_inc.eq(dw//8)
+        })
+
+        next_length = Signal.like(self.length)
+        last_error  = Signal()
+        self.comb += [
+            next_length.eq(length + length_inc),
+            last_error.eq((packet_fifo.source.error & packet_fifo.source.last_be) != 0),
+            self.offset.eq(length),
+            self.length.eq(Mux(self.done, pkt_len, next_length)),
+        ]
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(packet_fifo.source.valid,
+                If(self.enable,
+                    NextState("WRITE")
+                ).Else(
+                    NextState("DISCARD-ALL")
+                )
+            )
+        )
+        fsm.act("WRITE",
+            If(packet_fifo.source.valid,
+                source.valid.eq(packet_fifo.source.valid),
+                source.data.eq(packet_fifo.source.data),
+                source.last.eq(packet_fifo.source.last),
+                packet_fifo.source.ready.eq(source.ready),
+                If(source.ready,
+                    NextValue(length, next_length),
+                    NextValue(pkt_len, next_length),
+                    If(next_length > eth_mtu,
+                        NextValue(error, 1),
+                        If(packet_fifo.source.last,
+                            NextState("DISCARD")
+                        ).Else(
+                            NextState("DISCARD-ALL")
+                        )
+                    ).Elif(packet_fifo.source.last,
+                        If(error | last_error,
+                            NextValue(error, 1),
+                            NextState("DISCARD")
+                        ).Else(
+                            NextState("TERMINATE")
+                        )
+                    ).Elif(last_error,
+                        NextValue(error, 1)
+                    )
+                )
+            )
+        )
+        fsm.act("DISCARD-ALL",
+            packet_fifo.source.ready.eq(1),
+            If(packet_fifo.source.valid & packet_fifo.source.last,
+                NextState("DISCARD")
+            )
+        )
+        fsm.act("DISCARD",
+            self.drop.eq(1),
+            self.error.eq(error),
+            NextValue(length, 0),
+            NextValue(pkt_len, 0),
+            NextValue(error, 0),
+            NextState("IDLE")
+        )
+        fsm.act("TERMINATE",
+            self.done.eq(1),
+            NextValue(length, 0),
+            NextValue(pkt_len, 0),
+            NextValue(error, 0),
+            NextState("IDLE")
+        )
+        if timestamp is not None:
+            self.sync += If(fsm.ongoing("WRITE") & packet_fifo.source.valid & source.ready & (length == 0),
+                timestamp_value.eq(timestamp)
+            )
+
+
+# MAC Packet Reader Frontend -----------------------------------------------------------------------
+
+class LiteEthMACPacketReader(LiteXModule):
+    def __init__(self, dw, depth, fifo_depth=1, timestamp=None):
+        # Endpoint / Signals.
+        self.sink   = sink   = stream.Endpoint(eth_packet_description(dw))
+        self.source = source = stream.Endpoint(eth_phy_description(dw))
+
+        self.enable      = Signal()
+        self.idle        = Signal()
+        self.done        = Signal()
+
+        self.length      = Signal(bits_for(depth*dw//8))
+
+        # Parameters Check / Compute.
+        assert dw in [8, 16, 32, 64]
+        assert depth > 0
+        assert fifo_depth > 0
+        if timestamp is not None:
+            timestampbits  = len(timestamp)
+            self.timestamp = Signal(timestampbits)
+
+        # # #
+
+        if timestamp is not None:
+            timestamp_value = Signal(timestampbits)
+            self.comb += self.timestamp.eq(timestamp_value)
+
+        # Packet FIFO.
+        packet_fifo = PacketFIFO(
+            eth_phy_description(dw),
+            payload_depth = fifo_depth * depth,
+            param_depth   = fifo_depth,
+        )
+        self.submodules += packet_fifo
+        self.comb += packet_fifo.source.connect(source)
+        self.comb += packet_fifo.sink.error.eq(0)
+
+        # Encode Length to last_be.
+        length_lsb = self.length[:int(math.log2(dw/8))] if (dw != 8) else 0
+        self.comb += If(packet_fifo.sink.last,
+            Case(length_lsb, {
+                1         : packet_fifo.sink.last_be.eq(0b00000001),
+                2         : packet_fifo.sink.last_be.eq(0b00000010),
+                3         : packet_fifo.sink.last_be.eq(0b00000100),
+                4         : packet_fifo.sink.last_be.eq(0b00001000),
+                5         : packet_fifo.sink.last_be.eq(0b00010000),
+                6         : packet_fifo.sink.last_be.eq(0b00100000),
+                7         : packet_fifo.sink.last_be.eq(0b01000000),
+                "default" : packet_fifo.sink.last_be.eq(2**(dw//8 - 1)),
+            })
+        )
+
+        if timestamp is not None:
+            self.sync += If(self.idle & self.enable, timestamp_value.eq(timestamp))
+
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            self.idle.eq(1),
+            If(self.enable,
+                NextState("READ")
+            )
+        )
+        fsm.act("READ",
+            packet_fifo.sink.valid.eq(sink.valid),
+            packet_fifo.sink.data.eq(sink.data),
+            packet_fifo.sink.last.eq(sink.last),
+            sink.ready.eq(packet_fifo.sink.ready),
+            If(sink.valid & sink.ready & sink.last,
+                NextState("END")
+            )
+        )
+        fsm.act("END",
+            If(source.valid & source.ready & source.last,
+                self.done.eq(1),
+                NextState("IDLE"),
+            )
+        )

--- a/liteeth/mac/sram.py
+++ b/liteeth/mac/sram.py
@@ -15,13 +15,13 @@ from litex.soc.interconnect.csr import *
 from litex.soc.interconnect.csr_eventmanager import *
 
 from liteeth.common import *
+from liteeth.mac.packet import LiteEthMACPacketWriter, LiteEthMACPacketReader
 
 # MAC SRAM Writer ----------------------------------------------------------------------------------
 
 class LiteEthMACSRAMWriter(LiteXModule):
     def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None, eth_mtu=eth_mtu_default):
         # Endpoint / Signals.
-        self.sink      = sink = stream.Endpoint(eth_phy_description(dw))
         self.crc_error = Signal()
 
         # Parameters Check / Compute.
@@ -47,27 +47,13 @@ class LiteEthMACSRAMWriter(LiteXModule):
 
         # # #
 
-        write   = Signal()
-        errors  = self._errors.status
+        # Packet frontend.
+        self.packet = packet = LiteEthMACPacketWriter(dw, depth, eth_mtu=eth_mtu, timestamp=timestamp)
+        self.sink = packet.sink
+        self.comb += packet.source.ready.eq(1),
 
-        slot       = Signal(slotbits)
-        length     = Signal(lengthbits)
-        length_inc = Signal(4)
-
-        # Sink is already ready: packets are dropped when no slot is available.
-        sink.ready.reset = 1
-
-        # Decode Length increment from from last_be.
-        self.comb += Case(sink.last_be, {
-            0b00000001 : length_inc.eq(1),
-            0b00000010 : length_inc.eq(2),
-            0b00000100 : length_inc.eq(3),
-            0b00001000 : length_inc.eq(4),
-            0b00010000 : length_inc.eq(5),
-            0b00100000 : length_inc.eq(6),
-            0b01000000 : length_inc.eq(7),
-            "default"  : length_inc.eq(dw//8)
-        })
+        errors = self._errors.status
+        slot   = Signal(slotbits)
 
         # Status FIFO.
         stat_fifo_layout = [("slot", slotbits), ("length", lengthbits)]
@@ -75,76 +61,29 @@ class LiteEthMACSRAMWriter(LiteXModule):
             stat_fifo_layout += [("timestamp", timestampbits)]
         self.stat_fifo = stat_fifo = stream.SyncFIFO(stat_fifo_layout, nslots)
 
-        # FSM.
-        self.fsm = fsm = FSM(reset_state="WRITE")
-        fsm.act("WRITE",
-            If(sink.valid,
-                If(stat_fifo.sink.ready,
-                    write.eq(1),
-                    NextValue(length, length + length_inc),
-                    If(length >= self.eth_mtu,
-                         NextState("DISCARD-REMAINING")
-                    ),
-                    If(sink.last,
-                        If((sink.error & sink.last_be) != 0,
-                            NextState("DISCARD")
-                        ).Else(
-                            NextState("TERMINATE")
-                        )
-                    )
-                ).Else(
-                    NextValue(errors, errors + 1),
-                    NextState("DISCARD-ALL")
-                )
-            )
-        )
-        fsm.act("DISCARD-REMAINING",
-            If(sink.valid & sink.last,
-                If((sink.error & sink.last_be) != 0,
-                    NextState("DISCARD")
-                ).Else(
-                    NextState("TERMINATE")
-                )
-            )
-        )
-        fsm.act("DISCARD-ALL",
-            If(sink.valid & sink.last,
-                If((sink.last_be) != 0,
-                    NextState("DISCARD")
-                ).Else(
-                    NextValue(length, 0),
-                    NextState("WRITE")
-                )
-            )
-        )
-        fsm.act("DISCARD",
-            NextValue(length, 0),
-            NextState("WRITE")
-        )
-        fsm.act("TERMINATE",
-            stat_fifo.sink.valid.eq(1),
-            stat_fifo.sink.slot.eq(slot),
-            stat_fifo.sink.length.eq(length),
-            NextValue(length, 0),
-            NextValue(slot, slot + 1),
-            NextState("WRITE")
-        )
-
         self.comb += [
+            packet.enable.eq(stat_fifo.sink.ready),
+            stat_fifo.sink.valid.eq(packet.done),
+            stat_fifo.sink.slot.eq(slot),
+            stat_fifo.sink.length.eq(packet.length),
             stat_fifo.source.ready.eq(self.ev.available.clear),
             self.ev.available.trigger.eq(stat_fifo.source.valid),
             self._slot.status.eq(stat_fifo.source.slot),
             self._length.status.eq(stat_fifo.source.length),
         ]
         if timestamp is not None:
-            # Latch Timestamp on start of packet.
-            self.sync += If(length == 0, stat_fifo.sink.timestamp.eq(timestamp))
             self.comb += self._timestamp.status.eq(stat_fifo.source.timestamp)
+            self.comb += stat_fifo.sink.timestamp.eq(packet.timestamp)
+
+        self.sync += [
+            If(packet.drop, errors.eq(errors + 1)),
+            If(packet.done & stat_fifo.sink.ready, slot.eq(slot + 1)),
+        ]
 
         # Memory.
         wr_slot = slot
-        wr_addr = length[int(math.log2(dw//8)):]
-        wr_data = Signal(len(sink.data))
+        wr_addr = packet.offset[int(math.log2(dw//8)):]
+        wr_data = Signal(len(packet.source.data))
 
         # Create a Memory per Slot.
         mems  = [None] * nslots
@@ -156,7 +95,7 @@ class LiteEthMACSRAMWriter(LiteXModule):
         self.mems = mems
 
         # Endianness Handling.
-        self.comb += wr_data.eq({"big": reverse_bytes(sink.data), "little": sink.data}[endianness])
+        self.comb += wr_data.eq({"big": reverse_bytes(packet.source.data), "little": packet.source.data}[endianness])
 
         # Connect Memory ports.
         cases = {}
@@ -167,15 +106,12 @@ class LiteEthMACSRAMWriter(LiteXModule):
             ]
             cases[n] = [port.we.eq(1)]
 
-        self.comb += If(sink.valid & write, Case(wr_slot, cases))
+        self.comb += If(packet.source.valid & packet.source.ready, Case(wr_slot, cases))
 
 # MAC SRAM Reader ----------------------------------------------------------------------------------
 
 class LiteEthMACSRAMReader(LiteXModule):
     def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None):
-        # Endpoint / Signals.
-        self.source = source = stream.Endpoint(eth_phy_description(dw))
-
         # Parameters Check / Compute.
         assert dw in [8, 16, 32, 64]
         slotbits   = max(int(math.log2(nslots)), 1)
@@ -201,8 +137,9 @@ class LiteEthMACSRAMReader(LiteXModule):
 
         # # #
 
-        read   = Signal()
-        length = Signal(lengthbits)
+        # Packet frontend.
+        self.packet = packet = LiteEthMACPacketReader(dw, depth, timestamp=timestamp)
+        self.source = source = packet.source
 
         # Command FIFO.
         cmd_fifo = stream.SyncFIFO([("slot", slotbits), ("length", lengthbits)], nslots)
@@ -224,60 +161,48 @@ class LiteEthMACSRAMReader(LiteXModule):
             self.comb += self._timestamp_slot.status.eq(stat_fifo.source.slot)
             self.comb += self._timestamp.status.eq(stat_fifo.source.timestamp)
 
-        # Encode Length to last_be.
-        length_lsb = cmd_fifo.source.length[:int(math.log2(dw/8))] if (dw != 8) else 0
-        self.comb += If(source.last,
-            Case(length_lsb, {
-                1         : source.last_be.eq(0b00000001),
-                2         : source.last_be.eq(0b00000010),
-                3         : source.last_be.eq(0b00000100),
-                4         : source.last_be.eq(0b00001000),
-                5         : source.last_be.eq(0b00010000),
-                6         : source.last_be.eq(0b00100000),
-                7         : source.last_be.eq(0b01000000),
-                "default" : source.last_be.eq(2**(dw//8 - 1)),
-            })
-        )
+        self.comb += packet.length.eq(cmd_fifo.source.length)
+
+        # Memory.
+        read      = Signal()
+        rd_slot   = cmd_fifo.source.slot
+        rd_offset = Signal(lengthbits)
+        rd_data   = Signal(len(source.data))
+
 
         # FSM.
         self.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
-            If(cmd_fifo.source.valid,
+            If(cmd_fifo.source.valid & packet.idle,
+                packet.enable.eq(1),
                 read.eq(1),
-                NextValue(length, dw//8),
+                NextValue(rd_offset, dw//8),
                 NextState("READ")
             )
         )
         fsm.act("READ",
-            source.valid.eq(1),
-            source.last.eq(length >= cmd_fifo.source.length),
-            If(source.ready,
+            packet.sink.valid.eq(1),
+            packet.sink.last.eq(rd_offset >= cmd_fifo.source.length),
+            If(packet.done,
+                NextState("TERMINATE")
+            ).Elif(packet.sink.ready & ~packet.sink.last,
                 read.eq(1),
-                NextValue(length, length + dw//8),
-                If(source.last,
-                    NextState("TERMINATE")
-                )
+                NextValue(rd_offset, rd_offset + dw//8),
             )
         )
         fsm.act("TERMINATE",
-            NextValue(length, 0),
+            NextValue(rd_offset, 0),
             self.ev.done.trigger.eq(1),
             cmd_fifo.source.ready.eq(1),
             NextState("IDLE")
         )
 
         if timestamp is not None:
-            # Latch Timestamp on start of outgoing packet.
-            self.sync += If(length == 0, stat_fifo.sink.timestamp.eq(timestamp))
-            self.comb += stat_fifo.sink.valid.eq(fsm.ongoing("END"))
+            self.comb += stat_fifo.sink.valid.eq(fsm.ongoing("TERMINATE"))
+            self.comb += stat_fifo.sink.timestamp.eq(packet.timestamp)
             self.comb += stat_fifo.sink.slot.eq(cmd_fifo.source.slot)
             # Trigger event when Status FIFO has contents (Override FSM assignment).
             self.comb += self.ev.done.trigger.eq(stat_fifo.source.valid)
-
-        # Memory.
-        rd_slot = cmd_fifo.source.slot
-        rd_addr = Signal(lengthbits)
-        rd_data = Signal(len(source.data))
 
         # Create a Memory per Slot.
         mems    = [None]*nslots
@@ -293,14 +218,14 @@ class LiteEthMACSRAMReader(LiteXModule):
         for n, port in enumerate(ports):
             self.comb += [
                 port.re.eq(read),
-                port.adr.eq(length[int(math.log2(dw//8)):]),
+                port.adr.eq(rd_offset[int(math.log2(dw//8)):])
             ]
             cases[n] = [rd_data.eq(port.dat_r)]
 
         self.comb += Case(rd_slot, cases)
 
         # Endianness Handling.
-        self.comb += source.data.eq({"big" : reverse_bytes(rd_data), "little": rd_data}[endianness])
+        self.comb += packet.sink.data.eq({"big" : reverse_bytes(rd_data), "little": rd_data}[endianness])
 
 # MAC SRAM -----------------------------------------------------------------------------------------
 

--- a/test/test_mac_packet.py
+++ b/test/test_mac_packet.py
@@ -1,0 +1,319 @@
+#
+# This file is part of LiteEth.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from liteeth.common import eth_mtu_default
+from liteeth.mac.packet import LiteEthMACPacketWriter, LiteEthMACPacketReader
+
+# Helpers ------------------------------------------------------------------------------------------
+
+def mac_packet_last_be(dw, length):
+    return 1 << ((length - 1) % (dw//8))
+
+def mac_packet_words(dw, data):
+    words = []
+    for offset in range(0, len(data), dw//8):
+        word = 0
+        for byte, value in enumerate(data[offset:offset + dw//8]):
+            word |= value << (8*byte)
+        words.append(word)
+    return words
+
+def mac_packet_bytes(dw, word, last=0, last_be=0):
+    data = []
+    for byte in range(dw//8):
+        if last and 2**byte > last_be:
+            break
+        data.append((word >> (8*byte)) & 0xff)
+    return data
+
+def mac_packet_test_cases(length=10):
+    return [(dw, [n + 1 for n in range(length)]) for dw in [32, 64]]
+
+def wait_until(cond, timeout=128):
+    for _ in range(timeout):
+        if (yield from cond()):
+            return False
+        yield
+    return True
+
+def mac_packet_send(sink, dw, data, error=0):
+    words = mac_packet_words(dw, data)
+    for n, word in enumerate(words):
+        last = n == len(words) - 1
+        yield sink.data.eq(word)
+        yield sink.last.eq(last)
+        if hasattr(sink, "last_be"):
+            yield sink.last_be.eq(mac_packet_last_be(dw, len(data)) if last else 0)
+        if hasattr(sink, "error"):
+            yield sink.error.eq(error if last else 0)
+        yield sink.valid.eq(1)
+        yield
+        while not (yield sink.ready):
+            yield
+        yield sink.valid.eq(0)
+        yield sink.last.eq(0)
+        if hasattr(sink, "last_be"):
+            yield sink.last_be.eq(0)
+        if hasattr(sink, "error"):
+            yield sink.error.eq(0)
+        yield
+
+# DUT
+# -------------------------------------------------------------------------
+
+class MACPacketReaderDUT(Module):
+    def __init__(self, dw, depth, timestamp=None):
+        self.packet = LiteEthMACPacketReader(dw, depth, timestamp=timestamp)
+        self.submodules += self.packet
+        self.source = self.packet.source
+
+# Test MAC Packet Writer ---------------------------------------------------------------------------
+
+class TestMACPacketWriter(unittest.TestCase):
+    def _run_writer_drop_case(self, dw, data, eth_mtu, enable=1, error=0):
+        dut    = LiteEthMACPacketWriter(dw, depth=8, eth_mtu=eth_mtu)
+        result = {"drop": False, "error": None, "done": False, "source_valid": False, "timeout": False}
+
+        def generator(timeout=128):
+            yield dut.enable.eq(enable)
+            yield dut.source.ready.eq(1)
+            yield from mac_packet_send(dut.sink, dw, data, error=error)
+
+            for _ in range(timeout):
+                result["source_valid"] |= bool((yield dut.source.valid))
+                result["done"]         |= bool((yield dut.done))
+                if (yield dut.drop):
+                    result["drop"]  = True
+                    result["error"] = (yield dut.error)
+                    return
+                yield
+            result["timeout"] = True
+
+        run_simulation(dut, generator())
+        return result
+
+    def test_writer_good_packet(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                dut    = LiteEthMACPacketWriter(dw, depth=8, eth_mtu=eth_mtu_default)
+                result = {
+                    "data"        : [],
+                    "offsets"     : [],
+                    "write_count" : 0,
+                    "done"        : False,
+                    "length"      : None,
+                    "timeout"     : False,
+                }
+
+                def generator(timeout=128):
+                    yield dut.enable.eq(1)
+                    yield dut.source.ready.eq(0)
+                    yield from mac_packet_send(dut.sink, dw, data)
+                    yield dut.source.ready.eq(1)
+
+                    for _ in range(timeout):
+                        if (yield dut.source.valid) and (yield dut.source.ready):
+                            word    = (yield dut.source.data)
+                            result["data"] += mac_packet_bytes(dw, word)
+                            result["offsets"].append((yield dut.offset))
+                            result["write_count"] += 1
+                        if (yield dut.done):
+                            result["done"]   = True
+                            result["length"] = (yield dut.length)
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["data"][:len(data)], data)
+                self.assertEqual(result["offsets"], list(range(0, len(data), dw//8)))
+                self.assertEqual(result["write_count"], len(mac_packet_words(dw, data)))
+                self.assertTrue(result["done"])
+                self.assertEqual(result["length"], len(data))
+
+    def test_writer_disabled_packet_drops(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                result = self._run_writer_drop_case(
+                    dw      = dw,
+                    data    = data,
+                    eth_mtu = eth_mtu_default,
+                    enable  = 0,
+                    error   = 0,
+                )
+                self.assertFalse(result["timeout"])
+                self.assertTrue(result["drop"])
+                self.assertEqual(result["error"], 0)
+                self.assertFalse(result["done"])
+                self.assertFalse(result["source_valid"])
+
+    def test_writer_oversized_packet_drops_with_error(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                result = self._run_writer_drop_case(
+                    dw      = dw,
+                    data    = data,
+                    eth_mtu = len(data) - 1,
+                    enable  = 1,
+                    error   = 0,
+                )
+                self.assertFalse(result["timeout"])
+                self.assertTrue(result["drop"])
+                self.assertEqual(result["error"], 1)
+                self.assertFalse(result["done"])
+                self.assertTrue(result["source_valid"])
+
+    def test_writer_final_error_drops_with_error(self):
+        for dw, data in mac_packet_test_cases(length=6):
+            with self.subTest(dw=dw):
+                result = self._run_writer_drop_case(
+                    dw      = dw,
+                    data    = data,
+                    eth_mtu = eth_mtu_default,
+                    enable  = 1,
+                    error   = mac_packet_last_be(dw, len(data)),
+                )
+                self.assertFalse(result["timeout"])
+                self.assertTrue(result["drop"])
+                self.assertEqual(result["error"], 1)
+                self.assertFalse(result["done"])
+                self.assertTrue(result["source_valid"])
+
+    def test_writer_timestamp_updates(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                timestamp       = Signal(32)
+                timestamp_value = 0x22
+                dut             = LiteEthMACPacketWriter(dw, depth=8, eth_mtu=eth_mtu_default, timestamp=timestamp)
+                result          = {"timestamp": None, "timeout": False}
+
+                def generator(timeout=128):
+                    yield timestamp.eq(timestamp_value)
+                    yield dut.enable.eq(1)
+                    yield dut.source.ready.eq(0)
+                    yield from mac_packet_send(dut.sink, dw, data)
+
+                    yield dut.source.ready.eq(1)
+                    result["timeout"] = (yield from wait_until(lambda: (yield dut.source.valid), timeout=timeout))
+                    if result["timeout"]:
+                        return
+                    yield
+
+                    for _ in range(timeout):
+                        if (yield dut.done):
+                            result["timestamp"] = (yield dut.timestamp)
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["timestamp"], timestamp_value)
+
+# Test MAC Packet Reader ---------------------------------------------------------------------------
+
+class TestMACPacketReader(unittest.TestCase):
+    def _run_reader_until_done(self, dw, data, timestamp=None, timestamp_value=0x55):
+        dut    = MACPacketReaderDUT(dw, depth=8, timestamp=timestamp)
+        result = {"data": [], "last_be": None, "done": False, "timeout": False}
+        if timestamp is not None:
+            result["timestamp"] = None
+
+        def generator(timeout=128):
+            if timestamp is not None:
+                yield timestamp.eq(timestamp_value)
+            yield dut.packet.length.eq(len(data))
+            yield dut.source.ready.eq(0)
+            yield dut.packet.enable.eq(1)
+            yield
+            yield dut.packet.enable.eq(0)
+            yield from mac_packet_send(dut.packet.sink, dw, data)
+            yield dut.source.ready.eq(1)
+
+            for _ in range(timeout):
+                if (yield dut.source.valid) and (yield dut.source.ready):
+                    word    = (yield dut.source.data)
+                    last    = (yield dut.source.last)
+                    last_be = (yield dut.source.last_be)
+                    result["data"] += mac_packet_bytes(dw, word, last, last_be)
+                    if last:
+                        result["last_be"] = last_be
+                if (yield dut.packet.done):
+                    result["done"] = True
+                    if timestamp is not None:
+                        result["timestamp"] = (yield dut.packet.timestamp)
+                    return
+                yield
+            result["timeout"] = True
+
+        run_simulation(dut, generator())
+        return result
+
+    def test_reader_packet_length_last_be_and_done(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                result = self._run_reader_until_done(
+                    dw   = dw,
+                    data = data,
+                )
+
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["data"], data)
+                self.assertEqual(result["last_be"], mac_packet_last_be(dw, len(data)))
+                self.assertTrue(result["done"])
+
+    def test_reader_timestamp_updates(self):
+        for dw, data in mac_packet_test_cases(length=8):
+            with self.subTest(dw=dw):
+                timestamp       = Signal(32)
+                timestamp_value = 0x55
+                result          = self._run_reader_until_done(
+                    dw              = dw,
+                    data            = data,
+                    timestamp       = timestamp,
+                    timestamp_value = timestamp_value,
+                )
+
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["timestamp"], timestamp_value)
+
+    def test_reader_done_waits_for_final_source_accept(self):
+        for dw, data in mac_packet_test_cases(length=4):
+            with self.subTest(dw=dw):
+                dut    = MACPacketReaderDUT(dw, depth=4)
+                result = {"done_before_ready": False, "done_after_ready": False, "timeout": False}
+
+                def generator(timeout=128):
+                    yield dut.packet.length.eq(len(data))
+                    yield dut.source.ready.eq(0)
+                    yield dut.packet.enable.eq(1)
+                    yield
+                    yield dut.packet.enable.eq(0)
+                    yield from mac_packet_send(dut.packet.sink, dw, data)
+
+                    result["timeout"] = (yield from wait_until(lambda: (yield dut.source.valid) and (yield dut.source.last), timeout=timeout))
+                    if result["timeout"]:
+                        return
+                    for _ in range(4):
+                        result["done_before_ready"] |= bool((yield dut.packet.done))
+                        yield
+
+                    yield dut.source.ready.eq(1)
+                    for _ in range(16):
+                        if (yield dut.packet.done):
+                            result["done_after_ready"] = True
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
+                self.assertFalse(result["timeout"])
+                self.assertFalse(result["done_before_ready"])
+                self.assertTrue(result["done_after_ready"])


### PR DESCRIPTION
Add packet fifo based backpressure module for `LiteEthMACSRAM`

This backpressure module includes some common packet assembly/disassembly logic for the sram module. I hope it could be a good start point for the DMA based ethernet.

For RX logic, most common logic is moved into the new packet class so the SRAM writer class reduced significantly. However, the TX logic movement is not very good as still many logic is SRAM specifically.

This module also introduce a small resource waste as the packet module must buffer at least one packet, otherwise the module will fail. It may be improved with something bypass in the future.

This PR is tested on VexiiRiscv@200Mhz (with mainline kernel 7.2-rc1):
```log
[root@ku5p-test ~]# iperf3 -c 192.168.1.151                                                                                                                                                                                            
Connecting to host 192.168.1.151, port 5201
[  5] local 192.168.1.182 port 36580 connected to 192.168.1.151 port 5201
[ ID] Interval           Transfer     Bitrate         Retr  Cwnd
[  5]   0.00-1.00   sec  11.4 MBytes  95.1 Mbits/sec    0    132 KBytes       
[  5]   1.00-2.00   sec  2.62 MBytes  22.1 Mbits/sec    0    132 KBytes       
[  5]   2.00-3.00   sec  11.1 MBytes  93.3 Mbits/sec    0    132 KBytes       
[  5]   3.00-4.00   sec  6.62 MBytes  55.6 Mbits/sec    0    132 KBytes       
[  5]   4.00-5.36   sec  0.00 Bytes  0.00 bits/sec    0    132 KBytes       
[  5]   5.36-7.41   sec  0.00 Bytes  0.00 bits/sec    0    132 KBytes       
[  5]   7.41-7.43   sec   128 KBytes  47.8 Mbits/sec    0    132 KBytes       
[  5]   7.43-8.00   sec  2.50 MBytes  37.0 Mbits/sec    0    132 KBytes       
[  5]   8.00-9.16   sec  0.00 Bytes  0.00 bits/sec    0    132 KBytes       
[  5]   9.16-10.04  sec  4.00 MBytes  38.1 Mbits/sec    0    132 KBytes       
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.04  sec   115 MBytes  95.9 Mbits/sec    0            sender
[  5]   0.00-10.07  sec   115 MBytes  95.6 Mbits/sec                  receiver

iperf Done.
[root@ku5p-test ~]# iperf3 -R -c 192.168.1.151                                                                                                                                                                                         
Connecting to host 192.168.1.151, port 5201
Reverse mode, remote host 192.168.1.151 is sending
[  5] local 192.168.1.182 port 36098 connected to 192.168.1.151 port 5201
[ ID] Interval           Transfer     Bitrate
[  5]   0.00-1.00   sec  6.88 MBytes  57.6 Mbits/sec                  
[  5]   1.00-2.00   sec  6.88 MBytes  57.7 Mbits/sec                  
[  5]   2.00-3.00   sec  6.88 MBytes  57.6 Mbits/sec                  
[  5]   3.00-4.00   sec  7.00 MBytes  58.8 Mbits/sec                  
[  5]   4.00-5.00   sec  6.88 MBytes  57.6 Mbits/sec                  
[  5]   5.00-6.00   sec  6.88 MBytes  57.7 Mbits/sec                  
[  5]   6.00-7.00   sec  6.88 MBytes  57.7 Mbits/sec                  
[  5]   7.00-8.00   sec  7.00 MBytes  58.7 Mbits/sec                  
[  5]   8.00-9.00   sec  6.88 MBytes  57.7 Mbits/sec                  
[  5]   9.00-10.00  sec  6.75 MBytes  56.6 Mbits/sec                  
- - - - - - - - - - - - - - - - - - - - - - - - -
[ ID] Interval           Transfer     Bitrate         Retr
[  5]   0.00-10.03  sec  69.0 MBytes  57.7 Mbits/sec  1724            sender
[  5]   0.00-10.00  sec  68.9 MBytes  57.8 Mbits/sec                  receiver

iperf Done.
```