### PR TITLE
phy/a7_1000basex: expose PCS configuration hooks

### DIFF
--- a/liteeth/phy/a7_1000basex.py
+++ b/liteeth/phy/a7_1000basex.py
@@ -26,6 +26,10 @@ class A7_1000BASEX(LiteXModule):
     rx_clk_freq = 125e6
     tx_clk_freq = 125e6
     def __init__(self, qpll_channel, data_pads, sys_clk_freq, with_csr=True,
+        # PCS Parameters.
+        pcs_kwargs       = None,
+        with_pcs_buffers = False,
+
         # TX Parameters.
         tx_cm_type     = "PLL",
         tx_cm_buf_type = "BUFH",
@@ -36,10 +40,26 @@ class A7_1000BASEX(LiteXModule):
         rx_cm_buf_type = "BUFG",
         rx_polarity    = 0,
     ):
-        self.pcs = pcs = PCS(lsb_first=True, eth_tx_clk_freq=self.tx_clk_freq)
+        pcs_kwargs = {} if pcs_kwargs is None else dict(pcs_kwargs)
+        pcs_kwargs.setdefault("eth_tx_clk_freq", self.tx_clk_freq)
+        self.pcs = pcs = PCS(lsb_first=True, **pcs_kwargs)
 
-        self.sink    = pcs.sink
-        self.source  = pcs.source
+        # Optional pipeline cuts at the MAC boundary ease timing closure when
+        # the PCS runs at 312.5MHz. The TBI/autonegotiation path is unchanged.
+        if with_pcs_buffers:
+            self.tx_pcs_buffer = tx_pcs_buffer = ClockDomainsRenamer("eth_tx")(
+                stream.Buffer(eth_phy_description(self.dw), pipe_ready=True))
+            self.rx_pcs_buffer = rx_pcs_buffer = ClockDomainsRenamer("eth_rx")(
+                stream.Buffer(eth_phy_description(self.dw), pipe_ready=True))
+            self.sink   = tx_pcs_buffer.sink
+            self.source = rx_pcs_buffer.source
+            self.comb += [
+                tx_pcs_buffer.source.connect(pcs.sink),
+                pcs.source.connect(rx_pcs_buffer.sink),
+            ]
+        else:
+            self.sink   = pcs.sink
+            self.source = pcs.source
         self.link_up = pcs.link_up
 
         self.cd_eth_tx      = ClockDomain()
@@ -77,7 +97,6 @@ class A7_1000BASEX(LiteXModule):
         drprdy  = Signal()
         drpdo   = Signal(16)
         drpwe   = Signal()
-
 
         # Work around Python's 255 argument limitation.
         self.gtp_params = gtp_params = dict(

--- a/test/test_a7_1000basex.py
+++ b/test/test_a7_1000basex.py
@@ -1,0 +1,61 @@
+#
+# This file is part of LiteEth.
+#
+# Copyright (c) 2026 Florent Kermarrec <florent@enjoy-digital.fr>
+# SPDX-License-Identifier: BSD-2-Clause
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from migen import Signal
+
+import liteeth.phy.a7_1000basex as a7_1000basex
+from liteeth.phy.a7_gtp import QPLLChannel
+from liteeth.phy.pcs_1000basex import PCS
+
+
+class TestA72500BASEX(unittest.TestCase):
+    @staticmethod
+    def make_pads():
+        return SimpleNamespace(
+            rxn = Signal(),
+            rxp = Signal(),
+            txn = Signal(),
+            txp = Signal(),
+        )
+
+    def test_pcs_kwargs_override_default_timer_clock(self):
+        pcs_config = {}
+
+        def make_pcs(**kwargs):
+            pcs_config.update(kwargs)
+            return PCS(**kwargs)
+
+        with mock.patch.object(a7_1000basex, "PCS", side_effect=make_pcs):
+            a7_1000basex.A7_2500BASEX(
+                qpll_channel = QPLLChannel(0),
+                data_pads    = self.make_pads(),
+                sys_clk_freq = 100e6,
+                with_csr     = False,
+                pcs_kwargs   = {"eth_tx_clk_freq": 125e6},
+            )
+
+        self.assertEqual(pcs_config["eth_tx_clk_freq"], 125e6)
+        self.assertTrue(pcs_config["lsb_first"])
+
+    def test_optional_pcs_buffers_are_exposed_at_phy_boundary(self):
+        dut = a7_1000basex.A7_2500BASEX(
+            qpll_channel     = QPLLChannel(0),
+            data_pads        = self.make_pads(),
+            sys_clk_freq     = 100e6,
+            with_csr         = False,
+            with_pcs_buffers = True,
+        )
+
+        self.assertIs(dut.sink, dut.tx_pcs_buffer.sink)
+        self.assertIs(dut.source, dut.rx_pcs_buffer.source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- allow 7-series BASE-X PHY users to override PCS parameters while preserving the existing timer-clock default
- optionally add ready-pipelined stream buffers at the PCS/MAC boundary for high-rate timing closure
- cover both configuration paths with focused A7 2500BASE-X tests

## Motivation

The LiteX-M2SDR Acorn-baseboard 2500BASE-X configuration needs the legacy 125 MHz Clause-37 timer constants for interoperability with the LianGuo LG 2.5GE copper SFP. Its 312.5 MHz PCS/MAC boundary also benefits from an explicit pipeline cut.

## Validation

- `pytest -q test/test_a7_1000basex.py`
- full `pytest -q`
- hardware: Artix-7 M2SDR, LianGuo LG 2.5GE SFP, PCS link up and 10/10 ICMP replies
