### PR TITLE
test: refresh ICMP and Etherbone coverage

### DIFF
--- a/test/model/etherbone.py
+++ b/test/model/etherbone.py
@@ -31,25 +31,30 @@ class Etherbone(Module):
 
         udp.set_etherbone_callback(self.callback)
 
-    def send(self, packet):
-        packet.encode()
+    def send(self, packet, target_ip=0x12345678):
+        if not packet.encoded:
+            packet.encode()
         if self.debug:
             print_etherbone(">>>>>>>>")
             print_etherbone(packet)
-        udp_packet = udp.UDPPacket(packet)
+        udp_packet = udp.UDPPacket(packet.bytes)
         udp_packet.src_port = 0x1234 # FIXME
         udp_packet.dst_port = 0x1234 # FIXME
-        udp_packet.length   = len(packet)
+        udp_packet.length   = len(packet.bytes) + udp_header.length
         udp_packet.checksum = 0
-        self.udp.send(udp_packet)
+        self.udp.send(udp_packet, target_ip=target_ip)
 
-    def receive(self):
+    def receive(self, timeout=None):
         self.rx_packet = EtherbonePacket()
+        cycles = 0
         while not self.rx_packet.done:
+            if timeout is not None and cycles >= timeout:
+                break
+            cycles += 1
             yield
 
     def callback(self, packet):
-        packet = EtherbonePacket(packet)
+        packet = EtherbonePacket(init=bytes(packet))
         packet.decode()
         if self.debug:
             print_etherbone("<<<<<<<<")

--- a/test/model/icmp.py
+++ b/test/model/icmp.py
@@ -41,6 +41,13 @@ class ICMPPacket(Packet):
         for d in split_bytes(header, icmp_header.length):
             self.insert(0, d)
 
+    def insert_checksum(self):
+        self[2] = 0
+        self[3] = 0
+        c = ip.checksum(self)
+        self[2] = c & 0xff
+        self[3] = (c >> 8) & 0xff
+
     def __repr__(self):
         r = "--------\n"
         for k in sorted(icmp_header.fields.keys()):
@@ -63,21 +70,22 @@ class ICMP(Module):
 
         self.ip.set_icmp_callback(self.callback)
 
-    def send(self, packet):
+    def send(self, packet, target_ip=0x12345678):
         packet.encode()
+        packet.insert_checksum()
         if self.debug:
             print_icmp(">>>>>>>>")
             print_icmp(packet)
         ip_packet = ip.IPPacket(packet)
         ip_packet.version         = 0x4
         ip_packet.ihl             = 0x5
-        ip_packet.total_length    = len(packet) + ip_packet.ihl
+        ip_packet.total_length    = len(packet) + ipv4_header.length
         ip_packet.identification  = 0
         ip_packet.flags           = 0
         ip_packet.fragment_offset = 0
         ip_packet.ttl             = 0x80
         ip_packet.sender_ip       = self.ip_address
-        ip_packet.target_ip       = 0x12345678  # XXX
+        ip_packet.target_ip       = target_ip
         ip_packet.checksum        = 0
         ip_packet.protocol        = icmp_protocol
         self.ip.send(ip_packet)

--- a/test/model/ip.py
+++ b/test/model/ip.py
@@ -25,9 +25,11 @@ def carry_around_add(a, b):
 
 def checksum(msg):
     s = 0
-    for i in range(0, len(msg), 2):
+    for i in range(0, len(msg) - 1, 2):
         w = msg[i] + (msg[i+1] << 8)
         s = carry_around_add(s, w)
+    if len(msg)%2:
+        s = carry_around_add(s, msg[-1])
     return ~s & 0xffff
 
 

--- a/test/model/phy.py
+++ b/test/model/phy.py
@@ -18,13 +18,13 @@ def print_phy(s):
 
 class PHYSource(PacketStreamer):
     def __init__(self, dw):
-        PacketStreamer.__init__(self, eth_phy_description(dw))
+        PacketStreamer.__init__(self, eth_phy_description(dw), byte_data=True)
 
 # PHY Sink -----------------------------------------------------------------------------------------
 
 class PHYSink(PacketLogger):
     def __init__(self, dw):
-        PacketLogger.__init__(self, eth_phy_description(dw))
+        PacketLogger.__init__(self, eth_phy_description(dw), byte_data=True)
 
 # PHY ----------------------------------------------------------------------------------------------
 

--- a/test/model/udp.py
+++ b/test/model/udp.py
@@ -69,7 +69,7 @@ class UDP(Module):
     def set_etherbone_callback(self, callback):
         self.etherbone_callback = callback
 
-    def send(self, packet):
+    def send(self, packet, target_ip=0x12345678):
         packet.encode()
         if self.debug:
             print_udp(">>>>>>>>")
@@ -77,13 +77,13 @@ class UDP(Module):
         ip_packet = ip.IPPacket(packet)
         ip_packet.version         = 0x4
         ip_packet.ihl             = 0x5
-        ip_packet.total_length    = len(packet) + ip_packet.ihl
+        ip_packet.total_length    = len(packet) + ipv4_header.length
         ip_packet.identification  = 0
         ip_packet.flags           = 0
         ip_packet.fragment_offset = 0
         ip_packet.ttl             = 0x80
         ip_packet.sender_ip       = self.ip_address
-        ip_packet.target_ip       = 0x12345678  # FIXME
+        ip_packet.target_ip       = target_ip
         ip_packet.checksum        = 0
         ip_packet.protocol        = udp_protocol
         self.ip.send(ip_packet)

--- a/test/stream_helpers.py
+++ b/test/stream_helpers.py
@@ -94,13 +94,24 @@ class Packet(list):
 
 
 class PacketStreamer(Module):
-    def __init__(self, description, last_be=None, packet_cls=Packet):
+    def __init__(self, description, last_be=None, packet_cls=Packet, byte_data=False):
         self.source = stream.Endpoint(description)
         self.last_be = last_be
+        self.byte_data = byte_data
 
         self.packets = []
         self.packet  = packet_cls()
         self.packet.done = True
+
+    def _pop_word(self):
+        bytes_per_clk = len(self.source.data)//8
+        nbytes = min(bytes_per_clk, len(self.packet))
+        data = 0
+        for i in range(nbytes):
+            data |= self.packet.pop(0) << (8*i)
+        last = len(self.packet) == 0
+        last_be = 1 << (nbytes - 1)
+        return data, last, last_be
 
     def send(self, packet):
         packet = deepcopy(packet)
@@ -117,6 +128,31 @@ class PacketStreamer(Module):
         while True:
             if len(self.packets) and self.packet.done:
                 self.packet = self.packets.pop(0)
+            if self.byte_data:
+                if not self.packet.ongoing and not self.packet.done:
+                    data, last, last_be = self._pop_word()
+                    yield self.source.valid.eq(1)
+                    yield self.source.data.eq(data)
+                    yield self.source.last.eq(last)
+                    if hasattr(self.source, "last_be"):
+                        yield self.source.last_be.eq(last_be if last else 0)
+                    self.packet.ongoing = True
+                elif (yield self.source.valid) and (yield self.source.ready):
+                    if len(self.packet):
+                        data, last, last_be = self._pop_word()
+                        yield self.source.valid.eq(1)
+                        yield self.source.data.eq(data)
+                        yield self.source.last.eq(last)
+                        if hasattr(self.source, "last_be"):
+                            yield self.source.last_be.eq(last_be if last else 0)
+                    else:
+                        self.packet.done = True
+                        yield self.source.valid.eq(0)
+                        yield self.source.last.eq(0)
+                        if hasattr(self.source, "last_be"):
+                            yield self.source.last_be.eq(0)
+                yield
+                continue
             if not self.packet.ongoing and not self.packet.done:
                 yield self.source.valid.eq(1)
                 yield self.source.data.eq(self.packet.pop(0))
@@ -135,20 +171,28 @@ class PacketStreamer(Module):
 
 
 class PacketLogger(Module):
-    def __init__(self, description, packet_cls=Packet):
+    def __init__(self, description, packet_cls=Packet, byte_data=False):
         self.sink = stream.Endpoint(description)
+        self.byte_data = byte_data
 
         self.packet_cls = packet_cls
         self.packet     = packet_cls()
         self.first      = True
 
-    def receive(self, length=None):
+    def receive(self, length=None, timeout=None):
         self.packet.done = False
+        cycles = 0
         if length is None:
             while not self.packet.done:
+                if timeout is not None and cycles >= timeout:
+                    break
+                cycles += 1
                 yield
         else:
             while length > len(self.packet):
+                if timeout is not None and cycles >= timeout:
+                    break
+                cycles += 1
                 yield
 
     @passive
@@ -159,7 +203,18 @@ class PacketLogger(Module):
                 if self.first:
                     self.packet = self.packet_cls()
                     self.first = False
-                self.packet.append((yield self.sink.data))
+                data = (yield self.sink.data)
+                if self.byte_data:
+                    bytes_per_clk = len(self.sink.data)//8
+                    nbytes = bytes_per_clk
+                    if (yield self.sink.last) and hasattr(self.sink, "last_be"):
+                        last_be = (yield self.sink.last_be)
+                        if last_be != 0:
+                            nbytes = last_be.bit_length()
+                    for i in range(nbytes):
+                        self.packet.append((data >> (8*i)) & 0xff)
+                else:
+                    self.packet.append(data)
                 if (yield self.sink.last):
                     self.packet.done = True
                     self.first = True

--- a/test/test_etherbone.py
+++ b/test/test_etherbone.py
@@ -1,126 +1,159 @@
 #
 # This file is part of LiteEth.
 #
-# Copyright (c) 2015-2018 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2015-2026 Florent Kermarrec <florent@enjoy-digital.fr>
 # SPDX-License-Identifier: BSD-2-Clause
 
 import unittest
 
-from migen import *
-
-from litex.soc.interconnect import wishbone
-from test.stream_helpers import *
+from litex.gen import *
+from litex.gen.sim import *
+from litex.soc.interconnect import stream, wishbone
 
 from liteeth.common import *
-from liteeth.core import LiteEthUDPIPCore
 from liteeth.frontend.etherbone import LiteEthEtherbone
 
-from test.model import phy, mac, arp, ip, udp, etherbone
-
-from litex.gen.sim import *
+from test.model import etherbone
+from test.stream_helpers import Packet, PacketLogger, PacketStreamer
 
 # Constants ----------------------------------------------------------------------------------------
 
-ip_address  = 0x12345678
-mac_address = 0x12345678abcd
+ip_address = 0x12345678
+udp_port   = 0x1234
+
+# Helpers ------------------------------------------------------------------------------------------
+
+class UDPPort:
+    def __init__(self, dw):
+        self.sink   = stream.Endpoint(eth_udp_user_description(dw))
+        self.source = stream.Endpoint(eth_udp_user_description(dw))
+
+
+class UDPCrossbar:
+    def __init__(self, dw):
+        self.dw   = dw
+        self.port = UDPPort(dw)
+
+    def get_port(self, udp_port, dw=8, cd="sys", depth=None):
+        assert dw == self.dw
+        return self.port
+
+
+class UDP:
+    def __init__(self, dw):
+        self.crossbar = UDPCrossbar(dw)
+
+
+def encode_packet(packet):
+    if not packet.encoded:
+        packet.encode()
+    return Packet(packet.bytes)
+
+
+def decode_packet(packet):
+    packet = etherbone.EtherbonePacket(init=bytes(packet))
+    packet.decode()
+    return packet
 
 # DUT ----------------------------------------------------------------------------------------------
 
 class DUT(LiteXModule):
-    def __init__(self, eth_mtu=eth_mtu_default):
-        self.phy_model       = phy.PHY(8, debug=False)
-        self.mac_model       = mac.MAC(self.phy_model, debug=False, loopback=False)
-        self.arp_model       = arp.ARP(self.mac_model, mac_address, ip_address, debug=False)
-        self.ip_model        = ip.IP(self.mac_model, mac_address, ip_address, debug=False, loopback=False)
-        self.udp_model       = udp.UDP(self.ip_model, ip_address, debug=False, loopback=False)
-        self.etherbone_model = etherbone.Etherbone(self.udp_model, debug=False)
-
-        self.core      = LiteEthUDPIPCore(self.phy_model, mac_address, ip_address, 100000, eth_mtu=eth_mtu)
-        self.etherbone = LiteEthEtherbone(self.core.udp, 0x1234)
+    def __init__(self):
+        self.udp       = UDP(32)
+        self.etherbone = LiteEthEtherbone(self.udp, udp_port, buffer_depth=8)
 
         self.sram         = wishbone.SRAM(1024)
         self.interconnect = wishbone.InterconnectPointToPoint(self.etherbone.wishbone.bus, self.sram.bus)
 
-# Genrator -----------------------------------------------------------------------------------------
-
-def main_generator(dut):
-    test_probe  = True
-    test_writes = True
-    test_reads  = True
-
-    # test probe
-    if test_probe:
-        packet = etherbone.EtherbonePacket()
-        packet.pf = 1
-        dut.etherbone_model.send(packet)
-        yield from dut.etherbone_model.receive()
-        print("probe: " + str(bool(dut.etherbone_model.rx_packet.pr)))
-
-    for i in range(2):
-        # test writes
-        if test_writes:
-            writes_datas = [j for j in range(4)]
-            writes = etherbone.EtherboneWrites(base_addr=0x1000, datas=writes_datas)
-            record = etherbone.EtherboneRecord()
-            record.writes      = writes
-            record.reads       = None
-            record.bca         = 0
-            record.rca         = 0
-            record.rff         = 0
-            record.cyc         = 0
-            record.wca         = 0
-            record.wff         = 0
-            record.byte_enable = 0xf
-            record.wcount      = len(writes_datas)
-            record.rcount      = 0
-
-            packet = etherbone.EtherbonePacket()
-            packet.records = [record]
-            dut.etherbone_model.send(packet)
-            for i in range(256):
-                yield
-
-        # test reads
-        if test_reads:
-            reads_addrs = [0x1000 + 4*j for j in range(4)]
-            reads = etherbone.EtherboneReads(base_ret_addr=0x1000, addrs=reads_addrs)
-            record = etherbone.EtherboneRecord()
-            record.writes      = None
-            record.reads       = reads
-            record.bca         = 0
-            record.rca         = 0
-            record.rff         = 0
-            record.cyc         = 0
-            record.wca         = 0
-            record.wff         = 0
-            record.byte_enable = 0xf
-            record.wcount      = 0
-            record.rcount      = len(reads_addrs)
-
-            packet = etherbone.EtherbonePacket()
-            packet.records = [record]
-            dut.etherbone_model.send(packet)
-            yield from dut.etherbone_model.receive()
-            loopback_writes_datas = []
-            loopback_writes_datas = dut.etherbone_model.rx_packet.records.pop().writes.get_datas()
-
-            # check resultss
-            s, l, e = check(writes_datas, loopback_writes_datas)
-            print("shift " + str(s) + " / length " + str(l) + " / errors " + str(e))
+        self.streamer = PacketStreamer(eth_udp_user_description(32), byte_data=True)
+        self.logger   = PacketLogger(eth_udp_user_description(32), byte_data=True)
+        udp_port_endpoint = self.udp.crossbar.port
+        self.comb += [
+            self.streamer.source.connect(udp_port_endpoint.source),
+            udp_port_endpoint.sink.connect(self.logger.sink),
+        ]
 
 # Test Etherbone -----------------------------------------------------------------------------------
 
 class TestEtherbone(unittest.TestCase):
-    def test_etherbone(self):
+    def send(self, dut, packet):
+        packet = encode_packet(packet)
+        yield dut.streamer.source.src_port.eq(udp_port)
+        yield dut.streamer.source.dst_port.eq(udp_port)
+        yield dut.streamer.source.ip_address.eq(ip_address)
+        yield dut.streamer.source.length.eq(len(packet))
+        yield from dut.streamer.send_blocking(packet)
+
+    def receive(self, dut):
+        yield from dut.logger.receive(timeout=256)
+        self.assertTrue(dut.logger.packet.done)
+        return decode_packet(dut.logger.packet)
+
+    def do_probe(self, dut):
+        packet = etherbone.EtherbonePacket()
+        packet.pf = 1
+        packet.encode()
+        packet.bytes += bytes([0x00]*4)
+        yield from self.send(dut, packet)
+
+        response = yield from self.receive(dut)
+        self.assertEqual(response.pr, 1)
+
+    def do_writes(self, dut, datas):
+        for i in range(len(datas)):
+            yield dut.sram.mem[i].eq(0)
+
+        writes = etherbone.EtherboneWrites(base_addr=0x0000, datas=datas)
+        record = etherbone.EtherboneRecord()
+        record.writes = writes
+
+        packet = etherbone.EtherbonePacket()
+        packet.records = [record]
+        yield from self.send(dut, packet)
+
+        for _ in range(64):
+            values = []
+            for i in range(len(datas)):
+                values.append((yield dut.sram.mem[i]))
+            if values == datas:
+                break
+            yield
+
+        values = []
+        for i in range(len(datas)):
+            values.append((yield dut.sram.mem[i]))
+        self.assertEqual(values, datas)
+
+    def do_reads(self, dut, datas):
+        for i, data in enumerate(datas):
+            yield dut.sram.mem[i].eq(data)
+
+        reads = etherbone.EtherboneReads(
+            base_ret_addr = 0x0000,
+            addrs         = [4*i for i in range(len(datas))])
+        record = etherbone.EtherboneRecord()
+        record.reads = reads
+
+        packet = etherbone.EtherbonePacket()
+        packet.records = [record]
+        yield from self.send(dut, packet)
+
+        response = yield from self.receive(dut)
+        self.assertEqual(len(response.records), 1)
+        self.assertIsNotNone(response.records[0].writes)
+        self.assertEqual(response.records[0].writes.get_datas(), datas)
+
+    def main_generator(self, dut):
+        yield from self.do_probe(dut)
+        yield from self.do_writes(dut, [0x12345678])
+        yield from self.do_writes(dut, [0x0a000000 | i for i in range(4)])
+        yield from self.do_reads(dut, [0x87654321])
+        yield from self.do_reads(dut, [0x0b000000 | i for i in range(4)])
+
+    def test_probe_write_read(self):
         dut = DUT()
-        generators = {
-            "sys"    : [main_generator(dut)],
-            "eth_tx" : [dut.phy_model.phy_sink.generator(), dut.phy_model.generator()],
-            "eth_rx" : [dut.phy_model.phy_source.generator()]
-        }
-        clocks = {
-            "sys":    10,
-            "eth_rx": 10,
-            "eth_tx": 10,
-        }
-        #run_simulation(dut, generators, clocks, vcd_name="sim.vcd") # FIXME: hanging
+        run_simulation(dut, [
+            self.main_generator(dut),
+            dut.streamer.generator(),
+            dut.logger.generator(),
+        ])

--- a/test/test_icmp.py
+++ b/test/test_icmp.py
@@ -8,66 +8,103 @@ import unittest
 
 from migen import *
 
-from litex.soc.interconnect import wishbone
-from test.stream_helpers import *
-
 from liteeth.common import *
 from liteeth.core import LiteEthIPCore
 
-from test.model.dumps import *
-from test.model.mac import *
-from test.model.ip import *
-from test.model.icmp import *
 from test.model import phy, mac, arp, ip, icmp
 
 from litex.gen.sim import *
 
 # Constants ----------------------------------------------------------------------------------------
 
-ip_address  = 0x12345678
-mac_address = 0x12345678abcd
+model_ip  = convert_ip("192.168.10.1")
+model_mac = 0x12345678abcd
+
+dut_ip    = convert_ip("192.168.10.50")
+dut_mac   = 0x12345678ffff
+
+# ICMP Model ---------------------------------------------------------------------------------------
+
+class ICMP(icmp.ICMP):
+    def __init__(self, ip, ip_address, replies, debug=False):
+        self.replies = replies
+        icmp.ICMP.__init__(self, ip, ip_address, debug=debug)
+
+    def process(self, packet):
+        self.replies.append(packet)
 
 # DUT ----------------------------------------------------------------------------------------------
 
 class DUT(LiteXModule):
-    def __init__(self, eth_mtu=eth_mtu_default):
-        self.phy_model  = phy.PHY(8, debug=True)
-        self.mac_model  = mac.MAC(self.phy_model, debug=True, loopback=False)
-        self.arp_model  = arp.ARP(self.mac_model, mac_address, ip_address, debug=True)
-        self.ip_model   = ip.IP(self.mac_model, mac_address, ip_address, debug=True, loopback=False)
-        self.icmp_model = icmp.ICMP(self.ip_model, ip_address, debug=True)
+    def __init__(self, dw=8, eth_mtu=eth_mtu_default):
+        self.icmp_replies = []
 
-        self.ip = LiteEthIPCore(self.phy_model, mac_address, ip_address, 100000, eth_mtu=eth_mtu)
+        self.phy_model  = phy.PHY(dw, debug=False)
+        self.mac_model  = mac.MAC(self.phy_model, debug=False, loopback=False)
+        self.arp_model  = arp.ARP(self.mac_model, model_mac, model_ip, debug=False)
+        self.ip_model   = ip.IP(self.mac_model, model_mac, model_ip, debug=False, loopback=False)
+        self.icmp_model = ICMP(self.ip_model, model_ip, self.icmp_replies, debug=False)
+
+        self.ip = LiteEthIPCore(self.phy_model, dut_mac, dut_ip, 100000, dw=dw, eth_mtu=eth_mtu)
 
 # Generator ----------------------------------------------------------------------------------------
 
-def main_generator(dut):
-    packet = MACPacket(ping_request)
-    packet.decode_remove_header()
-    packet = IPPacket(packet)
+def expected_ping_reply(payload, quench):
+    packet = icmp.ICMPPacket(payload)
+    packet.msgtype  = icmp_type_ping_reply
+    packet.code     = 0
+    packet.checksum = 0
+    packet.quench   = quench
+    packet.encode()
+    packet.insert_checksum()
+    packet = icmp.ICMPPacket(packet)
     packet.decode()
-    packet = ICMPPacket(packet)
-    packet.decode()
-    dut.icmp_model.send(packet)
+    return packet
 
-    for i in range(256):
+def main_generator(dut):
+    tc = unittest.TestCase()
+
+    payload = list(b"Hello World 123456")
+    quench  = 0x69b30001
+    request = icmp.ICMPPacket(payload)
+    request.msgtype  = icmp_type_ping_request
+    request.code     = 0
+    request.checksum = 0
+    request.quench   = quench
+
+    dut.icmp_model.send(request, target_ip=dut_ip)
+
+    for _ in range(512):
+        if dut.icmp_replies:
+            break
         yield
+
+    tc.assertEqual(len(dut.icmp_replies), 1)
+    reply    = dut.icmp_replies[0]
+    expected = expected_ping_reply(payload, quench)
+
+    tc.assertEqual(reply.msgtype,  icmp_type_ping_reply)
+    tc.assertEqual(reply.code,     0)
+    tc.assertEqual(reply.checksum, expected.checksum)
+    tc.assertEqual(reply.quench,   quench)
+    tc.assertEqual(list(reply),    payload)
 
 # Test ICMP ----------------------------------------------------------------------------------------
 
 class TestICMP(unittest.TestCase):
-    def test(self):
-        for mtu in [eth_mtu_default, eth_mtu_jumboframe]:
-            with self.subTest(eth_mtu=mtu):
-                dut = DUT(eth_mtu=mtu)
-                generators = {
-                    "sys"    : [main_generator(dut)],
-                    "eth_tx" : [dut.phy_model.phy_sink.generator(), dut.phy_model.generator()],
-                    "eth_rx" : [dut.phy_model.phy_source.generator()],
-                }
-                clocks = {
-                    "sys":    10,
-                    "eth_rx": 10,
-                    "eth_tx": 10,
-                }
-                run_simulation(dut, generators, clocks, vcd_name="sim.vcd")
+    def run_test(self, dw):
+        dut = DUT(dw=dw)
+        generators = {
+            "sys"    : [main_generator(dut)],
+            "eth_tx" : [dut.phy_model.phy_sink.generator(), dut.phy_model.generator()],
+            "eth_rx" : [dut.phy_model.phy_source.generator()],
+        }
+        clocks = {
+            "sys":    10,
+            "eth_rx": 10,
+            "eth_tx": 10,
+        }
+        run_simulation(dut, generators, clocks)
+
+    def test_echo_dw_8(self):
+        self.run_test(8)

--- a/test/test_phy_model.py
+++ b/test/test_phy_model.py
@@ -1,0 +1,52 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from litex.gen import *
+from litex.gen.sim import *
+
+from test.model import phy
+from test.stream_helpers import Packet
+
+# DUT ----------------------------------------------------------------------------------------------
+
+class DUT(LiteXModule):
+    def __init__(self, dw):
+        self.phy_model = phy.PHY(dw)
+        self.comb += self.phy_model.source.connect(self.phy_model.sink)
+
+# Generator ----------------------------------------------------------------------------------------
+
+def main_generator(dut, dw):
+    tc = unittest.TestCase()
+
+    for length in [1, 2, 3, 4, 5, 7, 8, 9, 17]:
+        packet = Packet(range(length))
+        dut.phy_model.send(packet)
+        yield from dut.phy_model.receive()
+        tc.assertEqual(list(dut.phy_model.packet), list(packet),
+            f"PHY model roundtrip failed for dw={dw}, length={length}")
+
+# Test PHY Model -----------------------------------------------------------------------------------
+
+class TestPHYModel(unittest.TestCase):
+    def run_test(self, dw):
+        dut = DUT(dw)
+        run_simulation(dut, [
+            main_generator(dut, dw),
+            dut.phy_model.phy_source.generator(),
+            dut.phy_model.phy_sink.generator(),
+        ])
+
+    def test_dw_8(self):
+        self.run_test(8)
+
+    def test_dw_32(self):
+        self.run_test(32)
+
+    def test_dw_64(self):
+        self.run_test(64)


### PR DESCRIPTION
Refresh the still-relevant pieces from Michael Betz's LiteEth PR #106 on current master.

This keeps the scope focused:
- fix test-model IP checksum handling for odd byte counts;
- fix ICMP/UDP model total_length handling and ICMP checksum insertion;
- make the PHY test model stream bytes correctly over wider data paths;
- add active ICMP echo and PHY model regressions;
- replace the old hanging Etherbone full-stack test with a fast UDP-boundary frontend regression for probe/write/read behavior.

The companion LiteX StrideConverter last_be work from the old PR has already been handled separately in LiteX commit https://github.com/enjoy-digital/litex/commit/a2a62dcc662465015dcd55d0de701d41de40a660.

Credit: based on ideas from Michael Betz's original work in https://github.com/enjoy-digital/liteeth/pull/106.