### PR TITLE
mac: add optional MAC-level packet FIFOs without default FIFO cost

### DIFF
--- a/liteeth/common.py
+++ b/liteeth/common.py
@@ -175,6 +175,13 @@ def eth_phy_description(dw):
     ]
     return EndpointDescription(payload_layout)
 
+# Packet
+def eth_packet_description(dw):
+    payload_layout = [
+        ("data", dw),
+    ]
+    return EndpointDescription(payload_layout)
+
 # MAC
 def eth_mac_description(dw):
     payload_layout = mac_header.get_layout() + [

--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -32,8 +32,8 @@ class LiteEthMAC(LiteXModule):
         rx_cdc_depth       = 32,
         rx_cdc_buffered    = False,
         eth_mtu            = eth_mtu_default,
-        rx_packet_fifo_depth = 0,
-        tx_packet_fifo_depth = 0,
+        rx_fifo_depth      = 0,
+        tx_fifo_depth      = 0,
     ):
         assert dw%8 == 0
         assert interface  in ["crossbar", "wishbone", "hybrid"]
@@ -81,8 +81,8 @@ class LiteEthMAC(LiteXModule):
                 endianness = endianness,
                 timestamp  = timestamp,
                 eth_mtu    = eth_mtu,
-                rx_packet_fifo_depth = rx_packet_fifo_depth,
-                tx_packet_fifo_depth = tx_packet_fifo_depth,
+                rx_fifo_depth = rx_fifo_depth,
+                tx_fifo_depth = tx_fifo_depth,
             )
             if full_memory_we:
                 wishbone_interface = self.apply_full_memory_we(wishbone_interface)

--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -7,10 +7,50 @@
 
 from litex.gen import *
 
+from litex.soc.interconnect.packet import PacketFIFO
+
 from liteeth.common import *
 from liteeth.mac.common import *
 from liteeth.mac.core import LiteEthMACCore
 from liteeth.mac.wishbone import LiteEthMACWishboneInterface
+
+# MAC Packet FIFOs ---------------------------------------------------------------------------------
+
+class LiteEthMACPacketFIFOs(LiteXModule):
+    def __init__(self, interface, dw, depth, rx_fifo_depth=0, tx_fifo_depth=0):
+        self.sink   = stream.Endpoint(eth_phy_description(dw))
+        self.source = stream.Endpoint(eth_phy_description(dw))
+
+        # # #
+
+        assert rx_fifo_depth >= 0
+        assert tx_fifo_depth >= 0
+
+        if rx_fifo_depth:
+            self.rx_fifo = rx_fifo = PacketFIFO(
+                eth_phy_description(dw),
+                payload_depth = rx_fifo_depth * depth,
+                param_depth   = rx_fifo_depth,
+            )
+            self.comb += [
+                self.sink.connect(rx_fifo.sink),
+                rx_fifo.source.connect(interface.sink),
+            ]
+        else:
+            self.comb += self.sink.connect(interface.sink)
+
+        if tx_fifo_depth:
+            self.tx_fifo = tx_fifo = PacketFIFO(
+                eth_phy_description(dw),
+                payload_depth = tx_fifo_depth * depth,
+                param_depth   = tx_fifo_depth,
+            )
+            self.comb += [
+                interface.source.connect(tx_fifo.sink),
+                tx_fifo.source.connect(self.source),
+            ]
+        else:
+            self.comb += interface.source.connect(self.source)
 
 # MAC ----------------------------------------------------------------------------------------------
 
@@ -81,12 +121,22 @@ class LiteEthMAC(LiteXModule):
                 endianness = endianness,
                 timestamp  = timestamp,
                 eth_mtu    = eth_mtu,
-                rx_fifo_depth = rx_fifo_depth,
-                tx_fifo_depth = tx_fifo_depth,
+                rx_drop_when_disabled = rx_fifo_depth == 0,
             )
             if full_memory_we:
                 wishbone_interface = self.apply_full_memory_we(wishbone_interface)
             self.interface = wishbone_interface
+            mac_interface  = wishbone_interface
+            if rx_fifo_depth or tx_fifo_depth:
+                sram_depth = (eth_mtu + (dw//8) - 1)//(dw//8)
+                self.packet_fifos = LiteEthMACPacketFIFOs(
+                    interface     = wishbone_interface,
+                    dw            = dw,
+                    depth         = sram_depth,
+                    rx_fifo_depth = rx_fifo_depth,
+                    tx_fifo_depth = tx_fifo_depth,
+                )
+                mac_interface = self.packet_fifos
             self.ev        = self.interface.sram.ev
             self.bus_rx    = self.interface.bus_rx
             self.bus_tx    = self.interface.bus_tx
@@ -95,13 +145,13 @@ class LiteEthMAC(LiteXModule):
             # Wishbone Mode.
             # --------------
             if interface in ["wishbone"]:
-                self.comb += self.interface.source.connect(self.core.sink)
-                self.comb += self.core.source.connect(self.interface.sink)
+                self.comb += mac_interface.source.connect(self.core.sink)
+                self.comb += self.core.source.connect(mac_interface.sink)
             # Hybrid Mode.
             # ------------
             if interface in ["hybrid"]:
                 self.crossbar     = LiteEthMACCrossbar(dw)
-                self.mac_crossbar = LiteEthMACCoreCrossbar(self.core, self.crossbar, self.interface, dw, hw_mac)
+                self.mac_crossbar = LiteEthMACCoreCrossbar(self.core, self.crossbar, mac_interface, dw, hw_mac)
 
     def apply_full_memory_we(self, interface):
         # FullMemoryWE splits memory into 8-bit blocks to ensure proper block RAM inference on most FPGAs.

--- a/liteeth/mac/__init__.py
+++ b/liteeth/mac/__init__.py
@@ -32,6 +32,8 @@ class LiteEthMAC(LiteXModule):
         rx_cdc_depth       = 32,
         rx_cdc_buffered    = False,
         eth_mtu            = eth_mtu_default,
+        rx_packet_fifo_depth = 0,
+        tx_packet_fifo_depth = 0,
     ):
         assert dw%8 == 0
         assert interface  in ["crossbar", "wishbone", "hybrid"]
@@ -79,6 +81,8 @@ class LiteEthMAC(LiteXModule):
                 endianness = endianness,
                 timestamp  = timestamp,
                 eth_mtu    = eth_mtu,
+                rx_packet_fifo_depth = rx_packet_fifo_depth,
+                tx_packet_fifo_depth = tx_packet_fifo_depth,
             )
             if full_memory_we:
                 wishbone_interface = self.apply_full_memory_we(wishbone_interface)

--- a/liteeth/mac/packet.py
+++ b/liteeth/mac/packet.py
@@ -18,7 +18,8 @@ from liteeth.common import *
 # MAC Packet Writer Frontend -----------------------------------------------------------------------
 
 class LiteEthMACPacketWriter(LiteXModule):
-    def __init__(self, dw, depth, eth_mtu=eth_mtu_default, fifo_depth=1, timestamp=None):
+    def __init__(self, dw, depth, eth_mtu=eth_mtu_default, fifo_depth=1, timestamp=None,
+        drop_when_disabled=False):
         # Endpoint / Signals.
         self.sink   = sink   = stream.Endpoint(eth_phy_description(dw))
         self.source = source = stream.Endpoint(eth_packet_description(dw))
@@ -84,8 +85,17 @@ class LiteEthMACPacketWriter(LiteXModule):
         # FSM.
         self.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
-            If(packet_source.valid & self.enable,
-                NextState("WRITE")
+            If(packet_source.valid,
+                If(self.enable,
+                    NextState("WRITE")
+                ).Elif(drop_when_disabled,
+                    packet_source.ready.eq(1),
+                    If(packet_source.last,
+                        NextState("DISCARD")
+                    ).Else(
+                        NextState("DISCARD-ALL")
+                    )
+                )
             )
         )
         fsm.act("WRITE",

--- a/liteeth/mac/packet.py
+++ b/liteeth/mac/packet.py
@@ -80,12 +80,8 @@ class LiteEthMACPacketWriter(LiteXModule):
         # FSM.
         self.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
-            If(packet_fifo.source.valid,
-                If(self.enable,
-                    NextState("WRITE")
-                ).Else(
-                    NextState("DISCARD-ALL")
-                )
+            If(packet_fifo.source.valid & self.enable,
+                NextState("WRITE")
             )
         )
         fsm.act("WRITE",

--- a/liteeth/mac/packet.py
+++ b/liteeth/mac/packet.py
@@ -1,0 +1,225 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2015-2021 Florent Kermarrec <florent@enjoy-digital.fr>
+# Copyright (c) 2015-2018 Sebastien Bourdeauducq <sb@m-labs.hk>
+# Copyright (c) 2021 Leon Schuermann <leon@is.currently.online>
+# Copyright (c) 2017 whitequark <whitequark@whitequark.org>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import math
+
+from litex.gen import *
+
+from litex.soc.interconnect.packet import PacketFIFO
+
+from liteeth.common import *
+
+# MAC Packet Writer Frontend -----------------------------------------------------------------------
+
+class LiteEthMACPacketWriter(LiteXModule):
+    def __init__(self, dw, depth, eth_mtu=eth_mtu_default, fifo_depth=1, timestamp=None):
+        # Endpoint / Signals.
+        self.sink   = sink   = stream.Endpoint(eth_phy_description(dw))
+        self.source = source = stream.Endpoint(eth_packet_description(dw))
+
+        self.enable  = Signal(reset=1)
+        self.done    = Signal()
+        self.drop    = Signal()
+        self.error   = Signal()
+        self.offset  = Signal(bits_for(depth*dw//8))
+        self.length  = Signal(bits_for(depth*dw//8))
+
+        # Parameters Check / Compute.
+        assert dw in [8, 16, 32, 64]
+        assert depth > 0
+        assert fifo_depth > 0
+        if timestamp is not None:
+            timestampbits  = len(timestamp)
+            self.timestamp = Signal(timestampbits)
+
+        # # #
+
+        length  = Signal.like(self.length)
+        error   = Signal()
+        pkt_len = Signal.like(self.length)
+
+        # Packet FIFO.
+        packet_fifo = PacketFIFO(
+            eth_phy_description(dw),
+            payload_depth = fifo_depth * depth,
+            param_depth   = fifo_depth,
+        )
+        self.submodules += packet_fifo
+        self.comb += sink.connect(packet_fifo.sink)
+        if timestamp is not None:
+            timestamp_value = Signal(timestampbits)
+            self.comb += self.timestamp.eq(timestamp_value)
+
+        # Decode Length increment from last_be.
+        length_inc = Signal(4)
+        self.comb += Case(packet_fifo.source.last_be, {
+            0b00000001 : length_inc.eq(1),
+            0b00000010 : length_inc.eq(2),
+            0b00000100 : length_inc.eq(3),
+            0b00001000 : length_inc.eq(4),
+            0b00010000 : length_inc.eq(5),
+            0b00100000 : length_inc.eq(6),
+            0b01000000 : length_inc.eq(7),
+            "default"  : length_inc.eq(dw//8)
+        })
+
+        next_length = Signal.like(self.length)
+        last_error  = Signal()
+        self.comb += [
+            next_length.eq(length + length_inc),
+            last_error.eq((packet_fifo.source.error & packet_fifo.source.last_be) != 0),
+            self.offset.eq(length),
+            self.length.eq(Mux(self.done, pkt_len, next_length)),
+        ]
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            If(packet_fifo.source.valid,
+                If(self.enable,
+                    NextState("WRITE")
+                ).Else(
+                    NextState("DISCARD-ALL")
+                )
+            )
+        )
+        fsm.act("WRITE",
+            If(packet_fifo.source.valid,
+                source.valid.eq(packet_fifo.source.valid),
+                source.data.eq(packet_fifo.source.data),
+                source.last.eq(packet_fifo.source.last),
+                packet_fifo.source.ready.eq(source.ready),
+                If(source.ready,
+                    NextValue(length, next_length),
+                    NextValue(pkt_len, next_length),
+                    If(next_length > eth_mtu,
+                        NextValue(error, 1),
+                        If(packet_fifo.source.last,
+                            NextState("DISCARD")
+                        ).Else(
+                            NextState("DISCARD-ALL")
+                        )
+                    ).Elif(packet_fifo.source.last,
+                        If(error | last_error,
+                            NextValue(error, 1),
+                            NextState("DISCARD")
+                        ).Else(
+                            NextState("TERMINATE")
+                        )
+                    ).Elif(last_error,
+                        NextValue(error, 1)
+                    )
+                )
+            )
+        )
+        fsm.act("DISCARD-ALL",
+            packet_fifo.source.ready.eq(1),
+            If(packet_fifo.source.valid & packet_fifo.source.last,
+                NextState("DISCARD")
+            )
+        )
+        fsm.act("DISCARD",
+            self.drop.eq(1),
+            self.error.eq(error),
+            NextValue(length, 0),
+            NextValue(pkt_len, 0),
+            NextValue(error, 0),
+            NextState("IDLE")
+        )
+        fsm.act("TERMINATE",
+            self.done.eq(1),
+            NextValue(length, 0),
+            NextValue(pkt_len, 0),
+            NextValue(error, 0),
+            NextState("IDLE")
+        )
+        if timestamp is not None:
+            self.sync += If(fsm.ongoing("WRITE") & packet_fifo.source.valid & source.ready & (length == 0),
+                timestamp_value.eq(timestamp)
+            )
+
+
+# MAC Packet Reader Frontend -----------------------------------------------------------------------
+
+class LiteEthMACPacketReader(LiteXModule):
+    def __init__(self, dw, depth, fifo_depth=1, timestamp=None):
+        # Endpoint / Signals.
+        self.sink   = sink   = stream.Endpoint(eth_packet_description(dw))
+        self.source = source = stream.Endpoint(eth_phy_description(dw))
+
+        self.enable      = Signal()
+        self.idle        = Signal()
+        self.done        = Signal()
+
+        self.length      = Signal(bits_for(depth*dw//8))
+
+        # Parameters Check / Compute.
+        assert dw in [8, 16, 32, 64]
+        assert depth > 0
+        assert fifo_depth > 0
+        if timestamp is not None:
+            timestampbits  = len(timestamp)
+            self.timestamp = Signal(timestampbits)
+
+        # # #
+
+        if timestamp is not None:
+            timestamp_value = Signal(timestampbits)
+            self.comb += self.timestamp.eq(timestamp_value)
+
+        # Packet FIFO.
+        packet_fifo = PacketFIFO(
+            eth_phy_description(dw),
+            payload_depth = fifo_depth * depth,
+            param_depth   = fifo_depth,
+        )
+        self.submodules += packet_fifo
+        self.comb += packet_fifo.source.connect(source)
+        self.comb += packet_fifo.sink.error.eq(0)
+
+        # Encode Length to last_be.
+        length_lsb = self.length[:int(math.log2(dw/8))] if (dw != 8) else 0
+        self.comb += If(packet_fifo.sink.last,
+            Case(length_lsb, {
+                1         : packet_fifo.sink.last_be.eq(0b00000001),
+                2         : packet_fifo.sink.last_be.eq(0b00000010),
+                3         : packet_fifo.sink.last_be.eq(0b00000100),
+                4         : packet_fifo.sink.last_be.eq(0b00001000),
+                5         : packet_fifo.sink.last_be.eq(0b00010000),
+                6         : packet_fifo.sink.last_be.eq(0b00100000),
+                7         : packet_fifo.sink.last_be.eq(0b01000000),
+                "default" : packet_fifo.sink.last_be.eq(2**(dw//8 - 1)),
+            })
+        )
+
+        if timestamp is not None:
+            self.sync += If(self.idle & self.enable, timestamp_value.eq(timestamp))
+
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        fsm.act("IDLE",
+            self.idle.eq(1),
+            If(self.enable,
+                NextState("READ")
+            )
+        )
+        fsm.act("READ",
+            packet_fifo.sink.valid.eq(sink.valid),
+            packet_fifo.sink.data.eq(sink.data),
+            packet_fifo.sink.last.eq(sink.last),
+            sink.ready.eq(packet_fifo.sink.ready),
+            If(sink.valid & sink.ready & sink.last,
+                NextState("END")
+            )
+        )
+        fsm.act("END",
+            If(source.valid & source.ready & source.last,
+                self.done.eq(1),
+                NextState("IDLE"),
+            )
+        )

--- a/liteeth/mac/packet.py
+++ b/liteeth/mac/packet.py
@@ -11,15 +11,12 @@ import math
 
 from litex.gen import *
 
-from litex.soc.interconnect.packet import PacketFIFO
-
 from liteeth.common import *
 
 # MAC Packet Writer Frontend -----------------------------------------------------------------------
 
 class LiteEthMACPacketWriter(LiteXModule):
-    def __init__(self, dw, depth, eth_mtu=eth_mtu_default, fifo_depth=1, timestamp=None,
-        drop_when_disabled=False):
+    def __init__(self, dw, depth, eth_mtu=eth_mtu_default, timestamp=None, drop_when_disabled=False):
         # Endpoint / Signals.
         self.sink   = sink   = stream.Endpoint(eth_phy_description(dw))
         self.source = source = stream.Endpoint(eth_packet_description(dw))
@@ -34,7 +31,6 @@ class LiteEthMACPacketWriter(LiteXModule):
         # Parameters Check / Compute.
         assert dw in [8, 16, 32, 64]
         assert depth > 0
-        assert fifo_depth >= 0
         if timestamp is not None:
             timestampbits  = len(timestamp)
             self.timestamp = Signal(timestampbits)
@@ -45,18 +41,7 @@ class LiteEthMACPacketWriter(LiteXModule):
         error   = Signal()
         pkt_len = Signal.like(self.length)
 
-        # Optional Packet FIFO.
-        if fifo_depth:
-            packet_fifo = PacketFIFO(
-                eth_phy_description(dw),
-                payload_depth = fifo_depth * depth,
-                param_depth   = fifo_depth,
-            )
-            self.submodules += packet_fifo
-            self.comb += sink.connect(packet_fifo.sink)
-            packet_source = packet_fifo.source
-        else:
-            packet_source = sink
+        packet_source = sink
         if timestamp is not None:
             timestamp_value = Signal(timestampbits)
             self.comb += self.timestamp.eq(timestamp_value)
@@ -82,29 +67,15 @@ class LiteEthMACPacketWriter(LiteXModule):
             self.offset.eq(length),
             self.length.eq(Mux(self.done, pkt_len, next_length)),
         ]
-        # FSM.
-        self.fsm = fsm = FSM(reset_state="IDLE")
-        fsm.act("IDLE",
-            If(packet_source.valid,
-                If(self.enable,
-                    NextState("WRITE")
-                ).Elif(drop_when_disabled,
-                    packet_source.ready.eq(1),
-                    If(packet_source.last,
-                        NextState("DISCARD")
-                    ).Else(
-                        NextState("DISCARD-ALL")
-                    )
-                )
-            )
-        )
-        fsm.act("WRITE",
-            If(packet_source.valid,
+
+        def write_statements(idle=False):
+            continue_statements = [NextState("WRITE")] if idle else []
+            return [
                 source.valid.eq(packet_source.valid),
                 source.data.eq(packet_source.data),
                 source.last.eq(packet_source.last),
                 packet_source.ready.eq(source.ready),
-                If(source.ready,
+                If(packet_source.valid & source.ready,
                     NextValue(length, next_length),
                     NextValue(pkt_len, next_length),
                     If(next_length > eth_mtu,
@@ -121,11 +92,40 @@ class LiteEthMACPacketWriter(LiteXModule):
                         ).Else(
                             NextState("TERMINATE")
                         )
-                    ).Elif(last_error,
-                        NextValue(error, 1)
+                    ).Else(
+                        If(last_error,
+                            NextValue(error, 1)
+                        ),
+                        *continue_statements
+                    )
+                )
+            ]
+
+        # FSM.
+        self.fsm = fsm = FSM(reset_state="IDLE")
+        if drop_when_disabled:
+            fsm.act("IDLE",
+                If(self.enable,
+                    *write_statements(idle=True)
+                ).Else(
+                    packet_source.ready.eq(1),
+                    If(packet_source.valid,
+                        If(packet_source.last,
+                            NextState("DISCARD")
+                        ).Else(
+                            NextState("DISCARD-ALL")
+                        )
                     )
                 )
             )
+        else:
+            fsm.act("IDLE",
+                If(self.enable,
+                    *write_statements(idle=True)
+                )
+            )
+        fsm.act("WRITE",
+            *write_statements()
         )
         fsm.act("DISCARD-ALL",
             packet_source.ready.eq(1),
@@ -149,7 +149,9 @@ class LiteEthMACPacketWriter(LiteXModule):
             NextState("IDLE")
         )
         if timestamp is not None:
-            self.sync += If(fsm.ongoing("WRITE") & packet_source.valid & source.ready & (length == 0),
+            self.sync += If(
+                (fsm.ongoing("IDLE") | fsm.ongoing("WRITE")) &
+                self.enable & packet_source.valid & packet_source.ready & (length == 0),
                 timestamp_value.eq(timestamp)
             )
 
@@ -157,7 +159,7 @@ class LiteEthMACPacketWriter(LiteXModule):
 # MAC Packet Reader Frontend -----------------------------------------------------------------------
 
 class LiteEthMACPacketReader(LiteXModule):
-    def __init__(self, dw, depth, fifo_depth=1, timestamp=None):
+    def __init__(self, dw, depth, timestamp=None):
         # Endpoint / Signals.
         self.sink   = sink   = stream.Endpoint(eth_packet_description(dw))
         self.source = source = stream.Endpoint(eth_phy_description(dw))
@@ -171,7 +173,6 @@ class LiteEthMACPacketReader(LiteXModule):
         # Parameters Check / Compute.
         assert dw in [8, 16, 32, 64]
         assert depth > 0
-        assert fifo_depth >= 0
         if timestamp is not None:
             timestampbits  = len(timestamp)
             self.timestamp = Signal(timestampbits)
@@ -182,41 +183,27 @@ class LiteEthMACPacketReader(LiteXModule):
             timestamp_value = Signal(timestampbits)
             self.comb += self.timestamp.eq(timestamp_value)
 
-        # Optional Packet FIFO.
         direct_read = Signal()
-        if fifo_depth:
-            packet_fifo = PacketFIFO(
-                eth_phy_description(dw),
-                payload_depth = fifo_depth * depth,
-                param_depth   = fifo_depth,
-            )
-            self.submodules += packet_fifo
-            packet_sink = packet_fifo.sink
-            self.comb += packet_fifo.source.connect(source)
-            self.comb += packet_sink.error.eq(0)
-        else:
-            packet_sink = sink
-            self.comb += [
-                source.valid.eq(sink.valid & direct_read),
-                source.data.eq(sink.data),
-                source.last.eq(sink.last),
-                source.error.eq(0),
-                sink.ready.eq(source.ready & direct_read),
-            ]
+        self.comb += [
+            source.valid.eq(sink.valid & direct_read),
+            source.data.eq(sink.data),
+            source.last.eq(sink.last),
+            source.error.eq(0),
+            sink.ready.eq(source.ready & direct_read),
+        ]
 
         # Encode Length to last_be.
         length_lsb = self.length[:int(math.log2(dw/8))] if (dw != 8) else 0
-        last_be    = packet_sink.last_be if fifo_depth else source.last_be
-        self.comb += If(packet_sink.last,
+        self.comb += If(source.last,
             Case(length_lsb, {
-                1         : last_be.eq(0b00000001),
-                2         : last_be.eq(0b00000010),
-                3         : last_be.eq(0b00000100),
-                4         : last_be.eq(0b00001000),
-                5         : last_be.eq(0b00010000),
-                6         : last_be.eq(0b00100000),
-                7         : last_be.eq(0b01000000),
-                "default" : last_be.eq(2**(dw//8 - 1)),
+                1         : source.last_be.eq(0b00000001),
+                2         : source.last_be.eq(0b00000010),
+                3         : source.last_be.eq(0b00000100),
+                4         : source.last_be.eq(0b00001000),
+                5         : source.last_be.eq(0b00010000),
+                6         : source.last_be.eq(0b00100000),
+                7         : source.last_be.eq(0b01000000),
+                "default" : source.last_be.eq(2**(dw//8 - 1)),
             })
         )
 
@@ -231,31 +218,13 @@ class LiteEthMACPacketReader(LiteXModule):
                 NextState("READ")
             )
         )
-        read_statements = []
-        if fifo_depth:
-            read_statements += [
-                packet_sink.valid.eq(sink.valid),
-                packet_sink.data.eq(sink.data),
-                packet_sink.last.eq(sink.last),
-                sink.ready.eq(packet_sink.ready),
-            ]
         fsm.act("READ",
             direct_read.eq(1),
-            *read_statements,
             If(sink.valid & sink.ready & sink.last,
                 NextState("END")
             )
         )
-        if fifo_depth:
-            end_statements = [If(source.valid & source.ready & source.last,
-                self.done.eq(1),
-                NextState("IDLE"),
-            )]
-        else:
-            end_statements = [
-                self.done.eq(1),
-                NextState("IDLE"),
-            ]
         fsm.act("END",
-            *end_statements,
+            self.done.eq(1),
+            NextState("IDLE"),
         )

--- a/liteeth/mac/packet.py
+++ b/liteeth/mac/packet.py
@@ -33,7 +33,7 @@ class LiteEthMACPacketWriter(LiteXModule):
         # Parameters Check / Compute.
         assert dw in [8, 16, 32, 64]
         assert depth > 0
-        assert fifo_depth > 0
+        assert fifo_depth >= 0
         if timestamp is not None:
             timestampbits  = len(timestamp)
             self.timestamp = Signal(timestampbits)
@@ -44,21 +44,25 @@ class LiteEthMACPacketWriter(LiteXModule):
         error   = Signal()
         pkt_len = Signal.like(self.length)
 
-        # Packet FIFO.
-        packet_fifo = PacketFIFO(
-            eth_phy_description(dw),
-            payload_depth = fifo_depth * depth,
-            param_depth   = fifo_depth,
-        )
-        self.submodules += packet_fifo
-        self.comb += sink.connect(packet_fifo.sink)
+        # Optional Packet FIFO.
+        if fifo_depth:
+            packet_fifo = PacketFIFO(
+                eth_phy_description(dw),
+                payload_depth = fifo_depth * depth,
+                param_depth   = fifo_depth,
+            )
+            self.submodules += packet_fifo
+            self.comb += sink.connect(packet_fifo.sink)
+            packet_source = packet_fifo.source
+        else:
+            packet_source = sink
         if timestamp is not None:
             timestamp_value = Signal(timestampbits)
             self.comb += self.timestamp.eq(timestamp_value)
 
         # Decode Length increment from last_be.
         length_inc = Signal(4)
-        self.comb += Case(packet_fifo.source.last_be, {
+        self.comb += Case(packet_source.last_be, {
             0b00000001 : length_inc.eq(1),
             0b00000010 : length_inc.eq(2),
             0b00000100 : length_inc.eq(3),
@@ -73,34 +77,34 @@ class LiteEthMACPacketWriter(LiteXModule):
         last_error  = Signal()
         self.comb += [
             next_length.eq(length + length_inc),
-            last_error.eq((packet_fifo.source.error & packet_fifo.source.last_be) != 0),
+            last_error.eq((packet_source.error & packet_source.last_be) != 0),
             self.offset.eq(length),
             self.length.eq(Mux(self.done, pkt_len, next_length)),
         ]
         # FSM.
         self.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
-            If(packet_fifo.source.valid & self.enable,
+            If(packet_source.valid & self.enable,
                 NextState("WRITE")
             )
         )
         fsm.act("WRITE",
-            If(packet_fifo.source.valid,
-                source.valid.eq(packet_fifo.source.valid),
-                source.data.eq(packet_fifo.source.data),
-                source.last.eq(packet_fifo.source.last),
-                packet_fifo.source.ready.eq(source.ready),
+            If(packet_source.valid,
+                source.valid.eq(packet_source.valid),
+                source.data.eq(packet_source.data),
+                source.last.eq(packet_source.last),
+                packet_source.ready.eq(source.ready),
                 If(source.ready,
                     NextValue(length, next_length),
                     NextValue(pkt_len, next_length),
                     If(next_length > eth_mtu,
                         NextValue(error, 1),
-                        If(packet_fifo.source.last,
+                        If(packet_source.last,
                             NextState("DISCARD")
                         ).Else(
                             NextState("DISCARD-ALL")
                         )
-                    ).Elif(packet_fifo.source.last,
+                    ).Elif(packet_source.last,
                         If(error | last_error,
                             NextValue(error, 1),
                             NextState("DISCARD")
@@ -114,8 +118,8 @@ class LiteEthMACPacketWriter(LiteXModule):
             )
         )
         fsm.act("DISCARD-ALL",
-            packet_fifo.source.ready.eq(1),
-            If(packet_fifo.source.valid & packet_fifo.source.last,
+            packet_source.ready.eq(1),
+            If(packet_source.valid & packet_source.last,
                 NextState("DISCARD")
             )
         )
@@ -135,7 +139,7 @@ class LiteEthMACPacketWriter(LiteXModule):
             NextState("IDLE")
         )
         if timestamp is not None:
-            self.sync += If(fsm.ongoing("WRITE") & packet_fifo.source.valid & source.ready & (length == 0),
+            self.sync += If(fsm.ongoing("WRITE") & packet_source.valid & source.ready & (length == 0),
                 timestamp_value.eq(timestamp)
             )
 
@@ -157,7 +161,7 @@ class LiteEthMACPacketReader(LiteXModule):
         # Parameters Check / Compute.
         assert dw in [8, 16, 32, 64]
         assert depth > 0
-        assert fifo_depth > 0
+        assert fifo_depth >= 0
         if timestamp is not None:
             timestampbits  = len(timestamp)
             self.timestamp = Signal(timestampbits)
@@ -168,28 +172,41 @@ class LiteEthMACPacketReader(LiteXModule):
             timestamp_value = Signal(timestampbits)
             self.comb += self.timestamp.eq(timestamp_value)
 
-        # Packet FIFO.
-        packet_fifo = PacketFIFO(
-            eth_phy_description(dw),
-            payload_depth = fifo_depth * depth,
-            param_depth   = fifo_depth,
-        )
-        self.submodules += packet_fifo
-        self.comb += packet_fifo.source.connect(source)
-        self.comb += packet_fifo.sink.error.eq(0)
+        # Optional Packet FIFO.
+        direct_read = Signal()
+        if fifo_depth:
+            packet_fifo = PacketFIFO(
+                eth_phy_description(dw),
+                payload_depth = fifo_depth * depth,
+                param_depth   = fifo_depth,
+            )
+            self.submodules += packet_fifo
+            packet_sink = packet_fifo.sink
+            self.comb += packet_fifo.source.connect(source)
+            self.comb += packet_sink.error.eq(0)
+        else:
+            packet_sink = sink
+            self.comb += [
+                source.valid.eq(sink.valid & direct_read),
+                source.data.eq(sink.data),
+                source.last.eq(sink.last),
+                source.error.eq(0),
+                sink.ready.eq(source.ready & direct_read),
+            ]
 
         # Encode Length to last_be.
         length_lsb = self.length[:int(math.log2(dw/8))] if (dw != 8) else 0
-        self.comb += If(packet_fifo.sink.last,
+        last_be    = packet_sink.last_be if fifo_depth else source.last_be
+        self.comb += If(packet_sink.last,
             Case(length_lsb, {
-                1         : packet_fifo.sink.last_be.eq(0b00000001),
-                2         : packet_fifo.sink.last_be.eq(0b00000010),
-                3         : packet_fifo.sink.last_be.eq(0b00000100),
-                4         : packet_fifo.sink.last_be.eq(0b00001000),
-                5         : packet_fifo.sink.last_be.eq(0b00010000),
-                6         : packet_fifo.sink.last_be.eq(0b00100000),
-                7         : packet_fifo.sink.last_be.eq(0b01000000),
-                "default" : packet_fifo.sink.last_be.eq(2**(dw//8 - 1)),
+                1         : last_be.eq(0b00000001),
+                2         : last_be.eq(0b00000010),
+                3         : last_be.eq(0b00000100),
+                4         : last_be.eq(0b00001000),
+                5         : last_be.eq(0b00010000),
+                6         : last_be.eq(0b00100000),
+                7         : last_be.eq(0b01000000),
+                "default" : last_be.eq(2**(dw//8 - 1)),
             })
         )
 
@@ -204,18 +221,31 @@ class LiteEthMACPacketReader(LiteXModule):
                 NextState("READ")
             )
         )
+        read_statements = []
+        if fifo_depth:
+            read_statements += [
+                packet_sink.valid.eq(sink.valid),
+                packet_sink.data.eq(sink.data),
+                packet_sink.last.eq(sink.last),
+                sink.ready.eq(packet_sink.ready),
+            ]
         fsm.act("READ",
-            packet_fifo.sink.valid.eq(sink.valid),
-            packet_fifo.sink.data.eq(sink.data),
-            packet_fifo.sink.last.eq(sink.last),
-            sink.ready.eq(packet_fifo.sink.ready),
+            direct_read.eq(1),
+            *read_statements,
             If(sink.valid & sink.ready & sink.last,
                 NextState("END")
             )
         )
-        fsm.act("END",
-            If(source.valid & source.ready & source.last,
+        if fifo_depth:
+            end_statements = [If(source.valid & source.ready & source.last,
                 self.done.eq(1),
                 NextState("IDLE"),
-            )
+            )]
+        else:
+            end_statements = [
+                self.done.eq(1),
+                NextState("IDLE"),
+            ]
+        fsm.act("END",
+            *end_statements,
         )

--- a/liteeth/mac/sram.py
+++ b/liteeth/mac/sram.py
@@ -50,11 +50,12 @@ class LiteEthMACSRAMWriter(LiteXModule):
 
         # Packet frontend.
         self.packet = packet = LiteEthMACPacketWriter(
-            dw         = dw,
-            depth      = depth,
-            eth_mtu    = eth_mtu,
-            fifo_depth = fifo_depth,
-            timestamp  = timestamp,
+            dw                 = dw,
+            depth              = depth,
+            eth_mtu            = eth_mtu,
+            fifo_depth         = fifo_depth,
+            timestamp          = timestamp,
+            drop_when_disabled = fifo_depth == 0,
         )
         self.sink = packet.sink
         self.comb += packet.source.ready.eq(1),

--- a/liteeth/mac/sram.py
+++ b/liteeth/mac/sram.py
@@ -21,7 +21,7 @@ from liteeth.mac.packet import LiteEthMACPacketWriter, LiteEthMACPacketReader
 
 class LiteEthMACSRAMWriter(LiteXModule):
     def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None,
-        eth_mtu=eth_mtu_default, fifo_depth=0):
+        eth_mtu=eth_mtu_default, drop_when_disabled=True):
         # Endpoint / Signals.
         self.crc_error = Signal()
 
@@ -53,9 +53,8 @@ class LiteEthMACSRAMWriter(LiteXModule):
             dw                 = dw,
             depth              = depth,
             eth_mtu            = eth_mtu,
-            fifo_depth         = fifo_depth,
             timestamp          = timestamp,
-            drop_when_disabled = fifo_depth == 0,
+            drop_when_disabled = drop_when_disabled,
         )
         self.sink = packet.sink
         self.comb += packet.source.ready.eq(1),
@@ -119,7 +118,7 @@ class LiteEthMACSRAMWriter(LiteXModule):
 # MAC SRAM Reader ----------------------------------------------------------------------------------
 
 class LiteEthMACSRAMReader(LiteXModule):
-    def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None, fifo_depth=0):
+    def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None):
         # Parameters Check / Compute.
         assert dw in [8, 16, 32, 64]
         slotbits   = max(int(math.log2(nslots)), 1)
@@ -147,10 +146,9 @@ class LiteEthMACSRAMReader(LiteXModule):
 
         # Packet frontend.
         self.packet = packet = LiteEthMACPacketReader(
-            dw         = dw,
-            depth      = depth,
-            fifo_depth = fifo_depth,
-            timestamp  = timestamp,
+            dw        = dw,
+            depth     = depth,
+            timestamp = timestamp,
         )
         self.source = source = packet.source
 
@@ -244,23 +242,22 @@ class LiteEthMACSRAMReader(LiteXModule):
 
 class LiteEthMACSRAM(LiteXModule):
     def __init__(self, dw, depth, nrxslots, ntxslots, endianness, timestamp=None,
-        eth_mtu=eth_mtu_default, rx_fifo_depth=0, tx_fifo_depth=0):
+        eth_mtu=eth_mtu_default, rx_drop_when_disabled=True):
         self.writer = LiteEthMACSRAMWriter(
-            dw                = dw,
-            depth             = depth,
-            nslots            = nrxslots,
-            endianness        = endianness,
-            timestamp         = timestamp,
-            eth_mtu           = eth_mtu,
-            fifo_depth        = rx_fifo_depth,
+            dw                   = dw,
+            depth                = depth,
+            nslots               = nrxslots,
+            endianness           = endianness,
+            timestamp            = timestamp,
+            eth_mtu              = eth_mtu,
+            drop_when_disabled   = rx_drop_when_disabled,
         )
         self.reader = LiteEthMACSRAMReader(
-            dw                = dw,
-            depth             = depth,
-            nslots            = ntxslots,
-            endianness        = endianness,
-            timestamp         = timestamp,
-            fifo_depth        = tx_fifo_depth,
+            dw         = dw,
+            depth      = depth,
+            nslots     = ntxslots,
+            endianness = endianness,
+            timestamp  = timestamp,
         )
         self.ev     = SharedIRQ(self.writer.ev, self.reader.ev)
         self.sink, self.source = self.writer.sink, self.reader.source

--- a/liteeth/mac/sram.py
+++ b/liteeth/mac/sram.py
@@ -15,13 +15,13 @@ from litex.soc.interconnect.csr import *
 from litex.soc.interconnect.csr_eventmanager import *
 
 from liteeth.common import *
+from liteeth.mac.packet import LiteEthMACPacketWriter, LiteEthMACPacketReader
 
 # MAC SRAM Writer ----------------------------------------------------------------------------------
 
 class LiteEthMACSRAMWriter(LiteXModule):
     def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None, eth_mtu=eth_mtu_default):
         # Endpoint / Signals.
-        self.sink      = sink = stream.Endpoint(eth_phy_description(dw))
         self.crc_error = Signal()
 
         # Parameters Check / Compute.
@@ -47,27 +47,13 @@ class LiteEthMACSRAMWriter(LiteXModule):
 
         # # #
 
-        write   = Signal()
-        errors  = self._errors.status
+        # Packet frontend.
+        self.packet = packet = LiteEthMACPacketWriter(dw, depth, eth_mtu=eth_mtu, timestamp=timestamp)
+        self.sink = packet.sink
+        self.comb += packet.source.ready.eq(1),
 
-        slot       = Signal(slotbits)
-        length     = Signal(lengthbits)
-        length_inc = Signal(4)
-
-        # Sink is already ready: packets are dropped when no slot is available.
-        sink.ready.reset = 1
-
-        # Decode Length increment from from last_be.
-        self.comb += Case(sink.last_be, {
-            0b00000001 : length_inc.eq(1),
-            0b00000010 : length_inc.eq(2),
-            0b00000100 : length_inc.eq(3),
-            0b00001000 : length_inc.eq(4),
-            0b00010000 : length_inc.eq(5),
-            0b00100000 : length_inc.eq(6),
-            0b01000000 : length_inc.eq(7),
-            "default"  : length_inc.eq(dw//8)
-        })
+        errors = self._errors.status
+        slot   = Signal(slotbits)
 
         # Status FIFO.
         stat_fifo_layout = [("slot", slotbits), ("length", lengthbits)]
@@ -75,76 +61,29 @@ class LiteEthMACSRAMWriter(LiteXModule):
             stat_fifo_layout += [("timestamp", timestampbits)]
         self.stat_fifo = stat_fifo = stream.SyncFIFO(stat_fifo_layout, nslots)
 
-        # FSM.
-        self.fsm = fsm = FSM(reset_state="WRITE")
-        fsm.act("WRITE",
-            If(sink.valid,
-                If(stat_fifo.sink.ready,
-                    write.eq(1),
-                    NextValue(length, length + length_inc),
-                    If(length >= self.eth_mtu,
-                         NextState("DISCARD-REMAINING")
-                    ),
-                    If(sink.last,
-                        If((sink.error & sink.last_be) != 0,
-                            NextState("DISCARD")
-                        ).Else(
-                            NextState("TERMINATE")
-                        )
-                    )
-                ).Else(
-                    NextValue(errors, errors + 1),
-                    NextState("DISCARD-ALL")
-                )
-            )
-        )
-        fsm.act("DISCARD-REMAINING",
-            If(sink.valid & sink.last,
-                If((sink.error & sink.last_be) != 0,
-                    NextState("DISCARD")
-                ).Else(
-                    NextState("TERMINATE")
-                )
-            )
-        )
-        fsm.act("DISCARD-ALL",
-            If(sink.valid & sink.last,
-                If((sink.last_be) != 0,
-                    NextState("DISCARD")
-                ).Else(
-                    NextValue(length, 0),
-                    NextState("WRITE")
-                )
-            )
-        )
-        fsm.act("DISCARD",
-            NextValue(length, 0),
-            NextState("WRITE")
-        )
-        fsm.act("TERMINATE",
-            stat_fifo.sink.valid.eq(1),
-            stat_fifo.sink.slot.eq(slot),
-            stat_fifo.sink.length.eq(length),
-            NextValue(length, 0),
-            NextValue(slot, slot + 1),
-            NextState("WRITE")
-        )
-
         self.comb += [
+            packet.enable.eq(stat_fifo.sink.ready),
+            stat_fifo.sink.valid.eq(packet.done),
+            stat_fifo.sink.slot.eq(slot),
+            stat_fifo.sink.length.eq(packet.length),
             stat_fifo.source.ready.eq(self.ev.available.clear),
             self.ev.available.trigger.eq(stat_fifo.source.valid),
             self._slot.status.eq(stat_fifo.source.slot),
             self._length.status.eq(stat_fifo.source.length),
         ]
         if timestamp is not None:
-            # Latch Timestamp on start of packet.
-            self.sync += If(length == 0, stat_fifo.sink.timestamp.eq(timestamp))
             self.comb += self._timestamp.status.eq(stat_fifo.source.timestamp)
+            self.comb += stat_fifo.sink.timestamp.eq(packet.timestamp)
+
+        self.sync += [
+            If(packet.drop, errors.eq(errors + 1)),
+            If(packet.done & stat_fifo.sink.ready, slot.eq(slot + 1)),
+        ]
 
         # Memory.
         wr_slot = slot
-        wr_addr = length[int(math.log2(dw//8)):]
-        wr_data = Signal(len(sink.data))
+        wr_addr = packet.offset[int(math.log2(dw//8)):]
+        wr_data = Signal(len(packet.source.data))
 
         # Create a Memory per Slot.
         mems  = [None] * nslots
@@ -156,7 +95,7 @@ class LiteEthMACSRAMWriter(LiteXModule):
         self.mems = mems
 
         # Endianness Handling.
-        self.comb += wr_data.eq({"big": reverse_bytes(sink.data), "little": sink.data}[endianness])
+        self.comb += wr_data.eq({"big": reverse_bytes(packet.source.data), "little": packet.source.data}[endianness])
 
         # Connect Memory ports.
         cases = {}
@@ -167,15 +106,12 @@ class LiteEthMACSRAMWriter(LiteXModule):
             ]
             cases[n] = [port.we.eq(1)]
 
-        self.comb += If(sink.valid & write, Case(wr_slot, cases))
+        self.comb += If(packet.source.valid & packet.source.ready, Case(wr_slot, cases))
 
 # MAC SRAM Reader ----------------------------------------------------------------------------------
 
 class LiteEthMACSRAMReader(LiteXModule):
     def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None):
-        # Endpoint / Signals.
-        self.source = source = stream.Endpoint(eth_phy_description(dw))
-
         # Parameters Check / Compute.
         assert dw in [8, 16, 32, 64]
         slotbits   = max(int(math.log2(nslots)), 1)
@@ -201,8 +137,9 @@ class LiteEthMACSRAMReader(LiteXModule):
 
         # # #
 
-        read   = Signal()
-        length = Signal(lengthbits)
+        # Packet frontend.
+        self.packet = packet = LiteEthMACPacketReader(dw, depth, timestamp=timestamp)
+        self.source = source = packet.source
 
         # Command FIFO.
         cmd_fifo = stream.SyncFIFO([("slot", slotbits), ("length", lengthbits)], nslots)
@@ -224,60 +161,48 @@ class LiteEthMACSRAMReader(LiteXModule):
             self.comb += self._timestamp_slot.status.eq(stat_fifo.source.slot)
             self.comb += self._timestamp.status.eq(stat_fifo.source.timestamp)
 
-        # Encode Length to last_be.
-        length_lsb = cmd_fifo.source.length[:int(math.log2(dw/8))] if (dw != 8) else 0
-        self.comb += If(source.last,
-            Case(length_lsb, {
-                1         : source.last_be.eq(0b00000001),
-                2         : source.last_be.eq(0b00000010),
-                3         : source.last_be.eq(0b00000100),
-                4         : source.last_be.eq(0b00001000),
-                5         : source.last_be.eq(0b00010000),
-                6         : source.last_be.eq(0b00100000),
-                7         : source.last_be.eq(0b01000000),
-                "default" : source.last_be.eq(2**(dw//8 - 1)),
-            })
-        )
+        self.comb += packet.length.eq(cmd_fifo.source.length)
+
+        # Memory.
+        read      = Signal()
+        rd_slot   = cmd_fifo.source.slot
+        rd_offset = Signal(lengthbits)
+        rd_data   = Signal(len(source.data))
+
 
         # FSM.
         self.fsm = fsm = FSM(reset_state="IDLE")
         fsm.act("IDLE",
-            If(cmd_fifo.source.valid,
+            If(cmd_fifo.source.valid & packet.idle,
+                packet.enable.eq(1),
                 read.eq(1),
-                NextValue(length, dw//8),
+                NextValue(rd_offset, dw//8),
                 NextState("READ")
             )
         )
         fsm.act("READ",
-            source.valid.eq(1),
-            source.last.eq(length >= cmd_fifo.source.length),
-            If(source.ready,
+            packet.sink.valid.eq(1),
+            packet.sink.last.eq(rd_offset >= cmd_fifo.source.length),
+            If(packet.done,
+                NextState("TERMINATE")
+            ).Elif(packet.sink.ready & ~packet.sink.last,
                 read.eq(1),
-                NextValue(length, length + dw//8),
-                If(source.last,
-                    NextState("TERMINATE")
-                )
+                NextValue(rd_offset, rd_offset + dw//8),
             )
         )
         fsm.act("TERMINATE",
-            NextValue(length, 0),
+            NextValue(rd_offset, 0),
             self.ev.done.trigger.eq(1),
             cmd_fifo.source.ready.eq(1),
             NextState("IDLE")
         )
 
         if timestamp is not None:
-            # Latch Timestamp on start of outgoing packet.
-            self.sync += If(length == 0, stat_fifo.sink.timestamp.eq(timestamp))
-            self.comb += stat_fifo.sink.valid.eq(fsm.ongoing("END"))
+            self.comb += stat_fifo.sink.valid.eq(fsm.ongoing("TERMINATE"))
+            self.comb += stat_fifo.sink.timestamp.eq(packet.timestamp)
             self.comb += stat_fifo.sink.slot.eq(cmd_fifo.source.slot)
             # Trigger event when Status FIFO has contents (Override FSM assignment).
             self.comb += self.ev.done.trigger.eq(stat_fifo.source.valid)
-
-        # Memory.
-        rd_slot = cmd_fifo.source.slot
-        rd_addr = Signal(lengthbits)
-        rd_data = Signal(len(source.data))
 
         # Create a Memory per Slot.
         mems    = [None]*nslots
@@ -293,14 +218,14 @@ class LiteEthMACSRAMReader(LiteXModule):
         for n, port in enumerate(ports):
             self.comb += [
                 port.re.eq(read),
-                port.adr.eq(length[int(math.log2(dw//8)):]),
+                port.adr.eq(rd_offset[int(math.log2(dw//8)):])
             ]
             cases[n] = [rd_data.eq(port.dat_r)]
 
         self.comb += Case(rd_slot, cases)
 
         # Endianness Handling.
-        self.comb += source.data.eq({"big" : reverse_bytes(rd_data), "little": rd_data}[endianness])
+        self.comb += packet.sink.data.eq({"big" : reverse_bytes(rd_data), "little": rd_data}[endianness])
 
 # MAC SRAM -----------------------------------------------------------------------------------------
 

--- a/liteeth/mac/sram.py
+++ b/liteeth/mac/sram.py
@@ -20,7 +20,8 @@ from liteeth.mac.packet import LiteEthMACPacketWriter, LiteEthMACPacketReader
 # MAC SRAM Writer ----------------------------------------------------------------------------------
 
 class LiteEthMACSRAMWriter(LiteXModule):
-    def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None, eth_mtu=eth_mtu_default):
+    def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None,
+        eth_mtu=eth_mtu_default, packet_fifo_depth=0):
         # Endpoint / Signals.
         self.crc_error = Signal()
 
@@ -48,7 +49,13 @@ class LiteEthMACSRAMWriter(LiteXModule):
         # # #
 
         # Packet frontend.
-        self.packet = packet = LiteEthMACPacketWriter(dw, depth, eth_mtu=eth_mtu, timestamp=timestamp)
+        self.packet = packet = LiteEthMACPacketWriter(
+            dw         = dw,
+            depth      = depth,
+            eth_mtu    = eth_mtu,
+            fifo_depth = packet_fifo_depth,
+            timestamp  = timestamp,
+        )
         self.sink = packet.sink
         self.comb += packet.source.ready.eq(1),
 
@@ -111,7 +118,7 @@ class LiteEthMACSRAMWriter(LiteXModule):
 # MAC SRAM Reader ----------------------------------------------------------------------------------
 
 class LiteEthMACSRAMReader(LiteXModule):
-    def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None):
+    def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None, packet_fifo_depth=0):
         # Parameters Check / Compute.
         assert dw in [8, 16, 32, 64]
         slotbits   = max(int(math.log2(nslots)), 1)
@@ -138,7 +145,12 @@ class LiteEthMACSRAMReader(LiteXModule):
         # # #
 
         # Packet frontend.
-        self.packet = packet = LiteEthMACPacketReader(dw, depth, timestamp=timestamp)
+        self.packet = packet = LiteEthMACPacketReader(
+            dw         = dw,
+            depth      = depth,
+            fifo_depth = packet_fifo_depth,
+            timestamp  = timestamp,
+        )
         self.source = source = packet.source
 
         # Command FIFO.
@@ -230,8 +242,24 @@ class LiteEthMACSRAMReader(LiteXModule):
 # MAC SRAM -----------------------------------------------------------------------------------------
 
 class LiteEthMACSRAM(LiteXModule):
-    def __init__(self, dw, depth, nrxslots, ntxslots, endianness, timestamp=None, eth_mtu=eth_mtu_default):
-        self.writer = LiteEthMACSRAMWriter(dw, depth, nrxslots, endianness, timestamp, eth_mtu=eth_mtu)
-        self.reader = LiteEthMACSRAMReader(dw, depth, ntxslots, endianness, timestamp)
+    def __init__(self, dw, depth, nrxslots, ntxslots, endianness, timestamp=None,
+        eth_mtu=eth_mtu_default, rx_packet_fifo_depth=0, tx_packet_fifo_depth=0):
+        self.writer = LiteEthMACSRAMWriter(
+            dw                = dw,
+            depth             = depth,
+            nslots            = nrxslots,
+            endianness        = endianness,
+            timestamp         = timestamp,
+            eth_mtu           = eth_mtu,
+            packet_fifo_depth = rx_packet_fifo_depth,
+        )
+        self.reader = LiteEthMACSRAMReader(
+            dw                = dw,
+            depth             = depth,
+            nslots            = ntxslots,
+            endianness        = endianness,
+            timestamp         = timestamp,
+            packet_fifo_depth = tx_packet_fifo_depth,
+        )
         self.ev     = SharedIRQ(self.writer.ev, self.reader.ev)
         self.sink, self.source = self.writer.sink, self.reader.source

--- a/liteeth/mac/sram.py
+++ b/liteeth/mac/sram.py
@@ -21,7 +21,7 @@ from liteeth.mac.packet import LiteEthMACPacketWriter, LiteEthMACPacketReader
 
 class LiteEthMACSRAMWriter(LiteXModule):
     def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None,
-        eth_mtu=eth_mtu_default, packet_fifo_depth=0):
+        eth_mtu=eth_mtu_default, fifo_depth=0):
         # Endpoint / Signals.
         self.crc_error = Signal()
 
@@ -53,7 +53,7 @@ class LiteEthMACSRAMWriter(LiteXModule):
             dw         = dw,
             depth      = depth,
             eth_mtu    = eth_mtu,
-            fifo_depth = packet_fifo_depth,
+            fifo_depth = fifo_depth,
             timestamp  = timestamp,
         )
         self.sink = packet.sink
@@ -118,7 +118,7 @@ class LiteEthMACSRAMWriter(LiteXModule):
 # MAC SRAM Reader ----------------------------------------------------------------------------------
 
 class LiteEthMACSRAMReader(LiteXModule):
-    def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None, packet_fifo_depth=0):
+    def __init__(self, dw, depth, nslots=2, endianness="big", timestamp=None, fifo_depth=0):
         # Parameters Check / Compute.
         assert dw in [8, 16, 32, 64]
         slotbits   = max(int(math.log2(nslots)), 1)
@@ -148,7 +148,7 @@ class LiteEthMACSRAMReader(LiteXModule):
         self.packet = packet = LiteEthMACPacketReader(
             dw         = dw,
             depth      = depth,
-            fifo_depth = packet_fifo_depth,
+            fifo_depth = fifo_depth,
             timestamp  = timestamp,
         )
         self.source = source = packet.source
@@ -243,7 +243,7 @@ class LiteEthMACSRAMReader(LiteXModule):
 
 class LiteEthMACSRAM(LiteXModule):
     def __init__(self, dw, depth, nrxslots, ntxslots, endianness, timestamp=None,
-        eth_mtu=eth_mtu_default, rx_packet_fifo_depth=0, tx_packet_fifo_depth=0):
+        eth_mtu=eth_mtu_default, rx_fifo_depth=0, tx_fifo_depth=0):
         self.writer = LiteEthMACSRAMWriter(
             dw                = dw,
             depth             = depth,
@@ -251,7 +251,7 @@ class LiteEthMACSRAM(LiteXModule):
             endianness        = endianness,
             timestamp         = timestamp,
             eth_mtu           = eth_mtu,
-            packet_fifo_depth = rx_packet_fifo_depth,
+            fifo_depth        = rx_fifo_depth,
         )
         self.reader = LiteEthMACSRAMReader(
             dw                = dw,
@@ -259,7 +259,7 @@ class LiteEthMACSRAM(LiteXModule):
             nslots            = ntxslots,
             endianness        = endianness,
             timestamp         = timestamp,
-            packet_fifo_depth = tx_packet_fifo_depth,
+            fifo_depth        = tx_fifo_depth,
         )
         self.ev     = SharedIRQ(self.writer.ev, self.reader.ev)
         self.sink, self.source = self.writer.sink, self.reader.source

--- a/liteeth/mac/wishbone.py
+++ b/liteeth/mac/wishbone.py
@@ -22,8 +22,8 @@ class LiteEthMACWishboneInterface(LiteXModule):
         rxslots_read_only  = True,
         txslots_write_only = False,
         eth_mtu            = eth_mtu_default,
-        rx_packet_fifo_depth = 0,
-        tx_packet_fifo_depth = 0,
+        rx_fifo_depth      = 0,
+        tx_fifo_depth      = 0,
     ):
         self.sink   = stream.Endpoint(eth_phy_description(dw))
         self.source = stream.Endpoint(eth_phy_description(dw))
@@ -44,8 +44,8 @@ class LiteEthMACWishboneInterface(LiteXModule):
             endianness           = endianness,
             timestamp            = timestamp,
             eth_mtu              = eth_mtu,
-            rx_packet_fifo_depth = rx_packet_fifo_depth,
-            tx_packet_fifo_depth = tx_packet_fifo_depth,
+            rx_fifo_depth        = rx_fifo_depth,
+            tx_fifo_depth        = tx_fifo_depth,
         )
         self.comb += [
             self.sink.connect(self.sram.sink),

--- a/liteeth/mac/wishbone.py
+++ b/liteeth/mac/wishbone.py
@@ -21,9 +21,8 @@ class LiteEthMACWishboneInterface(LiteXModule):
     def __init__(self, dw, nrxslots=2, ntxslots=2, endianness="big", timestamp=None,
         rxslots_read_only  = True,
         txslots_write_only = False,
-        eth_mtu            = eth_mtu_default,
-        rx_fifo_depth      = 0,
-        tx_fifo_depth      = 0,
+        eth_mtu               = eth_mtu_default,
+        rx_drop_when_disabled = True,
     ):
         self.sink   = stream.Endpoint(eth_phy_description(dw))
         self.source = stream.Endpoint(eth_phy_description(dw))
@@ -43,9 +42,8 @@ class LiteEthMACWishboneInterface(LiteXModule):
             ntxslots             = ntxslots,
             endianness           = endianness,
             timestamp            = timestamp,
-            eth_mtu              = eth_mtu,
-            rx_fifo_depth        = rx_fifo_depth,
-            tx_fifo_depth        = tx_fifo_depth,
+            eth_mtu               = eth_mtu,
+            rx_drop_when_disabled = rx_drop_when_disabled,
         )
         self.comb += [
             self.sink.connect(self.sram.sink),

--- a/liteeth/mac/wishbone.py
+++ b/liteeth/mac/wishbone.py
@@ -22,6 +22,8 @@ class LiteEthMACWishboneInterface(LiteXModule):
         rxslots_read_only  = True,
         txslots_write_only = False,
         eth_mtu            = eth_mtu_default,
+        rx_packet_fifo_depth = 0,
+        tx_packet_fifo_depth = 0,
     ):
         self.sink   = stream.Endpoint(eth_phy_description(dw))
         self.source = stream.Endpoint(eth_phy_description(dw))
@@ -34,7 +36,17 @@ class LiteEthMACWishboneInterface(LiteXModule):
         # ----------------
         self.eth_mtu = eth_mtu
         sram_depth = math.ceil(eth_mtu/(dw//8))
-        self.sram = sram.LiteEthMACSRAM(dw, sram_depth, nrxslots, ntxslots, endianness, timestamp, eth_mtu=eth_mtu)
+        self.sram = sram.LiteEthMACSRAM(
+            dw                   = dw,
+            depth                = sram_depth,
+            nrxslots             = nrxslots,
+            ntxslots             = ntxslots,
+            endianness           = endianness,
+            timestamp            = timestamp,
+            eth_mtu              = eth_mtu,
+            rx_packet_fifo_depth = rx_packet_fifo_depth,
+            tx_packet_fifo_depth = tx_packet_fifo_depth,
+        )
         self.comb += [
             self.sink.connect(self.sram.sink),
             self.sram.source.connect(self.source),

--- a/test/test_mac_packet.py
+++ b/test/test_mac_packet.py
@@ -68,8 +68,8 @@ def mac_packet_send(sink, dw, data, error=0):
 # -------------------------------------------------------------------------
 
 class MACPacketReaderDUT(Module):
-    def __init__(self, dw, depth, timestamp=None):
-        self.packet = LiteEthMACPacketReader(dw, depth, timestamp=timestamp)
+    def __init__(self, dw, depth, fifo_depth=1, timestamp=None):
+        self.packet = LiteEthMACPacketReader(dw, depth, fifo_depth=fifo_depth, timestamp=timestamp)
         self.submodules += self.packet
         self.source = self.packet.source
 
@@ -137,6 +137,80 @@ class TestMACPacketWriter(unittest.TestCase):
                 self.assertEqual(result["write_count"], len(mac_packet_words(dw, data)))
                 self.assertTrue(result["done"])
                 self.assertEqual(result["length"], len(data))
+
+    def test_writer_zero_depth_good_packet(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                dut    = LiteEthMACPacketWriter(
+                    dw         = dw,
+                    depth      = len(mac_packet_words(dw, data)),
+                    eth_mtu    = eth_mtu_default,
+                    fifo_depth = 0,
+                )
+                result = {"data": [], "done": False, "length": None, "timeout": False}
+
+                def generator(timeout=128):
+                    yield dut.enable.eq(1)
+                    yield dut.source.ready.eq(1)
+                    words = mac_packet_words(dw, data)
+                    for n, word in enumerate(words):
+                        last = n == len(words) - 1
+                        yield dut.sink.data.eq(word)
+                        yield dut.sink.last.eq(last)
+                        yield dut.sink.last_be.eq(mac_packet_last_be(dw, len(data)) if last else 0)
+                        yield dut.sink.error.eq(0)
+                        yield dut.sink.valid.eq(1)
+                        for _ in range(timeout):
+                            yield
+                            if (yield dut.source.valid) and (yield dut.source.ready):
+                                result["data"] += mac_packet_bytes(dw, (yield dut.source.data))
+                            if (yield dut.sink.ready):
+                                break
+                        else:
+                            result["timeout"] = True
+                            return
+
+                    yield dut.sink.valid.eq(0)
+                    yield dut.sink.last.eq(0)
+                    yield dut.sink.last_be.eq(0)
+                    for _ in range(timeout):
+                        if (yield dut.source.valid) and (yield dut.source.ready):
+                            result["data"] += mac_packet_bytes(dw, (yield dut.source.data))
+                        if (yield dut.done):
+                            result["done"]   = True
+                            result["length"] = (yield dut.length)
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["data"][:len(data)], data)
+                self.assertTrue(result["done"])
+                self.assertEqual(result["length"], len(data))
+
+    def test_writer_zero_depth_disabled_backpressures(self):
+        for dw, _ in mac_packet_test_cases(length=4):
+            with self.subTest(dw=dw):
+                dut    = LiteEthMACPacketWriter(dw, depth=4, eth_mtu=eth_mtu_default, fifo_depth=0)
+                result = {"ready": None, "source_valid": None, "drop": None}
+
+                def generator():
+                    yield dut.enable.eq(0)
+                    yield dut.source.ready.eq(1)
+                    yield dut.sink.valid.eq(1)
+                    yield dut.sink.data.eq(0x5a)
+                    yield dut.sink.last.eq(1)
+                    yield dut.sink.last_be.eq(mac_packet_last_be(dw, 1))
+                    yield
+                    result["ready"]       = (yield dut.sink.ready)
+                    result["source_valid"] = (yield dut.source.valid)
+                    result["drop"]        = (yield dut.drop)
+
+                run_simulation(dut, generator())
+                self.assertEqual(result["ready"], 0)
+                self.assertEqual(result["source_valid"], 0)
+                self.assertEqual(result["drop"], 0)
 
     def test_writer_disabled_backpressures_until_enabled(self):
         for dw, data in mac_packet_test_cases(length=4):
@@ -253,7 +327,16 @@ class TestMACPacketWriter(unittest.TestCase):
 
 class TestMACPacketReader(unittest.TestCase):
     def _run_reader_until_done(self, dw, data, timestamp=None, timestamp_value=0x55):
-        dut    = MACPacketReaderDUT(dw, depth=len(mac_packet_words(dw, data)), timestamp=timestamp)
+        return self._run_reader_until_done_with_fifo_depth(
+            dw              = dw,
+            data            = data,
+            fifo_depth      = 1,
+            timestamp       = timestamp,
+            timestamp_value = timestamp_value,
+        )
+
+    def _run_reader_until_done_with_fifo_depth(self, dw, data, fifo_depth, timestamp=None, timestamp_value=0x55):
+        dut    = MACPacketReaderDUT(dw, depth=len(mac_packet_words(dw, data)), fifo_depth=fifo_depth, timestamp=timestamp)
         result = {"data": [], "last_be": None, "done": False, "timeout": False}
         if timestamp is not None:
             result["timestamp"] = None
@@ -300,6 +383,80 @@ class TestMACPacketReader(unittest.TestCase):
                 self.assertEqual(result["data"], data)
                 self.assertEqual(result["last_be"], mac_packet_last_be(dw, len(data)))
                 self.assertTrue(result["done"])
+
+    def test_reader_zero_depth_packet_length_last_be_and_done(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                dut    = MACPacketReaderDUT(
+                    dw         = dw,
+                    depth      = len(mac_packet_words(dw, data)),
+                    fifo_depth = 0,
+                )
+                result = {"data": [], "last_be": None, "done": False, "timeout": False}
+
+                def generator(timeout=128):
+                    yield dut.packet.length.eq(len(data))
+                    yield dut.source.ready.eq(1)
+                    yield dut.packet.enable.eq(1)
+                    yield
+                    yield dut.packet.enable.eq(0)
+
+                    words = mac_packet_words(dw, data)
+                    for n, word in enumerate(words):
+                        last = n == len(words) - 1
+                        yield dut.packet.sink.data.eq(word)
+                        yield dut.packet.sink.last.eq(last)
+                        yield dut.packet.sink.valid.eq(1)
+                        for _ in range(timeout):
+                            yield
+                            if (yield dut.source.valid) and (yield dut.source.ready):
+                                source_last    = (yield dut.source.last)
+                                source_last_be = (yield dut.source.last_be)
+                                result["data"] += mac_packet_bytes(dw, (yield dut.source.data), source_last, source_last_be)
+                                if source_last:
+                                    result["last_be"] = source_last_be
+                            if (yield dut.packet.sink.ready):
+                                break
+                        else:
+                            result["timeout"] = True
+                            return
+
+                    yield dut.packet.sink.valid.eq(0)
+                    yield dut.packet.sink.last.eq(0)
+                    for _ in range(timeout):
+                        if (yield dut.packet.done):
+                            result["done"] = True
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["data"], data)
+                self.assertEqual(result["last_be"], mac_packet_last_be(dw, len(data)))
+                self.assertTrue(result["done"])
+
+    def test_reader_zero_depth_waits_for_enable(self):
+        for dw, data in mac_packet_test_cases(length=4):
+            with self.subTest(dw=dw):
+                dut    = MACPacketReaderDUT(dw, depth=len(mac_packet_words(dw, data)), fifo_depth=0)
+                result = {"ready": None, "source_valid": None, "done": None}
+
+                def generator():
+                    yield dut.packet.length.eq(len(data))
+                    yield dut.source.ready.eq(1)
+                    yield dut.packet.sink.data.eq(mac_packet_words(dw, data)[0])
+                    yield dut.packet.sink.last.eq(1)
+                    yield dut.packet.sink.valid.eq(1)
+                    yield
+                    result["ready"]        = (yield dut.packet.sink.ready)
+                    result["source_valid"] = (yield dut.source.valid)
+                    result["done"]         = (yield dut.packet.done)
+
+                run_simulation(dut, generator())
+                self.assertEqual(result["ready"], 0)
+                self.assertEqual(result["source_valid"], 0)
+                self.assertEqual(result["done"], 0)
 
     def test_reader_timestamp_updates(self):
         for dw, data in mac_packet_test_cases(length=8):

--- a/test/test_mac_packet.py
+++ b/test/test_mac_packet.py
@@ -1,0 +1,319 @@
+#
+# This file is part of LiteEth.
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+
+from migen import *
+
+from liteeth.common import eth_mtu_default
+from liteeth.mac.packet import LiteEthMACPacketWriter, LiteEthMACPacketReader
+
+# Helpers ------------------------------------------------------------------------------------------
+
+def mac_packet_last_be(dw, length):
+    return 1 << ((length - 1) % (dw//8))
+
+def mac_packet_words(dw, data):
+    words = []
+    for offset in range(0, len(data), dw//8):
+        word = 0
+        for byte, value in enumerate(data[offset:offset + dw//8]):
+            word |= value << (8*byte)
+        words.append(word)
+    return words
+
+def mac_packet_bytes(dw, word, last=0, last_be=0):
+    data = []
+    for byte in range(dw//8):
+        if last and 2**byte > last_be:
+            break
+        data.append((word >> (8*byte)) & 0xff)
+    return data
+
+def mac_packet_test_cases(length=10):
+    return [(dw, [n + 1 for n in range(length)]) for dw in [32, 64]]
+
+def wait_until(cond, timeout=128):
+    for _ in range(timeout):
+        if (yield from cond()):
+            return False
+        yield
+    return True
+
+def mac_packet_send(sink, dw, data, error=0):
+    words = mac_packet_words(dw, data)
+    for n, word in enumerate(words):
+        last = n == len(words) - 1
+        yield sink.data.eq(word)
+        yield sink.last.eq(last)
+        if hasattr(sink, "last_be"):
+            yield sink.last_be.eq(mac_packet_last_be(dw, len(data)) if last else 0)
+        if hasattr(sink, "error"):
+            yield sink.error.eq(error if last else 0)
+        yield sink.valid.eq(1)
+        yield
+        while not (yield sink.ready):
+            yield
+        yield sink.valid.eq(0)
+        yield sink.last.eq(0)
+        if hasattr(sink, "last_be"):
+            yield sink.last_be.eq(0)
+        if hasattr(sink, "error"):
+            yield sink.error.eq(0)
+        yield
+
+# DUT
+# -------------------------------------------------------------------------
+
+class MACPacketReaderDUT(Module):
+    def __init__(self, dw, depth, timestamp=None):
+        self.packet = LiteEthMACPacketReader(dw, depth, timestamp=timestamp)
+        self.submodules += self.packet
+        self.source = self.packet.source
+
+# Test MAC Packet Writer ---------------------------------------------------------------------------
+
+class TestMACPacketWriter(unittest.TestCase):
+    def _run_writer_drop_case(self, dw, data, eth_mtu, enable=1, error=0):
+        dut    = LiteEthMACPacketWriter(dw, depth=8, eth_mtu=eth_mtu)
+        result = {"drop": False, "error": None, "done": False, "source_valid": False, "timeout": False}
+
+        def generator(timeout=128):
+            yield dut.enable.eq(enable)
+            yield dut.source.ready.eq(1)
+            yield from mac_packet_send(dut.sink, dw, data, error=error)
+
+            for _ in range(timeout):
+                result["source_valid"] |= bool((yield dut.source.valid))
+                result["done"]         |= bool((yield dut.done))
+                if (yield dut.drop):
+                    result["drop"]  = True
+                    result["error"] = (yield dut.error)
+                    return
+                yield
+            result["timeout"] = True
+
+        run_simulation(dut, generator())
+        return result
+
+    def test_writer_good_packet(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                dut    = LiteEthMACPacketWriter(dw, depth=8, eth_mtu=eth_mtu_default)
+                result = {
+                    "data"        : [],
+                    "offsets"     : [],
+                    "write_count" : 0,
+                    "done"        : False,
+                    "length"      : None,
+                    "timeout"     : False,
+                }
+
+                def generator(timeout=128):
+                    yield dut.enable.eq(1)
+                    yield dut.source.ready.eq(0)
+                    yield from mac_packet_send(dut.sink, dw, data)
+                    yield dut.source.ready.eq(1)
+
+                    for _ in range(timeout):
+                        if (yield dut.source.valid) and (yield dut.source.ready):
+                            word    = (yield dut.source.data)
+                            result["data"] += mac_packet_bytes(dw, word)
+                            result["offsets"].append((yield dut.offset))
+                            result["write_count"] += 1
+                        if (yield dut.done):
+                            result["done"]   = True
+                            result["length"] = (yield dut.length)
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["data"][:len(data)], data)
+                self.assertEqual(result["offsets"], list(range(0, len(data), dw//8)))
+                self.assertEqual(result["write_count"], len(mac_packet_words(dw, data)))
+                self.assertTrue(result["done"])
+                self.assertEqual(result["length"], len(data))
+
+    def test_writer_disabled_packet_drops(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                result = self._run_writer_drop_case(
+                    dw      = dw,
+                    data    = data,
+                    eth_mtu = eth_mtu_default,
+                    enable  = 0,
+                    error   = 0,
+                )
+                self.assertFalse(result["timeout"])
+                self.assertTrue(result["drop"])
+                self.assertEqual(result["error"], 0)
+                self.assertFalse(result["done"])
+                self.assertFalse(result["source_valid"])
+
+    def test_writer_oversized_packet_drops_with_error(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                result = self._run_writer_drop_case(
+                    dw      = dw,
+                    data    = data,
+                    eth_mtu = len(data) - 1,
+                    enable  = 1,
+                    error   = 0,
+                )
+                self.assertFalse(result["timeout"])
+                self.assertTrue(result["drop"])
+                self.assertEqual(result["error"], 1)
+                self.assertFalse(result["done"])
+                self.assertTrue(result["source_valid"])
+
+    def test_writer_final_error_drops_with_error(self):
+        for dw, data in mac_packet_test_cases(length=6):
+            with self.subTest(dw=dw):
+                result = self._run_writer_drop_case(
+                    dw      = dw,
+                    data    = data,
+                    eth_mtu = eth_mtu_default,
+                    enable  = 1,
+                    error   = mac_packet_last_be(dw, len(data)),
+                )
+                self.assertFalse(result["timeout"])
+                self.assertTrue(result["drop"])
+                self.assertEqual(result["error"], 1)
+                self.assertFalse(result["done"])
+                self.assertTrue(result["source_valid"])
+
+    def test_writer_timestamp_updates(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                timestamp       = Signal(32)
+                timestamp_value = 0x22
+                dut             = LiteEthMACPacketWriter(dw, depth=8, eth_mtu=eth_mtu_default, timestamp=timestamp)
+                result          = {"timestamp": None, "timeout": False}
+
+                def generator(timeout=128):
+                    yield timestamp.eq(timestamp_value)
+                    yield dut.enable.eq(1)
+                    yield dut.source.ready.eq(0)
+                    yield from mac_packet_send(dut.sink, dw, data)
+
+                    yield dut.source.ready.eq(1)
+                    result["timeout"] = (yield from wait_until(lambda: (yield dut.source.valid), timeout=timeout))
+                    if result["timeout"]:
+                        return
+                    yield
+
+                    for _ in range(timeout):
+                        if (yield dut.done):
+                            result["timestamp"] = (yield dut.timestamp)
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["timestamp"], timestamp_value)
+
+# Test MAC Packet Reader ---------------------------------------------------------------------------
+
+class TestMACPacketReader(unittest.TestCase):
+    def _run_reader_until_done(self, dw, data, timestamp=None, timestamp_value=0x55):
+        dut    = MACPacketReaderDUT(dw, depth=8, timestamp=timestamp)
+        result = {"data": [], "last_be": None, "done": False, "timeout": False}
+        if timestamp is not None:
+            result["timestamp"] = None
+
+        def generator(timeout=128):
+            if timestamp is not None:
+                yield timestamp.eq(timestamp_value)
+            yield dut.packet.length.eq(len(data))
+            yield dut.source.ready.eq(0)
+            yield dut.packet.enable.eq(1)
+            yield
+            yield dut.packet.enable.eq(0)
+            yield from mac_packet_send(dut.packet.sink, dw, data)
+            yield dut.source.ready.eq(1)
+
+            for _ in range(timeout):
+                if (yield dut.source.valid) and (yield dut.source.ready):
+                    word    = (yield dut.source.data)
+                    last    = (yield dut.source.last)
+                    last_be = (yield dut.source.last_be)
+                    result["data"] += mac_packet_bytes(dw, word, last, last_be)
+                    if last:
+                        result["last_be"] = last_be
+                if (yield dut.packet.done):
+                    result["done"] = True
+                    if timestamp is not None:
+                        result["timestamp"] = (yield dut.packet.timestamp)
+                    return
+                yield
+            result["timeout"] = True
+
+        run_simulation(dut, generator())
+        return result
+
+    def test_reader_packet_length_last_be_and_done(self):
+        for dw, data in mac_packet_test_cases(length=10):
+            with self.subTest(dw=dw):
+                result = self._run_reader_until_done(
+                    dw   = dw,
+                    data = data,
+                )
+
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["data"], data)
+                self.assertEqual(result["last_be"], mac_packet_last_be(dw, len(data)))
+                self.assertTrue(result["done"])
+
+    def test_reader_timestamp_updates(self):
+        for dw, data in mac_packet_test_cases(length=8):
+            with self.subTest(dw=dw):
+                timestamp       = Signal(32)
+                timestamp_value = 0x55
+                result          = self._run_reader_until_done(
+                    dw              = dw,
+                    data            = data,
+                    timestamp       = timestamp,
+                    timestamp_value = timestamp_value,
+                )
+
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["timestamp"], timestamp_value)
+
+    def test_reader_done_waits_for_final_source_accept(self):
+        for dw, data in mac_packet_test_cases(length=4):
+            with self.subTest(dw=dw):
+                dut    = MACPacketReaderDUT(dw, depth=4)
+                result = {"done_before_ready": False, "done_after_ready": False, "timeout": False}
+
+                def generator(timeout=128):
+                    yield dut.packet.length.eq(len(data))
+                    yield dut.source.ready.eq(0)
+                    yield dut.packet.enable.eq(1)
+                    yield
+                    yield dut.packet.enable.eq(0)
+                    yield from mac_packet_send(dut.packet.sink, dw, data)
+
+                    result["timeout"] = (yield from wait_until(lambda: (yield dut.source.valid) and (yield dut.source.last), timeout=timeout))
+                    if result["timeout"]:
+                        return
+                    for _ in range(4):
+                        result["done_before_ready"] |= bool((yield dut.packet.done))
+                        yield
+
+                    yield dut.source.ready.eq(1)
+                    for _ in range(16):
+                        if (yield dut.packet.done):
+                            result["done_after_ready"] = True
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
+                self.assertFalse(result["timeout"])
+                self.assertFalse(result["done_before_ready"])
+                self.assertTrue(result["done_after_ready"])

--- a/test/test_mac_packet.py
+++ b/test/test_mac_packet.py
@@ -7,7 +7,10 @@ import unittest
 
 from migen import *
 
-from liteeth.common import eth_mtu_default
+from litex.soc.interconnect import stream
+
+from liteeth.common import eth_mtu_default, eth_phy_description
+from liteeth.mac import LiteEthMACPacketFIFOs
 from liteeth.mac.packet import LiteEthMACPacketWriter, LiteEthMACPacketReader
 
 # Helpers ------------------------------------------------------------------------------------------
@@ -68,10 +71,138 @@ def mac_packet_send(sink, dw, data, error=0):
 # -------------------------------------------------------------------------
 
 class MACPacketReaderDUT(Module):
-    def __init__(self, dw, depth, fifo_depth=1, timestamp=None):
-        self.packet = LiteEthMACPacketReader(dw, depth, fifo_depth=fifo_depth, timestamp=timestamp)
+    def __init__(self, dw, depth, timestamp=None):
+        self.packet = LiteEthMACPacketReader(dw, depth, timestamp=timestamp)
         self.submodules += self.packet
         self.source = self.packet.source
+
+class MACPacketFIFOInterface:
+    pass
+
+class MACPacketFIFOsDUT(Module):
+    def __init__(self, dw, depth, rx_fifo_depth=0, tx_fifo_depth=0):
+        self.interface        = interface = MACPacketFIFOInterface()
+        self.interface.sink   = stream.Endpoint(eth_phy_description(dw))
+        self.interface.source = stream.Endpoint(eth_phy_description(dw))
+        self.fifos = LiteEthMACPacketFIFOs(interface, dw, depth,
+            rx_fifo_depth = rx_fifo_depth,
+            tx_fifo_depth = tx_fifo_depth,
+        )
+        self.submodules += self.fifos
+
+def mac_packet_writer_send(dut, dw, data, result=None, error=0, timeout=128):
+    words = mac_packet_words(dw, data)
+    for n, word in enumerate(words):
+        last = n == len(words) - 1
+        yield dut.sink.data.eq(word)
+        yield dut.sink.last.eq(last)
+        yield dut.sink.last_be.eq(mac_packet_last_be(dw, len(data)) if last else 0)
+        yield dut.sink.error.eq(error if last else 0)
+        yield dut.sink.valid.eq(1)
+        for _ in range(timeout):
+            yield
+            if result is not None:
+                if "source_valid" in result:
+                    result["source_valid"] |= bool((yield dut.source.valid))
+                if (yield dut.source.valid) and (yield dut.source.ready):
+                    if "data" in result:
+                        result["data"] += mac_packet_bytes(dw, (yield dut.source.data))
+                    if "offsets" in result:
+                        result["offsets"].append((yield dut.offset))
+                    if "write_count" in result:
+                        result["write_count"] += 1
+            if (yield dut.sink.ready):
+                break
+        else:
+            if result is not None:
+                result["timeout"] = True
+            return
+
+    yield dut.sink.valid.eq(0)
+    yield dut.sink.last.eq(0)
+    yield dut.sink.last_be.eq(0)
+    yield dut.sink.error.eq(0)
+    yield
+
+# Test MAC Packet FIFOs ---------------------------------------------------------------------------
+
+class TestMACPacketFIFOs(unittest.TestCase):
+    def test_rx_fifo_buffers_packet(self):
+        dw     = 32
+        data   = [n + 1 for n in range(10)]
+        depth  = len(mac_packet_words(dw, data))
+        dut    = MACPacketFIFOsDUT(dw, depth, rx_fifo_depth=1)
+        result = {"accepted": 0, "data": [], "last_be": None, "timeout": False}
+
+        def generator(timeout=128):
+            yield dut.interface.sink.ready.eq(0)
+
+            words = mac_packet_words(dw, data)
+            for n, word in enumerate(words):
+                last = n == len(words) - 1
+                yield dut.fifos.sink.data.eq(word)
+                yield dut.fifos.sink.last.eq(last)
+                yield dut.fifos.sink.last_be.eq(mac_packet_last_be(dw, len(data)) if last else 0)
+                yield dut.fifos.sink.error.eq(0)
+                yield dut.fifos.sink.valid.eq(1)
+                for _ in range(timeout):
+                    yield
+                    if (yield dut.fifos.sink.ready):
+                        result["accepted"] += 1
+                        break
+                else:
+                    result["timeout"] = True
+                    return
+
+            yield dut.fifos.sink.valid.eq(0)
+            yield dut.fifos.sink.last.eq(0)
+            yield dut.fifos.sink.last_be.eq(0)
+            yield dut.interface.sink.ready.eq(1)
+
+            for _ in range(timeout):
+                if (yield dut.interface.sink.valid) and (yield dut.interface.sink.ready):
+                    last    = (yield dut.interface.sink.last)
+                    last_be = (yield dut.interface.sink.last_be)
+                    result["data"] += mac_packet_bytes(dw, (yield dut.interface.sink.data), last, last_be)
+                    if last:
+                        result["last_be"] = last_be
+                        return
+                yield
+            result["timeout"] = True
+
+        run_simulation(dut, generator())
+        self.assertFalse(result["timeout"])
+        self.assertEqual(result["accepted"], depth)
+        self.assertEqual(result["data"], data)
+        self.assertEqual(result["last_be"], mac_packet_last_be(dw, len(data)))
+
+    def test_tx_fifo_buffers_packet(self):
+        dw     = 32
+        data   = [n + 1 for n in range(10)]
+        depth  = len(mac_packet_words(dw, data))
+        dut    = MACPacketFIFOsDUT(dw, depth, tx_fifo_depth=1)
+        result = {"data": [], "last_be": None, "timeout": False}
+
+        def generator(timeout=128):
+            yield dut.fifos.source.ready.eq(0)
+            yield from mac_packet_send(dut.interface.source, dw, data)
+            yield dut.fifos.source.ready.eq(1)
+
+            for _ in range(timeout):
+                if (yield dut.fifos.source.valid) and (yield dut.fifos.source.ready):
+                    last    = (yield dut.fifos.source.last)
+                    last_be = (yield dut.fifos.source.last_be)
+                    result["data"] += mac_packet_bytes(dw, (yield dut.fifos.source.data), last, last_be)
+                    if last:
+                        result["last_be"] = last_be
+                        return
+                yield
+            result["timeout"] = True
+
+        run_simulation(dut, generator())
+        self.assertFalse(result["timeout"])
+        self.assertEqual(result["data"], data)
+        self.assertEqual(result["last_be"], mac_packet_last_be(dw, len(data)))
 
 # Test MAC Packet Writer ---------------------------------------------------------------------------
 
@@ -83,7 +214,9 @@ class TestMACPacketWriter(unittest.TestCase):
         def generator(timeout=128):
             yield dut.enable.eq(enable)
             yield dut.source.ready.eq(1)
-            yield from mac_packet_send(dut.sink, dw, data, error=error)
+            yield from mac_packet_writer_send(dut, dw, data, result=result, error=error)
+            if result["timeout"]:
+                return
 
             for _ in range(timeout):
                 result["source_valid"] |= bool((yield dut.source.valid))
@@ -113,16 +246,12 @@ class TestMACPacketWriter(unittest.TestCase):
 
                 def generator(timeout=128):
                     yield dut.enable.eq(1)
-                    yield dut.source.ready.eq(0)
-                    yield from mac_packet_send(dut.sink, dw, data)
                     yield dut.source.ready.eq(1)
+                    yield from mac_packet_writer_send(dut, dw, data, result=result)
+                    if result["timeout"]:
+                        return
 
                     for _ in range(timeout):
-                        if (yield dut.source.valid) and (yield dut.source.ready):
-                            word    = (yield dut.source.data)
-                            result["data"] += mac_packet_bytes(dw, word)
-                            result["offsets"].append((yield dut.offset))
-                            result["write_count"] += 1
                         if (yield dut.done):
                             result["done"]   = True
                             result["length"] = (yield dut.length)
@@ -138,44 +267,23 @@ class TestMACPacketWriter(unittest.TestCase):
                 self.assertTrue(result["done"])
                 self.assertEqual(result["length"], len(data))
 
-    def test_writer_zero_depth_good_packet(self):
+    def test_writer_direct_good_packet(self):
         for dw, data in mac_packet_test_cases(length=10):
             with self.subTest(dw=dw):
                 dut    = LiteEthMACPacketWriter(
-                    dw         = dw,
-                    depth      = len(mac_packet_words(dw, data)),
-                    eth_mtu    = eth_mtu_default,
-                    fifo_depth = 0,
+                    dw      = dw,
+                    depth   = len(mac_packet_words(dw, data)),
+                    eth_mtu = eth_mtu_default,
                 )
-                result = {"data": [], "done": False, "length": None, "timeout": False}
+                result = {"data": [], "done": False, "length": None, "source_valid": False, "timeout": False}
 
                 def generator(timeout=128):
                     yield dut.enable.eq(1)
                     yield dut.source.ready.eq(1)
-                    words = mac_packet_words(dw, data)
-                    for n, word in enumerate(words):
-                        last = n == len(words) - 1
-                        yield dut.sink.data.eq(word)
-                        yield dut.sink.last.eq(last)
-                        yield dut.sink.last_be.eq(mac_packet_last_be(dw, len(data)) if last else 0)
-                        yield dut.sink.error.eq(0)
-                        yield dut.sink.valid.eq(1)
-                        for _ in range(timeout):
-                            yield
-                            if (yield dut.source.valid) and (yield dut.source.ready):
-                                result["data"] += mac_packet_bytes(dw, (yield dut.source.data))
-                            if (yield dut.sink.ready):
-                                break
-                        else:
-                            result["timeout"] = True
-                            return
-
-                    yield dut.sink.valid.eq(0)
-                    yield dut.sink.last.eq(0)
-                    yield dut.sink.last_be.eq(0)
+                    yield from mac_packet_writer_send(dut, dw, data, result=result)
+                    if result["timeout"]:
+                        return
                     for _ in range(timeout):
-                        if (yield dut.source.valid) and (yield dut.source.ready):
-                            result["data"] += mac_packet_bytes(dw, (yield dut.source.data))
                         if (yield dut.done):
                             result["done"]   = True
                             result["length"] = (yield dut.length)
@@ -189,10 +297,10 @@ class TestMACPacketWriter(unittest.TestCase):
                 self.assertTrue(result["done"])
                 self.assertEqual(result["length"], len(data))
 
-    def test_writer_zero_depth_disabled_backpressures(self):
+    def test_writer_disabled_backpressures(self):
         for dw, _ in mac_packet_test_cases(length=4):
             with self.subTest(dw=dw):
-                dut    = LiteEthMACPacketWriter(dw, depth=4, eth_mtu=eth_mtu_default, fifo_depth=0)
+                dut    = LiteEthMACPacketWriter(dw, depth=4, eth_mtu=eth_mtu_default)
                 result = {"ready": None, "source_valid": None, "drop": None}
 
                 def generator():
@@ -219,7 +327,6 @@ class TestMACPacketWriter(unittest.TestCase):
                     dw                 = dw,
                     depth              = len(mac_packet_words(dw, data)),
                     eth_mtu            = eth_mtu_default,
-                    fifo_depth         = 0,
                     drop_when_disabled = True,
                 )
                 result = {
@@ -278,7 +385,7 @@ class TestMACPacketWriter(unittest.TestCase):
                     "data"             : [],
                     "done"             : False,
                     "drop"             : False,
-                    "source_valid"     : False,
+                    "source_valid_before_enable": False,
                     "backpressured"    : False,
                     "length"           : None,
                     "timeout"          : False,
@@ -287,19 +394,24 @@ class TestMACPacketWriter(unittest.TestCase):
                 def generator(timeout=128):
                     yield dut.enable.eq(0)
                     yield dut.source.ready.eq(1)
-                    yield from mac_packet_send(dut.sink, dw, data)
+                    words = mac_packet_words(dw, data)
+                    yield dut.sink.data.eq(words[0])
+                    yield dut.sink.last.eq(len(words) == 1)
+                    yield dut.sink.last_be.eq(mac_packet_last_be(dw, len(data)) if len(words) == 1 else 0)
+                    yield dut.sink.valid.eq(1)
 
                     for _ in range(4):
-                        result["source_valid"]  |= bool((yield dut.source.valid))
-                        result["drop"]          |= bool((yield dut.drop))
-                        result["done"]          |= bool((yield dut.done))
-                        result["backpressured"] |= not bool((yield dut.sink.ready))
+                        result["source_valid_before_enable"] |= bool((yield dut.source.valid))
+                        result["drop"]                       |= bool((yield dut.drop))
+                        result["done"]                       |= bool((yield dut.done))
+                        result["backpressured"]              |= not bool((yield dut.sink.ready))
                         yield
 
                     yield dut.enable.eq(1)
+                    yield from mac_packet_writer_send(dut, dw, data, result=result)
+                    if result["timeout"]:
+                        return
                     for _ in range(timeout):
-                        if (yield dut.source.valid) and (yield dut.source.ready):
-                            result["data"] += mac_packet_bytes(dw, (yield dut.source.data))
                         if (yield dut.drop):
                             result["drop"] = True
                         if (yield dut.done):
@@ -311,7 +423,7 @@ class TestMACPacketWriter(unittest.TestCase):
 
                 run_simulation(dut, generator())
                 self.assertFalse(result["timeout"])
-                self.assertFalse(result["source_valid"])
+                self.assertFalse(result["source_valid_before_enable"])
                 self.assertFalse(result["drop"])
                 self.assertTrue(result["backpressured"])
                 self.assertTrue(result["done"])
@@ -361,21 +473,12 @@ class TestMACPacketWriter(unittest.TestCase):
                 def generator(timeout=128):
                     yield timestamp.eq(timestamp_value)
                     yield dut.enable.eq(1)
-                    yield dut.source.ready.eq(0)
-                    yield from mac_packet_send(dut.sink, dw, data)
-
                     yield dut.source.ready.eq(1)
-                    result["timeout"] = (yield from wait_until(lambda: (yield dut.source.valid), timeout=timeout))
+                    yield from mac_packet_writer_send(dut, dw, data)
+                    result["timeout"] = (yield from wait_until(lambda: (yield dut.done), timeout=timeout))
                     if result["timeout"]:
                         return
-                    yield
-
-                    for _ in range(timeout):
-                        if (yield dut.done):
-                            result["timestamp"] = (yield dut.timestamp)
-                            return
-                        yield
-                    result["timeout"] = True
+                    result["timestamp"] = (yield dut.timestamp)
 
                 run_simulation(dut, generator())
                 self.assertFalse(result["timeout"])
@@ -385,16 +488,7 @@ class TestMACPacketWriter(unittest.TestCase):
 
 class TestMACPacketReader(unittest.TestCase):
     def _run_reader_until_done(self, dw, data, timestamp=None, timestamp_value=0x55):
-        return self._run_reader_until_done_with_fifo_depth(
-            dw              = dw,
-            data            = data,
-            fifo_depth      = 1,
-            timestamp       = timestamp,
-            timestamp_value = timestamp_value,
-        )
-
-    def _run_reader_until_done_with_fifo_depth(self, dw, data, fifo_depth, timestamp=None, timestamp_value=0x55):
-        dut    = MACPacketReaderDUT(dw, depth=len(mac_packet_words(dw, data)), fifo_depth=fifo_depth, timestamp=timestamp)
+        dut    = MACPacketReaderDUT(dw, depth=len(mac_packet_words(dw, data)), timestamp=timestamp)
         result = {"data": [], "last_be": None, "done": False, "timeout": False}
         if timestamp is not None:
             result["timestamp"] = None
@@ -403,21 +497,34 @@ class TestMACPacketReader(unittest.TestCase):
             if timestamp is not None:
                 yield timestamp.eq(timestamp_value)
             yield dut.packet.length.eq(len(data))
-            yield dut.source.ready.eq(0)
+            yield dut.source.ready.eq(1)
             yield dut.packet.enable.eq(1)
             yield
             yield dut.packet.enable.eq(0)
-            yield from mac_packet_send(dut.packet.sink, dw, data)
-            yield dut.source.ready.eq(1)
 
+            words = mac_packet_words(dw, data)
+            for n, word in enumerate(words):
+                last = n == len(words) - 1
+                yield dut.packet.sink.data.eq(word)
+                yield dut.packet.sink.last.eq(last)
+                yield dut.packet.sink.valid.eq(1)
+                for _ in range(timeout):
+                    yield
+                    if (yield dut.source.valid) and (yield dut.source.ready):
+                        source_last    = (yield dut.source.last)
+                        source_last_be = (yield dut.source.last_be)
+                        result["data"] += mac_packet_bytes(dw, (yield dut.source.data), source_last, source_last_be)
+                        if source_last:
+                            result["last_be"] = source_last_be
+                    if (yield dut.packet.sink.ready):
+                        break
+                else:
+                    result["timeout"] = True
+                    return
+
+            yield dut.packet.sink.valid.eq(0)
+            yield dut.packet.sink.last.eq(0)
             for _ in range(timeout):
-                if (yield dut.source.valid) and (yield dut.source.ready):
-                    word    = (yield dut.source.data)
-                    last    = (yield dut.source.last)
-                    last_be = (yield dut.source.last_be)
-                    result["data"] += mac_packet_bytes(dw, word, last, last_be)
-                    if last:
-                        result["last_be"] = last_be
                 if (yield dut.packet.done):
                     result["done"] = True
                     if timestamp is not None:
@@ -442,13 +549,12 @@ class TestMACPacketReader(unittest.TestCase):
                 self.assertEqual(result["last_be"], mac_packet_last_be(dw, len(data)))
                 self.assertTrue(result["done"])
 
-    def test_reader_zero_depth_packet_length_last_be_and_done(self):
+    def test_reader_direct_packet_length_last_be_and_done(self):
         for dw, data in mac_packet_test_cases(length=10):
             with self.subTest(dw=dw):
                 dut    = MACPacketReaderDUT(
-                    dw         = dw,
-                    depth      = len(mac_packet_words(dw, data)),
-                    fifo_depth = 0,
+                    dw    = dw,
+                    depth = len(mac_packet_words(dw, data)),
                 )
                 result = {"data": [], "last_be": None, "done": False, "timeout": False}
 
@@ -494,10 +600,10 @@ class TestMACPacketReader(unittest.TestCase):
                 self.assertEqual(result["last_be"], mac_packet_last_be(dw, len(data)))
                 self.assertTrue(result["done"])
 
-    def test_reader_zero_depth_waits_for_enable(self):
+    def test_reader_waits_for_enable(self):
         for dw, data in mac_packet_test_cases(length=4):
             with self.subTest(dw=dw):
-                dut    = MACPacketReaderDUT(dw, depth=len(mac_packet_words(dw, data)), fifo_depth=0)
+                dut    = MACPacketReaderDUT(dw, depth=len(mac_packet_words(dw, data)))
                 result = {"ready": None, "source_valid": None, "done": None}
 
                 def generator():
@@ -540,25 +646,34 @@ class TestMACPacketReader(unittest.TestCase):
                 def generator(timeout=128):
                     nwords = len(mac_packet_words(dw, data))
                     yield dut.packet.length.eq(len(data))
-                    yield dut.source.ready.eq(0)
+                    yield dut.source.ready.eq(1)
                     yield dut.packet.enable.eq(1)
                     yield
                     yield dut.packet.enable.eq(0)
-                    yield from mac_packet_send(dut.packet.sink, dw, data)
 
-                    if nwords > 1:
-                        yield dut.source.ready.eq(1)
-                        accepted = 0
+                    words = mac_packet_words(dw, data)
+                    for n, word in enumerate(words):
+                        last = n == nwords - 1
+                        yield dut.packet.sink.data.eq(word)
+                        yield dut.packet.sink.last.eq(last)
+                        yield dut.packet.sink.valid.eq(1)
+                        if last:
+                            yield dut.source.ready.eq(0)
                         for _ in range(timeout):
-                            if (yield dut.source.valid) and (yield dut.source.ready):
-                                accepted += 1
-                                if accepted == nwords - 1:
-                                    yield dut.source.ready.eq(0)
-                                    break
                             yield
-                        if accepted != nwords - 1:
+                            if (yield dut.packet.sink.ready):
+                                break
+                            if last:
+                                result["done_before_ready"] |= bool((yield dut.packet.done))
+                                if (yield dut.source.valid) and (yield dut.source.last):
+                                    break
+                        else:
                             result["timeout"] = True
                             return
+
+                        if last:
+                            yield
+                            break
 
                     result["timeout"] = (yield from wait_until(lambda: (yield dut.source.valid) and (yield dut.source.last), timeout=timeout))
                     if result["timeout"]:

--- a/test/test_mac_packet.py
+++ b/test/test_mac_packet.py
@@ -33,7 +33,7 @@ def mac_packet_bytes(dw, word, last=0, last_be=0):
     return data
 
 def mac_packet_test_cases(length=10):
-    return [(dw, [n + 1 for n in range(length)]) for dw in [32, 64]]
+    return [(dw, [n + 1 for n in range(length)]) for dw in [8, 16, 32, 64]]
 
 def wait_until(cond, timeout=128):
     for _ in range(timeout):
@@ -77,7 +77,7 @@ class MACPacketReaderDUT(Module):
 
 class TestMACPacketWriter(unittest.TestCase):
     def _run_writer_drop_case(self, dw, data, eth_mtu, enable=1, error=0):
-        dut    = LiteEthMACPacketWriter(dw, depth=8, eth_mtu=eth_mtu)
+        dut    = LiteEthMACPacketWriter(dw, depth=len(mac_packet_words(dw, data)), eth_mtu=eth_mtu)
         result = {"drop": False, "error": None, "done": False, "source_valid": False, "timeout": False}
 
         def generator(timeout=128):
@@ -101,7 +101,7 @@ class TestMACPacketWriter(unittest.TestCase):
     def test_writer_good_packet(self):
         for dw, data in mac_packet_test_cases(length=10):
             with self.subTest(dw=dw):
-                dut    = LiteEthMACPacketWriter(dw, depth=8, eth_mtu=eth_mtu_default)
+                dut    = LiteEthMACPacketWriter(dw, depth=len(mac_packet_words(dw, data)), eth_mtu=eth_mtu_default)
                 result = {
                     "data"        : [],
                     "offsets"     : [],
@@ -138,21 +138,53 @@ class TestMACPacketWriter(unittest.TestCase):
                 self.assertTrue(result["done"])
                 self.assertEqual(result["length"], len(data))
 
-    def test_writer_disabled_packet_drops(self):
-        for dw, data in mac_packet_test_cases(length=10):
+    def test_writer_disabled_backpressures_until_enabled(self):
+        for dw, data in mac_packet_test_cases(length=4):
             with self.subTest(dw=dw):
-                result = self._run_writer_drop_case(
-                    dw      = dw,
-                    data    = data,
-                    eth_mtu = eth_mtu_default,
-                    enable  = 0,
-                    error   = 0,
-                )
+                dut    = LiteEthMACPacketWriter(dw, depth=len(mac_packet_words(dw, data)), eth_mtu=eth_mtu_default)
+                result = {
+                    "data"             : [],
+                    "done"             : False,
+                    "drop"             : False,
+                    "source_valid"     : False,
+                    "backpressured"    : False,
+                    "length"           : None,
+                    "timeout"          : False,
+                }
+
+                def generator(timeout=128):
+                    yield dut.enable.eq(0)
+                    yield dut.source.ready.eq(1)
+                    yield from mac_packet_send(dut.sink, dw, data)
+
+                    for _ in range(4):
+                        result["source_valid"]  |= bool((yield dut.source.valid))
+                        result["drop"]          |= bool((yield dut.drop))
+                        result["done"]          |= bool((yield dut.done))
+                        result["backpressured"] |= not bool((yield dut.sink.ready))
+                        yield
+
+                    yield dut.enable.eq(1)
+                    for _ in range(timeout):
+                        if (yield dut.source.valid) and (yield dut.source.ready):
+                            result["data"] += mac_packet_bytes(dw, (yield dut.source.data))
+                        if (yield dut.drop):
+                            result["drop"] = True
+                        if (yield dut.done):
+                            result["done"]   = True
+                            result["length"] = (yield dut.length)
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
                 self.assertFalse(result["timeout"])
-                self.assertTrue(result["drop"])
-                self.assertEqual(result["error"], 0)
-                self.assertFalse(result["done"])
                 self.assertFalse(result["source_valid"])
+                self.assertFalse(result["drop"])
+                self.assertTrue(result["backpressured"])
+                self.assertTrue(result["done"])
+                self.assertEqual(result["length"], len(data))
+                self.assertEqual(result["data"][:len(data)], data)
 
     def test_writer_oversized_packet_drops_with_error(self):
         for dw, data in mac_packet_test_cases(length=10):
@@ -191,7 +223,7 @@ class TestMACPacketWriter(unittest.TestCase):
             with self.subTest(dw=dw):
                 timestamp       = Signal(32)
                 timestamp_value = 0x22
-                dut             = LiteEthMACPacketWriter(dw, depth=8, eth_mtu=eth_mtu_default, timestamp=timestamp)
+                dut             = LiteEthMACPacketWriter(dw, depth=len(mac_packet_words(dw, data)), eth_mtu=eth_mtu_default, timestamp=timestamp)
                 result          = {"timestamp": None, "timeout": False}
 
                 def generator(timeout=128):
@@ -221,7 +253,7 @@ class TestMACPacketWriter(unittest.TestCase):
 
 class TestMACPacketReader(unittest.TestCase):
     def _run_reader_until_done(self, dw, data, timestamp=None, timestamp_value=0x55):
-        dut    = MACPacketReaderDUT(dw, depth=8, timestamp=timestamp)
+        dut    = MACPacketReaderDUT(dw, depth=len(mac_packet_words(dw, data)), timestamp=timestamp)
         result = {"data": [], "last_be": None, "done": False, "timeout": False}
         if timestamp is not None:
             result["timestamp"] = None
@@ -287,16 +319,31 @@ class TestMACPacketReader(unittest.TestCase):
     def test_reader_done_waits_for_final_source_accept(self):
         for dw, data in mac_packet_test_cases(length=4):
             with self.subTest(dw=dw):
-                dut    = MACPacketReaderDUT(dw, depth=4)
+                dut    = MACPacketReaderDUT(dw, depth=len(mac_packet_words(dw, data)))
                 result = {"done_before_ready": False, "done_after_ready": False, "timeout": False}
 
                 def generator(timeout=128):
+                    nwords = len(mac_packet_words(dw, data))
                     yield dut.packet.length.eq(len(data))
                     yield dut.source.ready.eq(0)
                     yield dut.packet.enable.eq(1)
                     yield
                     yield dut.packet.enable.eq(0)
                     yield from mac_packet_send(dut.packet.sink, dw, data)
+
+                    if nwords > 1:
+                        yield dut.source.ready.eq(1)
+                        accepted = 0
+                        for _ in range(timeout):
+                            if (yield dut.source.valid) and (yield dut.source.ready):
+                                accepted += 1
+                                if accepted == nwords - 1:
+                                    yield dut.source.ready.eq(0)
+                                    break
+                            yield
+                        if accepted != nwords - 1:
+                            result["timeout"] = True
+                            return
 
                     result["timeout"] = (yield from wait_until(lambda: (yield dut.source.valid) and (yield dut.source.last), timeout=timeout))
                     if result["timeout"]:

--- a/test/test_mac_packet.py
+++ b/test/test_mac_packet.py
@@ -212,6 +212,64 @@ class TestMACPacketWriter(unittest.TestCase):
                 self.assertEqual(result["source_valid"], 0)
                 self.assertEqual(result["drop"], 0)
 
+    def test_writer_drop_when_disabled_discards_without_backpressure(self):
+        for dw, data in mac_packet_test_cases(length=4):
+            with self.subTest(dw=dw):
+                dut    = LiteEthMACPacketWriter(
+                    dw                 = dw,
+                    depth              = len(mac_packet_words(dw, data)),
+                    eth_mtu            = eth_mtu_default,
+                    fifo_depth         = 0,
+                    drop_when_disabled = True,
+                )
+                result = {
+                    "accepted"     : 0,
+                    "source_valid" : False,
+                    "done"         : False,
+                    "drop"         : False,
+                    "timeout"      : False,
+                }
+
+                def generator(timeout=128):
+                    yield dut.enable.eq(0)
+                    yield dut.source.ready.eq(1)
+
+                    words = mac_packet_words(dw, data)
+                    for n, word in enumerate(words):
+                        last = n == len(words) - 1
+                        yield dut.sink.data.eq(word)
+                        yield dut.sink.last.eq(last)
+                        yield dut.sink.last_be.eq(mac_packet_last_be(dw, len(data)) if last else 0)
+                        yield dut.sink.error.eq(0)
+                        yield dut.sink.valid.eq(1)
+                        yield
+                        result["source_valid"] |= bool((yield dut.source.valid))
+                        result["done"]         |= bool((yield dut.done))
+                        if (yield dut.sink.ready):
+                            result["accepted"] += 1
+                        else:
+                            result["timeout"] = True
+                            return
+
+                    yield dut.sink.valid.eq(0)
+                    yield dut.sink.last.eq(0)
+                    yield dut.sink.last_be.eq(0)
+                    for _ in range(timeout):
+                        result["source_valid"] |= bool((yield dut.source.valid))
+                        result["done"]         |= bool((yield dut.done))
+                        if (yield dut.drop):
+                            result["drop"] = True
+                            return
+                        yield
+                    result["timeout"] = True
+
+                run_simulation(dut, generator())
+                self.assertFalse(result["timeout"])
+                self.assertEqual(result["accepted"], len(mac_packet_words(dw, data)))
+                self.assertFalse(result["source_valid"])
+                self.assertFalse(result["done"])
+                self.assertTrue(result["drop"])
+
     def test_writer_disabled_backpressures_until_enabled(self):
         for dw, data in mac_packet_test_cases(length=4):
             with self.subTest(dw=dw):


### PR DESCRIPTION
This is a fresh, focused follow-up to #204, based on original packet FIFO/backpressure work from Inochi Amaoto. The original contributor branch cannot be updated directly (`maintainer_can_modify=false`), so this keeps the useful pieces on an enjoy-digital branch while preserving credit in the original commits.

The latest version also follows the review direction from @inochisa: the optional complete-packet FIFOs are owned by `LiteEthMAC` at the Wishbone/Hybrid MAC boundary, not by the low-level SRAM packet reader/writer helpers. The SRAM helpers are direct packet frontends again; they keep the slot/status/drop/memory policy, while FIFO elasticity is a MAC-level configuration choice.

## Improvements vs current master

- The SRAM RX/TX packet boundary logic is factored into explicit `LiteEthMACPacketWriter` / `LiteEthMACPacketReader` frontends, making length, `last_be`, MTU/error, timestamp, completion, drop, and disabled-path handling testable in isolation.
- The default Wishbone/Hybrid SRAM path keeps `rx_fifo_depth=0` / `tx_fifo_depth=0`, so current users do not pay for complete-packet FIFO payload memories.
- With the default `rx_fifo_depth=0`, RX keeps the master-compatible behavior: if no status FIFO slot is available, the packet is consumed/dropped and reported as a drop instead of propagating non-actionable backpressure into the Ethernet RX stream without any internal packet storage.
- With `rx_fifo_depth > 0`, `LiteEthMAC` inserts an RX `PacketFIFO` before the SRAM writer. The SRAM writer can then hold when no status slot is available, and the MAC-level FIFO provides the actual complete-packet elasticity/backpressure.
- With `tx_fifo_depth > 0`, `LiteEthMAC` inserts a TX `PacketFIFO` between the SRAM reader and MAC core.
- The public configuration names use the shorter direction+FIFO style already used by LiteEth stream frontends: `rx_fifo_depth` / `tx_fifo_depth`.
- Packet frontend and wrapper regressions now cover 8/16/32/64-bit datapaths, good packets, oversize/error drops, disabled/drop behavior, disabled/hold behavior, reader `last_be`/`done`, timestamp capture, direct zero-depth mode, and the MAC-boundary FIFO wrapper.

## CSR/Linux Compatibility

I checked the default Wishbone MAC configuration used by the existing tests against `origin/master` (`79b908f`) and this PR head (`bce752c`). The CSR ABI is unchanged.

`LiteEthMAC(..., interface="wishbone", dw=32, with_preamble_crc=True)` reports the same `get_csrs()` list on both revisions:

```text
0  sram_writer_slot                 CSRStatus   1
1  sram_writer_length               CSRStatus   11
2  sram_writer_errors               CSRStatus   32
3  sram_writer_ev_status            CSRStatus   1
4  sram_writer_ev_pending           CSRStatus   1
5  sram_writer_ev_enable            CSRStorage  1
6  sram_reader_start                CSR         1
7  sram_reader_ready                CSRStatus   1
8  sram_reader_level                CSRStatus   2
9  sram_reader_slot                 CSRStorage  1
10 sram_reader_length               CSRStorage  11
11 sram_reader_ev_status            CSRStatus   1
12 sram_reader_ev_pending           CSRStatus   1
13 sram_reader_ev_enable            CSRStorage  1
14 preamble_crc                     CSRStatus   1
15 rx_datapath_preamble_errors      CSRStatus   32
16 rx_datapath_crc_errors           CSRStatus   32
```

The constants are also unchanged:

```text
rx_slots  = 2
tx_slots  = 2
slot_size = 2048
```

No new CSR or EventManager is added by the packet frontends or by the optional packet FIFO wrapper. The new packet FIFO controls are Python constructor parameters only, so the default Linux/software-visible CSR layout stays compatible.

## Credit

- `fd9db31 core: add packet fifo support to SRAM interface` authored by Inochi Amaoto;
- `f72302e test: add test for packet reader/writer` authored by Inochi Amaoto;
- `bce752c mac: move packet FIFOs to MAC boundary` follows @inochisa's review feedback by moving the optional FIFO policy out of the SRAM packet helpers and into `LiteEthMAC`.

## Arty Implementation Check

`digilent_arty`, 32-bit Wishbone MAC harness, Vivado 2024.1. The harness touches both RX/TX SRAM slots so the numbers are comparable.

| Variant | LUTs | FFs | LUT RAM | BRAM tiles | WNS |
|---|---:|---:|---:|---:|---:|
| master (`79b908f`) | 392 | 460 | 6 | 5 | 1.215 ns |
| this PR (`bce752c`), default `rx_fifo_depth=0`, `tx_fifo_depth=0` | 435 | 463 | 6 | 5 | 1.215 ns |
| this PR (`bce752c`), `rx_fifo_depth=1`, `tx_fifo_depth=1` | 1310 | 539 | 606 | 5 | 1.236 ns |

So the default configuration adds a small amount of packet-control logic (`+43` LUTs, `+3` FFs in this harness) but no extra LUT RAM or BRAM, and the default generated hierarchy does not instantiate `LiteEthMACPacketFIFOs`. The large LUT RAM increase appears only when complete-packet FIFOs are explicitly enabled, as expected from the two MTU-sized `PacketFIFO` payload memories.

## Tested

- `python3 -m unittest test.test_mac_packet`
- `python3 -m unittest test.test_mac_wishbone`
- `python3 -m unittest test.test_mac_core`
- `python3 -m py_compile liteeth/mac/packet.py liteeth/mac/sram.py liteeth/mac/wishbone.py liteeth/mac/__init__.py test/test_mac_packet.py`
- `git diff --check`
- Default Wishbone MAC CSR list compared against `origin/master` (`79b908f`).
- Digilent Arty Vivado builds/bitstreams completed and met timing for master, this PR default, and this PR with `rx_fifo_depth=1`, `tx_fifo_depth=1`.

Draft for review of the API/default policy before merging.
