### PR TITLE
mac: avoid hybrid RX valid/ready coupling

### DIFF
--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -112,7 +112,6 @@ class LiteEthMAC(LiteXModule):
 class LiteEthMACCoreCrossbar(LiteXModule):
     def __init__(self, core, crossbar, interface, dw, hw_mac=None):
         rx_ready = Signal()
-        rx_valid = Signal()
 
         # IP core packet processing.
         self.packetizer   = LiteEthMACPacketizer(dw)
@@ -163,6 +162,8 @@ class LiteEthMACCoreCrossbar(LiteXModule):
             mac_mcast4 = Signal() # Matches IPv4 Multicast MAC addresses (01:00:5E:XX:XX:XX).
             mac_mcast6 = Signal() # Matches IPv6 Multicast MAC addresses (33:33:XX:XX:XX:XX).
             mac_valid  = Signal() # Matches any of the above MAC types.
+            hw_valid   = Signal() # Packet is expected on the hardware path.
+            cpu_valid  = Signal() # Packet is expected on the CPU path.
             self.comb += [
                 # Hardware MAC address check.
                 mac_local.eq(hw_mac == filter_depacketizer.source.payload.target_mac),
@@ -175,18 +176,27 @@ class LiteEthMACCoreCrossbar(LiteXModule):
                 # Combine all conditions to determine if the packet should be processed.
                 mac_valid.eq(mac_local | mac_bcast | mac_mcast4 | mac_mcast6),
 
-                # Accept when both FIFOs are ready.
-                rx_ready.eq(hw_fifo.sink.ready & cpu_fifo.sink.ready),
+                # Select paths:
+                # - Local unicast: HW only.
+                # - Broadcast/Multicast: HW + CPU.
+                # - Other unicast: CPU only.
+                hw_valid.eq(mac_valid),
+                cpu_valid.eq(~mac_local),
 
-                # Present when ready and Depacketizer valid.
-                rx_valid.eq(rx_ready & filter_depacketizer.source.valid),
+                # Accept when all selected sinks are ready.
+                rx_ready.eq((~hw_valid  | hw_fifo.sink.ready) &
+                            (~cpu_valid | cpu_fifo.sink.ready)),
 
                 # Depacketizer -> HW FIFO/CPU FIFO.
                 filter_depacketizer.source.connect(hw_fifo.sink,  omit={"ready", "valid"}),
                 filter_depacketizer.source.connect(cpu_fifo.sink, omit={"ready", "valid"}),
                 filter_depacketizer.source.ready.eq(rx_ready),
-                hw_fifo.sink.valid.eq(rx_valid & mac_valid),
-                cpu_fifo.sink.valid.eq(rx_valid & ~mac_local),
+                hw_fifo.sink.valid.eq(
+                    filter_depacketizer.source.valid & hw_valid &
+                    (~cpu_valid | cpu_fifo.sink.ready)),
+                cpu_fifo.sink.valid.eq(
+                    filter_depacketizer.source.valid & cpu_valid &
+                    (~hw_valid | hw_fifo.sink.ready)),
             ]
         else:
             # RX Broadcast.
@@ -194,15 +204,12 @@ class LiteEthMACCoreCrossbar(LiteXModule):
                 # Accept when both Interface/Depacketizer are ready.
                 rx_ready.eq(interface.sink.ready & self.depacketizer.sink.ready),
 
-                # Present when ready and Core valid.
-                rx_valid.eq(rx_ready & core.source.valid),
-
                 # Core -> Interface/Depacketizer.
                 core.source.connect(interface.sink,         omit={"ready", "valid"}),
                 core.source.connect(self.depacketizer.sink, omit={"ready", "valid"}),
                 core.source.ready.eq(rx_ready),
-                interface.sink.valid.eq(rx_valid),
-                self.depacketizer.sink.valid.eq(rx_valid),
+                interface.sink.valid.eq(core.source.valid & self.depacketizer.sink.ready),
+                self.depacketizer.sink.valid.eq(core.source.valid & interface.sink.ready),
             ]
 
         # TX arbiter FSM.

--- a/test/test_mac_hybrid.py
+++ b/test/test_mac_hybrid.py
@@ -1,0 +1,124 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from litex.gen import *
+from litex.gen.sim import *
+from litex.soc.interconnect import stream
+
+from liteeth.common import *
+from liteeth.mac import LiteEthMACCoreCrossbar
+from liteeth.mac.common import LiteEthMACCrossbar
+from test.model import mac
+
+# Helpers ------------------------------------------------------------------------------------------
+
+class EndpointPair:
+    def __init__(self, dw):
+        self.sink   = stream.Endpoint(eth_phy_description(dw))
+        self.source = stream.Endpoint(eth_phy_description(dw))
+
+def mac_packet(target_mac, payload):
+    packet               = mac.MACPacket(payload)
+    packet.target_mac    = target_mac
+    packet.sender_mac    = 0x90e2ba3c4d5e
+    packet.ethernet_type = ethernet_type_ip
+    packet.encode_header()
+    return packet
+
+def wait_signal(signal, cycles=128):
+    for _ in range(cycles):
+        if (yield signal):
+            return
+        yield
+    raise TimeoutError
+
+def send_packet(source, packet):
+    for n, byte in enumerate(packet):
+        last = n == (len(packet) - 1)
+        yield source.valid.eq(1)
+        yield source.data.eq(byte)
+        yield source.last.eq(last)
+        yield source.last_be.eq(1 if last else 0)
+        for _ in range(128):
+            yield
+            if (yield source.ready):
+                break
+        else:
+            raise TimeoutError
+    yield source.valid.eq(0)
+    yield source.last.eq(0)
+    yield source.last_be.eq(0)
+    yield
+
+# DUT ----------------------------------------------------------------------------------------------
+
+class DUT(LiteXModule):
+    def __init__(self, dw=8, hw_mac=None):
+        self.core      = EndpointPair(dw)
+        self.interface = EndpointPair(dw)
+        self.crossbar  = LiteEthMACCrossbar(dw)
+        self.port      = self.crossbar.get_port(ethernet_type_ip, dw=dw)
+
+        self.mac_crossbar = LiteEthMACCoreCrossbar(
+            core      = self.core,
+            crossbar  = self.crossbar,
+            interface = self.interface,
+            dw        = dw,
+            hw_mac    = hw_mac,
+        )
+
+# Test Hybrid MAC ----------------------------------------------------------------------------------
+
+class TestMACHybrid(unittest.TestCase):
+    def test_rx_broadcast_valid_does_not_depend_on_own_ready(self):
+        dut = DUT()
+
+        def generator():
+            yield dut.core.source.valid.eq(1)
+            yield dut.core.source.data.eq(0x5a)
+            yield dut.interface.sink.ready.eq(0)
+            yield
+
+            # CPU sink is not ready, so the source must not advance. Its valid
+            # still needs to be presented since the other sink is ready.
+            self.assertEqual((yield dut.core.source.ready), 0)
+            self.assertEqual((yield dut.interface.sink.valid), 1)
+            self.assertEqual((yield dut.mac_crossbar.depacketizer.sink.valid), 0)
+
+            yield dut.interface.sink.ready.eq(1)
+            yield
+
+            self.assertEqual((yield dut.core.source.ready), 1)
+            self.assertEqual((yield dut.interface.sink.valid), 1)
+            self.assertEqual((yield dut.mac_crossbar.depacketizer.sink.valid), 1)
+
+        run_simulation(dut, generator())
+
+    def test_rx_local_unicast_ignores_stalled_cpu_path(self):
+        hw_mac = 0x102030405060
+        dut    = DUT(hw_mac=hw_mac)
+
+        def generator():
+            yield dut.interface.sink.ready.eq(0)
+            yield dut.port.source.ready.eq(0)
+            yield
+
+            # Fill the CPU path with packets that are not selected for hardware.
+            for n in range(5):
+                packet = mac_packet(0x0a0b0c0d0e0f, [n])
+                yield from send_packet(dut.core.source, packet)
+
+            # A local-unicast packet only targets the hardware path and must not
+            # be held off by the stalled CPU path.
+            packet = mac_packet(hw_mac, [0x5a])
+            yield from send_packet(dut.core.source, packet)
+
+            yield from wait_signal(dut.port.source.valid)
+            self.assertEqual((yield dut.port.source.data), 0x5a)
+
+        run_simulation(dut, generator())


### PR DESCRIPTION
Refreshes the still-relevant idea from Xiretza's PR #115 on current master.

The hybrid MAC RX fanout was still gating downstream valid through combined downstream ready. This preserves current routing semantics while avoiding a sink valid depending on that same sink ready:
- local unicast -> hardware path only;
- broadcast/multicast -> hardware + CPU paths;
- other unicast -> CPU path only.

Adds focused regressions for:
- the no-filter hybrid broadcast fanout;
- the filtered `hw_mac` path, where local unicast must still reach hardware while the CPU path is stalled.

Credit: based on ideas from https://github.com/enjoy-digital/liteeth/pull/115 by Xiretza.
