### PR TITLE
frontend: make Stream2UDP TX packet-aware

### DIFF
--- a/liteeth/frontend/stream.py
+++ b/liteeth/frontend/stream.py
@@ -5,6 +5,7 @@
 # SPDX-License-Identifier: BSD-2-Clause
 
 from litex.gen import *
+from litex.soc.interconnect.packet import PacketFIFO
 
 from liteeth.common import *
 
@@ -34,42 +35,45 @@ class LiteEthStream2UDPTX(LiteXModule):
                 source.length.eq(data_width // 8)
             ]
         else:
-            level   = Signal(max=fifo_depth+1)
             counter = Signal(max=fifo_depth+1)
 
             _ip_address = Signal(32)
             _udp_port   = Signal(16)
 
-            self.fifo = fifo = stream.SyncFIFO([("data", data_width)], fifo_depth, buffered=True)
-            self.comb += sink.connect(fifo.sink)
+            packet_last   = Signal()
+            packet_full   = Signal()
+            packet_length = Signal(16)
+            source_active = Signal()
 
-            self.fsm = fsm = ResetInserter()(FSM(reset_state="IDLE"))
-            self.comb += fsm.reset.eq(~self.enable & ~source.valid)
-
-            fsm.act("IDLE",
-                NextValue(counter, 0),
-                NextValue(_ip_address, self.ip_address),
-                NextValue(_udp_port, self.udp_port),
-                # Send FIFO contents when:
-                # - We have a full packet:
-                If(fifo.sink.valid & fifo.sink.ready & fifo.sink.last,
-                    NextValue(level, fifo.level + 1), # +1 for level latency.
-                    NextState("SEND")
+            self.fifo = fifo = PacketFIFO(
+                layout         = stream.EndpointDescription(
+                    payload_layout = [("data", data_width)],
+                    param_layout   = [("length", 16)],
                 ),
-                # - Or when FIFO is full.
-                If(~fifo.sink.ready,
-                    NextValue(level, fifo_depth),
-                    NextState("SEND")
-                ),
+                payload_depth = fifo_depth,
+                param_depth   = fifo_depth,
+                buffered      = True,
             )
-            fsm.act("SEND",
-                source.valid.eq(1),
-                source.last.eq(counter == (level - 1)),
-                source.src_port.eq(_udp_port),
-                source.dst_port.eq(_udp_port),
-                source.ip_address.eq(_ip_address),
-                source.length.eq(level * (data_width//8)),
+
+            if fifo_depth > 0:
+                self.comb += packet_full.eq(counter == (fifo_depth - 1))
+
+            self.comb += [
+                packet_last.eq(sink.last | packet_full),
+                packet_length.eq((counter + 1) * (data_width//8)),
+
+                # Input.
+                sink.ready.eq(fifo.sink.ready),
+                fifo.sink.valid.eq(sink.valid),
+                fifo.sink.last.eq(packet_last),
+                fifo.sink.data.eq(sink.data),
+                fifo.sink.length.eq(packet_length),
+
+                # Output.
+                source.valid.eq(fifo.source.valid & (self.enable | source_active)),
+                fifo.source.ready.eq(source.ready & (self.enable | source_active)),
                 source.data.eq(fifo.source.data),
+                source.last.eq(fifo.source.last),
                 If(source.last,
                     source.last_be.eq({
                         64 : 0b10000000,
@@ -77,14 +81,29 @@ class LiteEthStream2UDPTX(LiteXModule):
                         16 : 0b10,
                         8  : 0b1
                     }[data_width])),
-                If(source.ready,
-                    fifo.source.ready.eq(1),
-                    NextValue(counter, counter + 1),
-                    If(source.last,
-                        NextState("IDLE")
+                source.src_port.eq(Mux(source_active, _udp_port, self.udp_port)),
+                source.dst_port.eq(Mux(source_active, _udp_port, self.udp_port)),
+                source.ip_address.eq(Mux(source_active, _ip_address, self.ip_address)),
+                source.length.eq(fifo.source.length),
+            ]
+
+            self.sync += [
+                If(sink.valid & sink.ready,
+                    If(packet_last,
+                        counter.eq(0)
+                    ).Else(
+                        counter.eq(counter + 1)
                     )
+                ),
+                If(fifo.source.valid & self.enable & ~source_active,
+                    source_active.eq(1),
+                    _ip_address.eq(self.ip_address),
+                    _udp_port.eq(self.udp_port),
+                ),
+                If(source.valid & source.ready & source.last,
+                    source_active.eq(0)
                 )
-            )
+            ]
 
     def add_csr(self):
         self._enable     = CSRStorage(1, description="Enable Module", reset=1)

--- a/test/test_stream.py
+++ b/test/test_stream.py
@@ -376,7 +376,98 @@ class TestStream(unittest.TestCase):
 
 
 class TestStream2UDPTX(unittest.TestCase):
-    """Tests for LiteEthStream2UDPTX with FIFO (disable-mid-packet safety)."""
+    """Tests for LiteEthStream2UDPTX with FIFO."""
+
+    def _send_words(self, dut, words):
+        for data, last in words:
+            yield dut.sink.data.eq(data)
+            yield dut.sink.valid.eq(1)
+            yield dut.sink.last.eq(last)
+            yield
+            while not (yield dut.sink.ready):
+                yield
+        yield dut.sink.valid.eq(0)
+        yield dut.sink.last.eq(0)
+
+    def test_back_to_back_multibeat_packets(self):
+        data_width = 32
+        dut = LiteEthStream2UDPTX(
+            ip_address = 0xC0A80132,
+            udp_port   = 2342,
+            data_width = data_width,
+            fifo_depth = 8,
+        )
+
+        packets = [
+            [0xA000, 0xA001],
+            [0xB000, 0xB001],
+            [0xC000, 0xC001],
+        ]
+        results = []
+
+        def producer():
+            words = []
+            for packet in packets:
+                for n, word in enumerate(packet):
+                    words.append((word, n == (len(packet) - 1)))
+            yield from self._send_words(dut, words)
+            for _ in range(64):
+                yield
+
+        def consumer():
+            current = []
+            yield dut.source.ready.eq(1)
+            for _ in range(128):
+                if (yield dut.source.valid):
+                    current.append((yield dut.source.data))
+                    expected_length = len(packets[len(results)]) * (data_width//8)
+                    self.assertEqual((yield dut.source.length), expected_length)
+                    if (yield dut.source.last):
+                        self.assertEqual((yield dut.source.last_be), 0b1000)
+                        results.append(current)
+                        current = []
+                    else:
+                        self.assertEqual((yield dut.source.last_be), 0)
+                yield
+
+        run_simulation(dut, [producer(), consumer()])
+        self.assertEqual(results, packets)
+
+    def test_full_fifo_without_last_emits_packet(self):
+        data_width = 32
+        fifo_depth = 4
+        dut = LiteEthStream2UDPTX(
+            ip_address = 0xC0A80132,
+            udp_port   = 2342,
+            data_width = data_width,
+            fifo_depth = fifo_depth,
+        )
+
+        words   = [(0xD000 + n, 0) for n in range(fifo_depth)]
+        results = []
+
+        def producer():
+            yield from self._send_words(dut, words)
+            for _ in range(64):
+                yield
+
+        def consumer():
+            yield dut.source.ready.eq(1)
+            for _ in range(128):
+                if (yield dut.source.valid):
+                    results.append((
+                        (yield dut.source.data),
+                        (yield dut.source.last),
+                        (yield dut.source.length),
+                    ))
+                    if (yield dut.source.last):
+                        break
+                yield
+
+        run_simulation(dut, [producer(), consumer()])
+        self.assertEqual([r[0] for r in results], [w[0] for w in words])
+        self.assertEqual([r[1] for r in results], [0, 0, 0, 1])
+        self.assertEqual(results[-1][2], fifo_depth * (data_width//8))
 
     def _run_disable_mid_packet(self, disable_at_word):
         """Disable the TX module mid-packet and verify the packet completes


### PR DESCRIPTION
Refreshes the still-relevant packet-boundary bug report from Christoph Mayer / @hcab14 in PR #121 on current master.

`LiteEthStream2UDPTX` FIFO mode currently starts transmission only when it sees `sink.last` from `IDLE`, then emits a fixed captured FIFO level. That loses queued packet boundaries when another complete multi-word packet is accepted while the first packet is already being transmitted.

This replaces the TX payload FIFO/FSM path with a packet-aware `PacketFIFO`:
- full stream packets can queue behind an active packet;
- payload data and per-packet `length` are stored in the FIFO;
- IP address and UDP port are latched when a queued packet becomes active on TX, avoiding a wider metadata FIFO;
- streams without `sink.last` still emit a packet when they reach `fifo_depth`;
- disabling the module still lets the currently-visible output packet finish before stopping between packets.

Latency/resource notes:
- the packet still cannot be emitted until `sink.last` or `fifo_depth`, since UDP needs the packet length before payload transmission;
- measured local sim latency from final input beat acceptance to first output beat is 2 clock cycles;
- sustained output remains one word per cycle once started;
- compared with the old single payload FIFO, the payload storage width stays `data_width + first/last`, and the added storage is a small length FIFO of about 18 bits per queued packet entry (`length` plus stream bookkeeping), not a second payload FIFO.

The no-FIFO path and RX path are left unchanged.

Verification:
- `python3 -m unittest test.test_stream.TestStream2UDPTX`
- `python3 -m unittest test.test_stream`
- `python3 -m unittest test.test_gen`
- `python3 -m unittest test.test_udp`
- `git diff --check`

Credit: based on the bug report and ideas from https://github.com/enjoy-digital/liteeth/pull/121 by Christoph Mayer / @hcab14. The PR discussion also pointed toward using packet-aware buffering (`PacketFIFO`) rather than adding a second payload FIFO.