### PR TITLE
phy: add opt-in ECP5 RGMII dynamic speed support

### DIFF
--- a/examples/udp_raw_ecp5rgmii.yml
+++ b/examples/udp_raw_ecp5rgmii.yml
@@ -8,6 +8,7 @@
 phy          : LiteEthECP5PHYRGMII
 phy_tx_delay : 0e-9
 phy_rx_delay : 2e-9
+# phy_dynamic_link : True # Enable experimental 10/100/1000 RGMII rate adaptation.
 # phy_hw_init_reset : True # Enable startup PHY reset pulse when required by the board PHY.
 device       : LFE5U-25F-6BG256C
 vendor       : lattice

--- a/liteeth/gen.py
+++ b/liteeth/gen.py
@@ -285,12 +285,18 @@ class PHYCore(SoCMini):
             liteeth_phys.LiteEthS7PHYRGMII,
             liteeth_phys.LiteEthECP5PHYRGMII,
         ]:
-            ethphy = phy(
+            phy_kwargs = dict(
                 clock_pads         = platform.request("rgmii_clocks"),
                 pads               = platform.request("rgmii"),
                 tx_delay           = core_config.get("phy_tx_delay", 2e-9),
                 rx_delay           = core_config.get("phy_rx_delay", 2e-9),
-                with_hw_init_reset = core_config.get("phy_hw_init_reset", False))
+                with_hw_init_reset = core_config.get("phy_hw_init_reset", False),
+            )
+            if phy in [liteeth_phys.LiteEthECP5PHYRGMII]:
+                phy_kwargs.update(
+                    with_dynamic_link = core_config.get("phy_dynamic_link", False),
+                )
+            ethphy = phy(**phy_kwargs)
         # SGMII.
         elif phy in [
             # 7-Series GTP/GTX.

--- a/liteeth/mac/core.py
+++ b/liteeth/mac/core.py
@@ -143,7 +143,7 @@ class LiteEthMACCore(LiteXModule):
 
             def add_gap(self):
                 """Add inter-frame gap insertion in the PHY TX domain."""
-                tx_gap = gap.LiteEthMACGap(phy_dw)
+                tx_gap = gap.LiteEthMACGap(phy_dw, cycles=getattr(phy, "tx_gap_cycles", None))
                 tx_gap = ClockDomainsRenamer("eth_tx")(tx_gap)
                 self.submodules += tx_gap
                 self.pipeline.append(tx_gap)

--- a/liteeth/mac/gap.py
+++ b/liteeth/mac/gap.py
@@ -13,26 +13,28 @@ from liteeth.common import *
 # MAC Gap ------------------------------------------------------------------------------------------
 
 class LiteEthMACGap(Module):
-    def __init__(self, dw):
+    def __init__(self, dw, cycles=None):
         self.sink   = sink   = stream.Endpoint(eth_phy_description(dw))
         self.source = source = stream.Endpoint(eth_phy_description(dw))
 
         # # #
 
-        gap     = math.ceil(eth_interpacket_gap/(dw//8))
-        counter = Signal(max=gap, reset_less=True)
+        if cycles is None:
+            cycles = math.ceil(eth_interpacket_gap/(dw//8))
+        counter = Signal(max=2**len(cycles), reset_less=True) if isinstance(cycles, Signal) else \
+                  Signal(max=cycles + 1, reset_less=True)
 
         self.submodules.fsm = fsm = FSM(reset_state="COPY")
         fsm.act("COPY",
-            NextValue(counter, 0),
             sink.connect(source),
             If(sink.valid & sink.last & sink.ready,
+                NextValue(counter, cycles),
                 NextState("GAP")
             )
         )
         fsm.act("GAP",
-            NextValue(counter, counter + 1),
-            If(counter == (gap-1),
+            NextValue(counter, counter - 1),
+            If(counter == 1,
                 NextState("COPY")
             )
         )

--- a/liteeth/phy/ecp5rgmii.py
+++ b/liteeth/phy/ecp5rgmii.py
@@ -8,6 +8,7 @@
 # RGMII PHY for ECP5 Lattice FPGA
 
 from migen import *
+from migen.genlib.cdc import MultiReg
 from migen.genlib.resetsync import AsyncResetSynchronizer
 
 from litex.gen import *
@@ -17,22 +18,167 @@ from litex.build.io import DDROutput, DDRInput
 from liteeth.common import *
 from liteeth.phy.common import *
 
+# LiteEth PHY RGMII Link State ---------------------------------------------------------------------
+
+class LiteEthRGMIILinkState:
+    def __init__(self):
+        self.link_up   = Signal(reset_less=True)
+        self.link_10M  = Signal(reset_less=True)
+        self.link_100M = Signal(reset_less=True)
+        self.link_1G   = Signal(reset=1)
+
+    def synchronize(self, to, cd):
+        return [
+            MultiReg(self.link_up,   to.link_up,   cd),
+            MultiReg(self.link_10M,  to.link_10M,  cd),
+            MultiReg(self.link_100M, to.link_100M, cd),
+            MultiReg(self.link_1G,   to.link_1G,   cd),
+        ]
+
+# LiteEth PHY RGMII TX Clock -----------------------------------------------------------------------
+
+class LiteEthRGMIITXClock(LiteXModule):
+    def __init__(self, link_state=None, external_tx_clk=False):
+        self.rising     = Signal(reset=1)
+        self.falling    = Signal()
+        self.tx_enable  = Signal(reset=1)
+        self.gap_cycles = Signal(max=eth_interpacket_gap*100 + 1, reset=eth_interpacket_gap)
+
+        # # #
+
+        if link_state is None:
+            self.comb += [
+                self.rising.eq(1),
+                self.falling.eq(0),
+                self.tx_enable.eq(1),
+                self.gap_cycles.eq(eth_interpacket_gap),
+            ]
+        elif external_tx_clk:
+            counter        = Signal(max=50)
+            counter_switch = Signal(max=25)
+
+            self.comb += [
+                If(link_state.link_1G,
+                    self.rising.eq(1),
+                    self.falling.eq(0),
+                    self.gap_cycles.eq(eth_interpacket_gap),
+                ).Else(
+                    self.rising.eq(counter >= counter_switch),
+                    self.falling.eq(counter > counter_switch),
+                    If(link_state.link_100M,
+                        self.gap_cycles.eq(eth_interpacket_gap*10),
+                    ).Else(
+                        self.gap_cycles.eq(eth_interpacket_gap*100),
+                    )
+                )
+            ]
+            self.sync.eth_tx += [
+                self.tx_enable.eq(counter == 0),
+                If(counter == 0,
+                    If(link_state.link_10M,
+                        counter.eq(49),
+                        counter_switch.eq(24),
+                    ).Elif(link_state.link_100M,
+                        counter.eq(4),
+                        counter_switch.eq(2),
+                    ).Else(
+                        counter.eq(0),
+                        counter_switch.eq(0),
+                    )
+                ).Else(
+                    counter.eq(counter - 1),
+                )
+            ]
+        else:
+            self.comb += [
+                self.rising.eq(1),
+                self.falling.eq(0),
+                self.tx_enable.eq(1),
+                If(link_state.link_1G,
+                    self.gap_cycles.eq(eth_interpacket_gap),
+                ).Else(
+                    self.gap_cycles.eq(eth_interpacket_gap*2),
+                )
+            ]
+
+# LiteEth PHY RGMII TX Datapath --------------------------------------------------------------------
+
+class LiteEthRGMIITXDatapath(LiteXModule):
+    def __init__(self, link_state=None, tx_enable=1):
+        self.sink    = sink = stream.Endpoint(eth_phy_description(8))
+        self.tx_ctl  = Signal(2)
+        self.tx_data = Signal(8)
+
+        # # #
+
+        if link_state is None:
+            self.comb += [
+                sink.ready.eq(1),
+                self.tx_ctl.eq(Cat(sink.valid, sink.valid)),
+                self.tx_data.eq(sink.data),
+            ]
+        else:
+            sdr_phase = Signal()
+            sdr_data  = Signal(8)
+            sdr_valid = Signal()
+
+            self.comb += sink.ready.eq(link_state.link_1G | (tx_enable & ~sdr_phase))
+            self.sync += [
+                If(link_state.link_1G,
+                    sdr_phase.eq(0),
+                    sdr_valid.eq(0),
+                    self.tx_ctl.eq(Cat(sink.valid, sink.valid)),
+                    self.tx_data.eq(sink.data),
+                ).Elif(tx_enable,
+                    If(sdr_phase,
+                        self.tx_ctl.eq(Cat(sdr_valid, sdr_valid)),
+                        self.tx_data.eq(Cat(sdr_data[4:8], sdr_data[4:8])),
+                        sdr_phase.eq(0),
+                        sdr_valid.eq(0),
+                    ).Else(
+                        self.tx_ctl.eq(Cat(sink.valid, sink.valid)),
+                        self.tx_data.eq(Cat(sink.data[0:4], sink.data[0:4])),
+                        If(sink.valid,
+                            sdr_data.eq(sink.data),
+                            sdr_valid.eq(1),
+                            sdr_phase.eq(1),
+                        )
+                    )
+                )
+            ]
+
 # LiteEth PHY RGMII TX -----------------------------------------------------------------------------
 
 class LiteEthPHYRGMIITX(LiteXModule):
-    def __init__(self, pads):
+    def __init__(self, pads, link_state=None, tx_enable=1):
         self.sink = sink = stream.Endpoint(eth_phy_description(8))
 
         # # #
 
         tx_ctl_oddrx1f  = Signal()
         tx_data_oddrx1f = Signal(4)
+        tx_ctl          = Signal(2)
+        tx_data         = Signal(8)
+
+        if link_state is None:
+            self.comb += [
+                sink.ready.eq(1),
+                tx_ctl.eq(Cat(sink.valid, sink.valid)),
+                tx_data.eq(sink.data),
+            ]
+        else:
+            self.datapath = datapath = LiteEthRGMIITXDatapath(link_state, tx_enable)
+            self.comb += [
+                sink.connect(datapath.sink),
+                tx_ctl.eq(datapath.tx_ctl),
+                tx_data.eq(datapath.tx_data),
+            ]
 
         self.specials += [
             DDROutput(
                 clk = ClockSignal("eth_tx"),
-                i1  = sink.valid,
-                i2  = sink.valid,
+                i1  = tx_ctl[0],
+                i2  = tx_ctl[1],
                 o   = tx_ctl_oddrx1f,
             ),
             Instance("DELAYG",
@@ -46,8 +192,8 @@ class LiteEthPHYRGMIITX(LiteXModule):
             self.specials += [
                 DDROutput(
                     clk = ClockSignal("eth_tx"),
-                    i1  = sink.data[i],
-                    i2  = sink.data[4+i],
+                    i1  = tx_data[i],
+                    i2  = tx_data[4+i],
                     o   = tx_data_oddrx1f[i],
                 ),
                 Instance("DELAYG",
@@ -57,12 +203,65 @@ class LiteEthPHYRGMIITX(LiteXModule):
                     o_Z         = pads.tx_data[i],
                 )
             ]
-        self.comb += sink.ready.eq(1)
+
+# LiteEth PHY RGMII RX Datapath --------------------------------------------------------------------
+
+class LiteEthRGMIIRXDatapath(LiteXModule):
+    def __init__(self, link_state=None):
+        self.rx_ctl  = rx_ctl  = Signal(2)
+        self.rx_data = rx_data = Signal(8)
+        self.source  = source  = stream.Endpoint(eth_phy_description(8))
+
+        # # #
+
+        if link_state is None:
+            rx_ctl_reg   = Signal(2)
+            rx_ctl_reg_d = Signal(2)
+            rx_data_reg  = Signal(8)
+
+            self.sync += [
+                rx_ctl_reg.eq(rx_ctl),
+                rx_ctl_reg_d.eq(rx_ctl_reg),
+                rx_data_reg.eq(rx_data),
+                source.valid.eq(rx_ctl_reg[0]),
+                source.data.eq(rx_data_reg),
+            ]
+            self.comb += source.last.eq(~rx_ctl_reg[0] & rx_ctl_reg_d[0])
+        else:
+            sdr_phase     = Signal()
+            sdr_low       = Signal(4)
+            rx_ctl_rising = Signal()
+            rx_ctl_d      = Signal()
+
+            self.comb += rx_ctl_rising.eq(rx_ctl[0])
+            self.sync += [
+                rx_ctl_d.eq(rx_ctl_rising),
+                source.valid.eq(0),
+                If(link_state.link_1G,
+                    sdr_phase.eq(0),
+                    source.valid.eq(rx_ctl_rising),
+                    source.data.eq(rx_data),
+                ).Else(
+                    If(rx_ctl_rising,
+                        If(sdr_phase,
+                            source.valid.eq(1),
+                            source.data.eq(Cat(sdr_low, rx_data[0:4])),
+                            sdr_phase.eq(0),
+                        ).Else(
+                            sdr_low.eq(rx_data[0:4]),
+                            sdr_phase.eq(1),
+                        )
+                    ).Else(
+                        sdr_phase.eq(0),
+                    )
+                )
+            ]
+            self.comb += source.last.eq(~rx_ctl_rising & rx_ctl_d)
 
 # LiteEth PHY RGMII RX -----------------------------------------------------------------------------
 
 class LiteEthPHYRGMIIRX(LiteXModule):
-    def __init__(self, pads, rx_delay=2e-9, with_inband_status=True):
+    def __init__(self, pads, rx_delay=2e-9, with_inband_status=True, link_state=None):
         self.source = source = stream.Endpoint(eth_phy_description(8))
 
         if with_inband_status:
@@ -89,10 +288,8 @@ class LiteEthPHYRGMIIRX(LiteXModule):
 
         rx_ctl_delayf  = Signal()
         rx_ctl         = Signal(2)
-        rx_ctl_reg     = Signal(2)
         rx_data_delayf = Signal(4)
         rx_data        = Signal(8)
-        rx_data_reg    = Signal(8)
 
         self.specials += [
             Instance("DELAYG",
@@ -108,7 +305,6 @@ class LiteEthPHYRGMIIRX(LiteXModule):
                 o2  = rx_ctl[1],
             )
         ]
-        self.sync += rx_ctl_reg.eq(rx_ctl)
         for i in range(4):
             self.specials += [
                 Instance("DELAYG",
@@ -123,33 +319,42 @@ class LiteEthPHYRGMIIRX(LiteXModule):
                     o2  = rx_data[i+4],
                 )
             ]
-        self.sync += rx_data_reg.eq(rx_data)
 
-        rx_ctl_reg_d = Signal(2)
-        self.sync += rx_ctl_reg_d.eq(rx_ctl_reg)
-
-        last = Signal()
-        self.comb += last.eq(~rx_ctl_reg[0] & rx_ctl_reg_d[0])
-        self.sync += [
-            source.valid.eq(rx_ctl_reg[0]),
-            source.data.eq(rx_data_reg)
+        self.datapath = datapath = LiteEthRGMIIRXDatapath(link_state)
+        self.comb += [
+            datapath.rx_ctl.eq(rx_ctl),
+            datapath.rx_data.eq(rx_data),
         ]
-        self.comb += source.last.eq(last)
+        self.comb += datapath.source.connect(source)
 
         if with_inband_status:
+            inband_status = [
+                self.inband_status.fields.link_status.eq(  rx_data[0]),
+                self.inband_status.fields.clock_speed.eq(  rx_data[1:3]),
+                self.inband_status.fields.duplex_status.eq(rx_data[3]),
+            ]
+            if link_state is not None:
+                inband_status += [
+                    link_state.link_up.eq(rx_data[0]),
+                    link_state.link_10M.eq(rx_data[1:3] == 0b00),
+                    link_state.link_100M.eq(rx_data[1:3] == 0b01),
+                    link_state.link_1G.eq(rx_data[1:3] == 0b10),
+                ]
             self.sync += [
                 If(rx_ctl == 0b00,
-                    self.inband_status.fields.link_status.eq(  rx_data[0]),
-                    self.inband_status.fields.clock_speed.eq(  rx_data[1:3]),
-                    self.inband_status.fields.duplex_status.eq(rx_data[3]),
+                    *inband_status
                 )
             ]
 
 # LiteEth PHY RGMII CRG ----------------------------------------------------------------------------
 
 class LiteEthPHYRGMIICRG(LiteXModule):
-    def __init__(self, clock_pads, pads, with_hw_init_reset, tx_delay=2e-9, tx_clk=None):
+    def __init__(self, clock_pads, pads, with_hw_init_reset, tx_delay=2e-9, tx_clk=None,
+        link_state = None,
+    ):
         self._reset = CSRStorage(description="PHY reset.")
+        self.tx_enable     = Signal(reset=1)
+        self.tx_gap_cycles = Signal(max=eth_interpacket_gap*100 + 1, reset=eth_interpacket_gap)
 
         # # #
 
@@ -167,12 +372,21 @@ class LiteEthPHYRGMIICRG(LiteXModule):
         tx_delay_taps = int(tx_delay/25e-12) # 25ps per tap
         assert tx_delay_taps < 128
 
+        self.tx_clock = tx_clock = LiteEthRGMIITXClock(
+            link_state      = link_state,
+            external_tx_clk = isinstance(tx_clk, Signal),
+        )
+        self.comb += [
+            self.tx_enable.eq(tx_clock.tx_enable),
+            self.tx_gap_cycles.eq(tx_clock.gap_cycles),
+        ]
+
         eth_tx_clk_o = Signal()
         self.specials += [
             DDROutput(
                 clk = ClockSignal("eth_tx"),
-                i1  = 1,
-                i2  = 0,
+                i1  = tx_clock.rising,
+                i2  = tx_clock.falling,
                 o   = eth_tx_clk_o,
             ),
             Instance("DELAYG",
@@ -207,11 +421,39 @@ class LiteEthPHYRGMII(LiteXModule):
         rx_delay           = 2e-9,
         with_inband_status = True,
         tx_clk             = None,
+        with_dynamic_link  = False,
         ):
-        self.crg = LiteEthPHYRGMIICRG(clock_pads, pads, with_hw_init_reset, tx_delay, tx_clk)
-        self.tx  = ClockDomainsRenamer("eth_tx")(LiteEthPHYRGMIITX(pads))
-        self.rx  = ClockDomainsRenamer("eth_rx")(LiteEthPHYRGMIIRX(pads, rx_delay, with_inband_status))
+        assert not (with_dynamic_link and not with_inband_status)
+
+        link_state_rx = None
+        link_state_tx = None
+        if with_dynamic_link:
+            self.link_state_rx = link_state_rx = LiteEthRGMIILinkState()
+            self.link_state_tx = link_state_tx = LiteEthRGMIILinkState()
+            self.specials += link_state_rx.synchronize(link_state_tx, "eth_tx")
+
+        self.crg = LiteEthPHYRGMIICRG(
+            clock_pads,
+            pads,
+            with_hw_init_reset,
+            tx_delay,
+            tx_clk,
+            link_state = link_state_tx,
+        )
+        self.tx  = ClockDomainsRenamer("eth_tx")(LiteEthPHYRGMIITX(
+            pads,
+            link_state = link_state_tx,
+            tx_enable  = self.crg.tx_enable,
+        ))
+        self.rx  = ClockDomainsRenamer("eth_rx")(LiteEthPHYRGMIIRX(
+            pads,
+            rx_delay,
+            with_inband_status,
+            link_state = link_state_rx,
+        ))
         self.sink, self.source = self.tx.sink, self.rx.source
+        if with_dynamic_link:
+            self.tx_gap_cycles = self.crg.tx_gap_cycles
 
         if hasattr(pads, "mdc"):
             self.mdio = LiteEthPHYMDIO(pads)

--- a/test/test_ecp5rgmii.py
+++ b/test/test_ecp5rgmii.py
@@ -1,0 +1,162 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from litex.gen.sim import *
+
+from liteeth.phy.ecp5rgmii import (
+    LiteEthRGMIILinkState,
+    LiteEthRGMIIRXDatapath,
+    LiteEthRGMIITXClock,
+    LiteEthRGMIITXDatapath,
+)
+
+
+class TestECP5RGMIIDynamicSpeed(unittest.TestCase):
+    def test_tx_clock_adapts_enable_and_gap_cycles(self):
+        link_state = LiteEthRGMIILinkState()
+        dut        = LiteEthRGMIITXClock(link_state=link_state, external_tx_clk=True)
+
+        enable_100m = []
+        enable_10m  = []
+
+        def eth_tx_generator():
+            yield link_state.link_1G.eq(0)
+            yield link_state.link_100M.eq(1)
+            yield
+            self.assertEqual((yield dut.gap_cycles), 120)
+            for _ in range(25):
+                enable_100m.append((yield dut.tx_enable))
+                yield
+
+            yield link_state.link_100M.eq(0)
+            yield link_state.link_10M.eq(1)
+            yield
+            self.assertEqual((yield dut.gap_cycles), 1200)
+            for _ in range(60):
+                enable_10m.append((yield dut.tx_enable))
+                yield
+
+        run_simulation(dut, {"eth_tx": [eth_tx_generator()]}, clocks={"eth_tx": 10})
+
+        pulses_100m = [i for i, enable in enumerate(enable_100m) if enable]
+        pulses_10m  = [i for i, enable in enumerate(enable_10m)  if enable]
+        self.assertEqual([b - a for a, b in zip(pulses_100m[-4:], pulses_100m[-3:])], [5, 5, 5])
+        self.assertEqual([b - a for a, b in zip(pulses_10m[-2:],  pulses_10m[-1:])],  [50])
+
+    def test_loop_clock_keeps_enable_and_uses_wide_gap(self):
+        link_state = LiteEthRGMIILinkState()
+        dut        = LiteEthRGMIITXClock(link_state=link_state, external_tx_clk=False)
+
+        def generator():
+            yield link_state.link_1G.eq(1)
+            yield
+            self.assertEqual((yield dut.tx_enable), 1)
+            self.assertEqual((yield dut.rising), 1)
+            self.assertEqual((yield dut.falling), 0)
+            self.assertEqual((yield dut.gap_cycles), 12)
+
+            yield link_state.link_1G.eq(0)
+            yield link_state.link_100M.eq(1)
+            yield
+            self.assertEqual((yield dut.tx_enable), 1)
+            self.assertEqual((yield dut.rising), 1)
+            self.assertEqual((yield dut.falling), 0)
+            self.assertEqual((yield dut.gap_cycles), 24)
+
+        run_simulation(dut, generator())
+
+    def test_tx_1g_uses_ddr_byte_each_cycle(self):
+        link_state = LiteEthRGMIILinkState()
+        dut        = LiteEthRGMIITXDatapath(link_state=link_state)
+
+        def generator():
+            yield link_state.link_1G.eq(1)
+            yield dut.sink.valid.eq(1)
+            yield dut.sink.data.eq(0x5a)
+            self.assertEqual((yield dut.sink.ready), 1)
+            yield
+            yield
+            self.assertEqual((yield dut.tx_ctl), 0b11)
+            self.assertEqual((yield dut.tx_data), 0x5a)
+
+        run_simulation(dut, generator())
+
+    def test_tx_100m_serializes_byte_over_two_clocks(self):
+        link_state = LiteEthRGMIILinkState()
+        dut        = LiteEthRGMIITXDatapath(link_state=link_state)
+
+        def generator():
+            yield link_state.link_1G.eq(0)
+            yield link_state.link_100M.eq(1)
+            yield
+
+            yield dut.sink.valid.eq(1)
+            yield dut.sink.data.eq(0xab)
+            self.assertEqual((yield dut.sink.ready), 1)
+            yield
+            yield dut.sink.valid.eq(0)
+            yield
+            self.assertEqual((yield dut.tx_ctl), 0b11)
+            self.assertEqual((yield dut.tx_data), 0xbb)
+            self.assertEqual((yield dut.sink.ready), 0)
+
+            yield
+            self.assertEqual((yield dut.tx_ctl), 0b11)
+            self.assertEqual((yield dut.tx_data), 0xaa)
+            self.assertEqual((yield dut.sink.ready), 1)
+
+        run_simulation(dut, generator())
+
+    def test_rx_1g_uses_ddr_byte_each_cycle(self):
+        link_state = LiteEthRGMIILinkState()
+        dut        = LiteEthRGMIIRXDatapath(link_state=link_state)
+
+        def generator():
+            yield link_state.link_1G.eq(1)
+            yield dut.rx_ctl.eq(0b11)
+            yield dut.rx_data.eq(0x5a)
+            yield
+            yield
+            self.assertEqual((yield dut.source.valid), 1)
+            self.assertEqual((yield dut.source.data), 0x5a)
+
+            yield dut.rx_ctl.eq(0b00)
+            yield
+            self.assertEqual((yield dut.source.last), 1)
+
+        run_simulation(dut, generator())
+
+    def test_rx_100m_reassembles_two_sdr_nibbles(self):
+        link_state = LiteEthRGMIILinkState()
+        dut        = LiteEthRGMIIRXDatapath(link_state=link_state)
+
+        def generator():
+            yield link_state.link_1G.eq(0)
+            yield link_state.link_100M.eq(1)
+            yield
+
+            yield dut.rx_ctl.eq(0b01)
+            yield dut.rx_data.eq(0x0b)
+            yield
+            self.assertEqual((yield dut.source.valid), 0)
+
+            yield dut.rx_data.eq(0x0a)
+            yield
+            self.assertEqual((yield dut.source.valid), 0)
+
+            yield dut.rx_ctl.eq(0b00)
+            yield
+            self.assertEqual((yield dut.source.valid), 1)
+            self.assertEqual((yield dut.source.data), 0xab)
+            self.assertEqual((yield dut.source.last), 1)
+
+        run_simulation(dut, generator())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/test_mac_gap.py
+++ b/test/test_mac_gap.py
@@ -1,0 +1,54 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from litex.gen import *
+from litex.gen.sim import *
+
+from liteeth.mac.gap import LiteEthMACGap
+
+
+class TestMACGap(unittest.TestCase):
+    def check_gap_cycles(self, cycles):
+        gap_cycles = Signal(max=32, reset=cycles)
+        dut        = LiteEthMACGap(dw=8, cycles=gap_cycles)
+        observed   = dict(low_cycles=0)
+
+        def generator():
+            yield dut.source.ready.eq(1)
+
+            # Send a single one-byte packet.
+            yield dut.sink.valid.eq(1)
+            yield dut.sink.last.eq(1)
+            yield dut.sink.last_be.eq(1)
+            while not (yield dut.sink.ready):
+                yield
+            yield
+
+            yield dut.sink.valid.eq(0)
+            yield dut.sink.last.eq(0)
+            yield dut.sink.last_be.eq(0)
+
+            # The sink must remain stalled for the configured gap cycles.
+            for _ in range(cycles):
+                self.assertEqual((yield dut.sink.ready), 0)
+                observed["low_cycles"] += 1
+                yield
+
+            self.assertEqual((yield dut.sink.ready), 1)
+
+        run_simulation(dut, generator())
+        self.assertEqual(observed["low_cycles"], cycles)
+
+    def test_dynamic_gap_cycles(self):
+        for cycles in [1, 3, 12, 24]:
+            with self.subTest(cycles=cycles):
+                self.check_gap_cycles(cycles)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Refreshes the still-relevant idea from Rowan Goemans' PR #138 on current master.

Current ECP5 RGMII is fixed around gigabit timing. This adds an explicit opt-in for 10/100/1000 rate adaptation:

- `with_dynamic_link` on `LiteEthPHYRGMII`
- `phy_dynamic_link` in `liteeth_gen` YAML for ECP5 RGMII only

Default behavior is unchanged unless the option is enabled.

When enabled:

- link speed is derived from RGMII in-band status and synchronized into `eth_tx`;
- TX serializes bytes as SDR nibbles with backpressure for 10/100M;
- RX reassembles rising-edge SDR nibbles for 10/100M;
- external 125MHz TX clock mode forwards divided 25MHz/2.5MHz clocks;
- loop-clock mode uses the PHY-provided RX/TX clock directly;
- MAC IFG can use PHY-provided gap cycles so the gap remains valid at slower byte times.

Testing:

- `python3 -m unittest test.test_ecp5rgmii`
- `python3 -m unittest test.test_mac_gap`
- `python3 -m unittest test.test_gen`
- `python3 liteeth/gen.py /tmp/udp_raw_ecp5rgmii_dynamic.yml --output-dir /tmp/liteeth-pr138-dynamic-rgmii --no-compile-gateware`
- `python3 -m py_compile liteeth/phy/ecp5rgmii.py liteeth/gen.py`
- `git diff --check`

Notes:

- This is a clean opt-in implementation, not a direct port of the draft.
- It is simulation/generator tested only here; hardware validation at 10/100M should still be done before merging as final support.
- The old PR reported 10M hardware issues, so this PR deliberately keeps the feature opt-in.

Credit: based on ideas from https://github.com/enjoy-digital/liteeth/pull/138 by Rowan Goemans / @rowanG077.
