### PR TITLE
core: add IPv4 gateway routing

### DIFF
--- a/examples/udp_raw_ecp5rgmii.yml
+++ b/examples/udp_raw_ecp5rgmii.yml
@@ -19,6 +19,8 @@ core            : udp
 
 mac_address     : 0x10e2d5000000
 ip_address      : 172.30.0.1
+# gateway_ip    : 172.30.0.254
+# netmask       : 255.255.255.0
 
 tx_cdc_depth    : 16
 tx_cdc_buffered : True

--- a/examples/udp_s7phyrgmii.yml
+++ b/examples/udp_s7phyrgmii.yml
@@ -15,6 +15,8 @@ clk_freq    : 125e6
 core        : udp
 mac_address : 0x10e2d5000000
 ip_address  : 192.168.1.50
+# gateway_ip : 192.168.1.1
+# netmask    : 255.255.255.0
 data_width  : 8
 
 # UDP Ports --------------------------------------------------------------------

--- a/liteeth/core/__init__.py
+++ b/liteeth/core/__init__.py
@@ -31,6 +31,8 @@ class LiteEthIPCore(LiteXModule):
         interface         = "crossbar",
         endianness        = "big",
         eth_mtu           = eth_mtu_default,
+        gateway_ip        = None,
+        netmask           = None,
     ):
         # Parameters.
         # -----------
@@ -73,6 +75,8 @@ class LiteEthIPCore(LiteXModule):
             arp_table      = self.arp.table,
             with_broadcast = with_ip_broadcast,
             dw             = dw,
+            gateway_ip     = gateway_ip,
+            netmask        = netmask,
         )
         # ICMP (Optional).
         # ----------------
@@ -118,6 +122,8 @@ class LiteEthUDPIPCore(LiteEthIPCore):
         interface         = "crossbar",
         endianness        = "big",
         eth_mtu           = eth_mtu_default,
+        gateway_ip        = None,
+        netmask           = None,
     ):
         # Parameters.
         # -----------
@@ -147,6 +153,8 @@ class LiteEthUDPIPCore(LiteEthIPCore):
             rx_cdc_depth      = rx_cdc_depth,
             rx_cdc_buffered   = rx_cdc_buffered,
             eth_mtu           = eth_mtu,
+            gateway_ip        = gateway_ip,
+            netmask           = netmask,
         )
         # UDP.
         # ----

--- a/liteeth/core/ip.py
+++ b/liteeth/core/ip.py
@@ -94,7 +94,16 @@ class LiteEthIPV4Packetizer(Packetizer):
 
 
 class LiteEthIPTX(LiteXModule):
-    def __init__(self, mac_address, ip_address, arp_table, dw=8, with_buffer=True):
+    def __init__(self, mac_address, ip_address, arp_table, dw=8, with_buffer=True,
+        gateway_ip = None,
+        netmask    = None,
+    ):
+        ip_address = convert_ip(ip_address)
+        assert (gateway_ip is None) == (netmask is None)
+        if gateway_ip is not None:
+            gateway_ip = convert_ip(gateway_ip)
+            netmask    = convert_ip(netmask)
+
         self.sink   = sink   = stream.Endpoint(eth_ipv4_user_description(dw))
         self.source = source = stream.Endpoint(eth_mac_description(dw))
         self.target_unreachable = Signal()
@@ -154,7 +163,14 @@ class LiteEthIPTX(LiteXModule):
                 )
             )
         )
-        self.comb += arp_table.request.ip_address.eq(sink.ip_address)
+        if gateway_ip is not None:
+            self.comb += If((sink.ip_address & netmask) == (ip_address & netmask),
+                arp_table.request.ip_address.eq(sink.ip_address)
+            ).Else(
+                arp_table.request.ip_address.eq(gateway_ip)
+            )
+        else:
+            self.comb += arp_table.request.ip_address.eq(sink.ip_address)
         fsm.act("SEND_MAC_ADDRESS_REQUEST",
             arp_table.request.valid.eq(1),
             If(arp_table.request.valid & arp_table.request.ready,
@@ -264,8 +280,18 @@ class LiteEthIPRX(LiteXModule):
 # IP -----------------------------------------------------------------------------------------------
 
 class LiteEthIP(LiteXModule):
-    def __init__(self, mac, mac_address, ip_address, arp_table, with_broadcast=True, dw=8):
-        self.tx = tx = LiteEthIPTX(mac_address, ip_address, arp_table, dw=dw)
+    def __init__(self, mac, mac_address, ip_address, arp_table, with_broadcast=True, dw=8,
+        gateway_ip = None,
+        netmask    = None,
+    ):
+        self.tx = tx = LiteEthIPTX(
+            mac_address = mac_address,
+            ip_address  = ip_address,
+            arp_table   = arp_table,
+            dw          = dw,
+            gateway_ip  = gateway_ip,
+            netmask     = netmask,
+        )
         self.rx = rx = LiteEthIPRX(mac_address, ip_address, with_broadcast, dw=dw)
         mac_port = mac.crossbar.get_port(ethernet_type_ip, dw)
         self.comb += [

--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -603,6 +603,8 @@ class UDPCore(PHYCore):
             ip_address        = ip_address,
             clk_freq          = core_config["clk_freq"],
             dw                = data_width,
+            gateway_ip        = core_config.get("gateway_ip", None),
+            netmask           = core_config.get("netmask", None),
             with_sys_datapath = data_width in [16, 32],
             tx_cdc_depth      = tx_cdc_depth,
             tx_cdc_buffered   = tx_cdc_buffered,

--- a/test/test_ip_gateway.py
+++ b/test/test_ip_gateway.py
@@ -1,0 +1,81 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from litex.gen import *
+from litex.gen.sim import *
+from litex.soc.interconnect import stream
+
+from liteeth.common import *
+from liteeth.core.ip import LiteEthIPTX
+
+# DUT ----------------------------------------------------------------------------------------------
+
+class ARPTable:
+    def __init__(self):
+        self.request  = stream.Endpoint(arp_table_request_layout)
+        self.response = stream.Endpoint(arp_table_response_layout)
+
+class DUT(LiteXModule):
+    def __init__(self, gateway_ip=None, netmask=None):
+        self.arp_table = ARPTable()
+        self.tx        = LiteEthIPTX(
+            mac_address = 0x10e2d5000000,
+            ip_address  = convert_ip("192.168.1.50"),
+            arp_table   = self.arp_table,
+            dw          = 8,
+            gateway_ip  = gateway_ip,
+            netmask     = netmask,
+        )
+
+# Test IP Gateway ----------------------------------------------------------------------------------
+
+class TestIPGateway(unittest.TestCase):
+    def check_arp_request_ip(self, dut, destination_ip, expected_arp_ip):
+        destination_ip  = convert_ip(destination_ip)
+        expected_arp_ip = convert_ip(expected_arp_ip)
+
+        def generator():
+            yield dut.tx.sink.valid.eq(1)
+            yield dut.tx.sink.last.eq(1)
+            yield dut.tx.sink.last_be.eq(1)
+            yield dut.tx.sink.length.eq(1)
+            yield dut.tx.sink.protocol.eq(udp_protocol)
+            yield dut.tx.sink.ip_address.eq(destination_ip)
+
+            for _ in range(64):
+                if (yield dut.arp_table.request.valid):
+                    self.assertEqual((yield dut.arp_table.request.ip_address), expected_arp_ip)
+                    return
+                yield
+            raise TimeoutError
+
+        run_simulation(dut, generator())
+
+    def test_default_arp_request_uses_destination_ip(self):
+        dut = DUT()
+        self.check_arp_request_ip(
+            dut             = dut,
+            destination_ip  = "10.0.0.1",
+            expected_arp_ip = "10.0.0.1",
+        )
+
+    def test_gateway_arp_request_uses_destination_ip_on_subnet(self):
+        dut = DUT(gateway_ip="192.168.1.1", netmask="255.255.255.0")
+        self.check_arp_request_ip(
+            dut             = dut,
+            destination_ip  = "192.168.1.100",
+            expected_arp_ip = "192.168.1.100",
+        )
+
+    def test_gateway_arp_request_uses_gateway_ip_off_subnet(self):
+        dut = DUT(gateway_ip="192.168.1.1", netmask="255.255.255.0")
+        self.check_arp_request_ip(
+            dut             = dut,
+            destination_ip  = "10.0.0.1",
+            expected_arp_ip = "192.168.1.1",
+        )


### PR DESCRIPTION
Refreshes the still-relevant gateway-routing idea from Rowan Goemans / rowanG077 in PR #139 on current master.

LiteEth IP TX currently ARPs for the destination IP for all unicast packets. That only works for same-subnet traffic. This adds optional `gateway_ip`/`netmask` support:
- destinations inside `ip_address & netmask` still ARP for the destination IP;
- destinations outside the subnet ARP for `gateway_ip`;
- the IPv4 destination address is unchanged.

The default behavior is unchanged when `gateway_ip`/`netmask` are not set.

This is exposed through:
- `LiteEthIPTX`;
- `LiteEthIP`;
- `LiteEthIPCore` / `LiteEthUDPIPCore`;
- `liteeth_gen` YAML (`gateway_ip`, `netmask`).

Adds focused tests for ARP target selection.

Verification:
- `python3 -m unittest test.test_ip_gateway`
- `python3 -m unittest test.test_ip`
- `python3 -m unittest test.test_udp`
- `python3 -m unittest test.test_gen`
- `python3 liteeth/gen.py /tmp/udp_s7phyrgmii_gateway.yml --output-dir /tmp/liteeth-pr139-gateway --no-compile-gateware`

Credit: based on ideas from https://github.com/enjoy-digital/liteeth/pull/139 by Rowan Goemans / @rowanG077.