### PR TITLE
liteeth_gen: expose RGMII HW init reset

### DIFF
--- a/examples/udp_raw_ecp5rgmii.yml
+++ b/examples/udp_raw_ecp5rgmii.yml
@@ -8,6 +8,7 @@
 phy          : LiteEthECP5PHYRGMII
 phy_tx_delay : 0e-9
 phy_rx_delay : 2e-9
+# phy_hw_init_reset : True # Enable startup PHY reset pulse when required by the board PHY.
 device       : LFE5U-25F-6BG256C
 vendor       : lattice
 toolchain    : trellis

--- a/examples/udp_s7phyrgmii.yml
+++ b/examples/udp_s7phyrgmii.yml
@@ -8,6 +8,7 @@
 phy       : LiteEthS7PHYRGMII
 vendor    : xilinx
 toolchain : vivado
+# phy_hw_init_reset : True # Enable startup PHY reset pulse when required by the board PHY.
 
 # Core -------------------------------------------------------------------------
 clk_freq    : 125e6

--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -290,7 +290,7 @@ class PHYCore(SoCMini):
                 pads               = platform.request("rgmii"),
                 tx_delay           = core_config.get("phy_tx_delay", 2e-9),
                 rx_delay           = core_config.get("phy_rx_delay", 2e-9),
-                with_hw_init_reset = False) # FIXME: required since sys_clk = eth_rx_clk.
+                with_hw_init_reset = core_config.get("phy_hw_init_reset", False))
         # SGMII.
         elif phy in [
             # 7-Series GTP/GTX.


### PR DESCRIPTION
Refreshes the still-relevant use case from Matt Johnston's PR #119 on current master.

Generated RGMII cores currently force `with_hw_init_reset=False`, so the external PHY reset pin only follows the CSR reset bit. Some boards/PHYs need a startup reset pulse, for example the KSZ9031RNX case described in PR #119.

This adds an explicit YAML opt-in:

```yaml
phy_hw_init_reset : True
```

The default remains `False` to preserve current generated-core behavior.

I also added the commented option to the S7/ECP5 RGMII example configs.

Verification:
- `python3 liteeth/gen.py examples/udp_raw_ecp5rgmii.yml --output-dir /tmp/liteeth-pr119-default --no-compile-gateware`
- `python3 liteeth/gen.py /tmp/udp_raw_ecp5rgmii_hw_reset.yml --output-dir /tmp/liteeth-pr119-enabled --no-compile-gateware`
- verified default output keeps `rgmii_rst_n = ~ethphy_reset_storage`
- verified opt-in output includes the HW reset counter in the `rgmii_rst_n` path
- `python3 -m unittest test.test_gen`

Credit: based on ideas from https://github.com/enjoy-digital/liteeth/pull/119 by Matt Johnston.
