### PR TITLE
core: parse DHCP lease time option

### DIFF
--- a/liteeth/core/dhcp.py
+++ b/liteeth/core/dhcp.py
@@ -11,9 +11,7 @@ DHCP
 Minimal DHCP (IPV4) support for LiteEth.
 
 Limitations/TODOs:
-- No lease time parsing/support, user logic should consider it short (or known from server) and
-issue a DHCP request regularly. Limitations is due to 32-bit data-path and parsing. Switching to a
-8-bit data-path for DHCP options would allow supporting it more easily.
+- User logic should issue a DHCP request before the parsed lease time expires.
 - Additional checks could be made on RX (see FIXMEs, but cost logic on FPGA).
 - Define more DHCP constants and use them in the code.
 """
@@ -319,12 +317,12 @@ class LiteEthDHCPRX(LiteXModule):
         self.mac_address        = Signal(48) # i
         self.server_ip_address  = Signal(32) # o
         self.offered_ip_address = Signal(32) # o
+        self.lease_time         = Signal(32) # o
 
         # TODO: Parse more DHCP Options.
         # self.gateway_ip_address = Signal(32)
         # self.subnet_mask        = Signal(32)
         # self.router             = Signal(32)
-        # self.lease_time         = Signal(32)
 
         # # #
 
@@ -393,6 +391,7 @@ class LiteEthDHCPRX(LiteXModule):
                    (udp_port.source.length >= DHCP_FIXED_HEADER_LENGTH + 4 + 4),
                     udp_port.source.ready.eq(0),
                     NextValue(message_type_seen, 0),
+                    NextValue(self.lease_time, 0),
                     NextState("HEADER")
                 ).Else(
                     NextState("DROP")
@@ -561,7 +560,8 @@ class LiteEthDHCPRX(LiteXModule):
             )
         )
         fsm.act("OPTION-LENGTH",
-            If((option_code == DHCP_OPTTYP_MESSAGE_TYPE) & (option_byte != 0x01),
+            If(((option_code == DHCP_OPTTYP_MESSAGE_TYPE) & (option_byte != 0x01)) |
+               ((option_code == DHCP_OPTTYP_LEASE_TIME)   & (option_byte != 0x04)),
                 NextState("ERROR")
             ).Else(
                 NextValue(option_length, option_byte),
@@ -594,6 +594,14 @@ class LiteEthDHCPRX(LiteXModule):
                         1 : NextValue(self.server_ip_address[16:24], option_byte),
                         2 : NextValue(self.server_ip_address[ 8:16], option_byte),
                         3 : NextValue(self.server_ip_address[ 0: 8], option_byte),
+                    })
+                ),
+                If((option_code == DHCP_OPTTYP_LEASE_TIME) & (option_length == 4),
+                    Case(option_value_index, {
+                        0 : NextValue(self.lease_time[24:32], option_byte),
+                        1 : NextValue(self.lease_time[16:24], option_byte),
+                        2 : NextValue(self.lease_time[ 8:16], option_byte),
+                        3 : NextValue(self.lease_time[ 0: 8], option_byte),
                     })
                 ),
                 finish_option_value()
@@ -637,6 +645,7 @@ class LiteEthDHCP(LiteXModule):
         # Parameters
         self.mac_address = Signal(48) # i
         self.ip_address  = Signal(32) # o
+        self.lease_time  = Signal(32) # o
 
         # # #
 
@@ -706,6 +715,7 @@ class LiteEthDHCP(LiteXModule):
             rx.ack.eq(1),
             If(rx.present & ~rx.error & (rx.type == DHCP_RX_ACK),
                 NextValue(self.ip_address, offered_ip_address),
+                NextValue(self.lease_time, rx.lease_time),
                 NextState("IDLE")
             )
         )

--- a/test/test_dhcp.py
+++ b/test/test_dhcp.py
@@ -19,6 +19,7 @@ mac_address        = 0x10e2d5000001
 transaction_id     = 0x12345678
 offered_ip_address = convert_ip("192.168.1.100")
 server_ip_address  = convert_ip("192.168.1.1")
+lease_time         = 3600
 
 # Helpers ------------------------------------------------------------------------------------------
 
@@ -228,6 +229,7 @@ class TestDHCPRX(unittest.TestCase):
                         type               = (yield dut.rx.type),
                         offered_ip_address = (yield dut.rx.offered_ip_address),
                         server_ip_address  = (yield dut.rx.server_ip_address),
+                        lease_time         = (yield dut.rx.lease_time),
                     )
                     yield dut.rx.ack.eq(1)
                     yield
@@ -283,6 +285,35 @@ class TestDHCPRX(unittest.TestCase):
         self.assertEqual(result["type"], DHCP_RX_ACK)
         self.assertEqual(result["server_ip_address"], server_ip_address)
 
+    def test_ack_parses_lease_time_option(self):
+        packet = build_dhcp_response(
+            message_type = DHCP_OPTVAL_MESSAGE_TYPE_ACK,
+            options      = [
+                DHCP_OPTTYP_SRV_IP_ADDRESS, 0x04, *split_be(server_ip_address, 4),
+                DHCP_OPTTYP_LEASE_TIME,     0x04, *split_be(lease_time, 4),
+                DHCP_OPTTYP_MESSAGE_TYPE,   0x01, DHCP_OPTVAL_MESSAGE_TYPE_ACK,
+                DHCP_OPTTYP_END,
+            ],
+        )
+        result = self.receive_packet(packet)
+
+        self.assertEqual(result["error"], 0)
+        self.assertEqual(result["type"], DHCP_RX_ACK)
+        self.assertEqual(result["lease_time"], lease_time)
+
+    def test_bad_lease_time_length_is_rejected(self):
+        packet = build_dhcp_response(
+            message_type = DHCP_OPTVAL_MESSAGE_TYPE_ACK,
+            options      = [
+                DHCP_OPTTYP_MESSAGE_TYPE, 0x01, DHCP_OPTVAL_MESSAGE_TYPE_ACK,
+                DHCP_OPTTYP_LEASE_TIME,   0x03, 0x00, 0x0e, 0x10,
+                DHCP_OPTTYP_END,
+            ],
+        )
+        result = self.receive_packet(packet)
+
+        self.assertEqual(result["error"], 1)
+
 # Test DHCP Core -----------------------------------------------------------------------------------
 
 class TestDHCPCore(unittest.TestCase):
@@ -305,6 +336,7 @@ class TestDHCPCore(unittest.TestCase):
             "done":          False,
             "timeout":       False,
             "ip_address":    0,
+            "lease_time":     0,
         }
 
         def make_server_response(message_type, xid):
@@ -315,6 +347,7 @@ class TestDHCPCore(unittest.TestCase):
                 options      = [
                     DHCP_OPTTYP_SRV_IP_ADDRESS, 0x04, *split_be(server_ip_address, 4),
                     DHCP_OPTTYP_MESSAGE_TYPE, 0x01, message_type,
+                    DHCP_OPTTYP_LEASE_TIME, 0x04, *split_be(lease_time, 4),
                     DHCP_OPTTYP_END,
                 ],
             )
@@ -376,6 +409,7 @@ class TestDHCPCore(unittest.TestCase):
                 if results["ack_sent"] and (yield dut.dhcp.done):
                     results["done"]       = True
                     results["ip_address"] = (yield dut.dhcp.ip_address)
+                    results["lease_time"] = (yield dut.dhcp.lease_time)
                     break
                 yield
 
@@ -387,6 +421,7 @@ class TestDHCPCore(unittest.TestCase):
         self.assertTrue(results["done"])
         self.assertFalse(results["timeout"])
         self.assertEqual(results["ip_address"], offered_ip_address)
+        self.assertEqual(results["lease_time"], lease_time)
 
     def test_ignores_rx_errors_while_waiting_for_offer(self):
         bad_packet = build_dhcp_response(
@@ -470,6 +505,7 @@ class TestDHCPSignals(unittest.TestCase):
 
         self.assertEqual(len(dut.tx.offered_ip_address), 32)
         self.assertEqual(len(dut.rx.offered_ip_address), 32)
+        self.assertEqual(len(dut.rx.lease_time), 32)
 
         class CoreDUT(LiteXModule):
             def __init__(self):
@@ -480,6 +516,7 @@ class TestDHCPSignals(unittest.TestCase):
 
         core_dut = CoreDUT()
         self.assertEqual(len(core_dut.dhcp.ip_address), 32)
+        self.assertEqual(len(core_dut.dhcp.lease_time), 32)
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Refreshes the still-relevant lease-time part of Rowan Goemans' PR #148 on current master.

This keeps the scope intentionally small:

- parse DHCP option 51 (`IP Address Lease Time`) in the existing DHCP RX options FSM;
- expose the parsed lease time on `LiteEthDHCPRX`;
- propagate the ACK lease time on `LiteEthDHCP`;
- keep the existing standalone DHCP control API unchanged;
- leave automatic renewal/retry policy for a follow-up PR.

The message-type ordering issue from the old PR is already handled on master, so this PR does not bring over the larger 8-bit options FIFO/parser or the generator/DHCP API restructuring.

Testing:

- `python3 -m unittest test.test_dhcp`
- `python3 -m unittest test.test_gen`
- `python3 liteeth/gen.py examples/udp_a7_gtp_sgmii.yml --output-dir /tmp/liteeth-pr148-a7-dhcp --no-compile-gateware`
- `python3 liteeth/gen.py examples/udp_usp_gth_sgmii.yml --output-dir /tmp/liteeth-pr148-usp-dhcp --no-compile-gateware`
- `python3 -m py_compile liteeth/core/dhcp.py test/test_dhcp.py`
- `git diff --check`

Credit: based on the lease-time idea from https://github.com/enjoy-digital/liteeth/pull/148 by Rowan Goemans / @rowanG077.
